### PR TITLE
propertyset projects have been replaced by properties projects, this has...

### DIFF
--- a/org.osate.build.main/pom.xml
+++ b/org.osate.build.main/pom.xml
@@ -43,8 +43,6 @@
     <module>../org.osate.xtext.aadl2</module>
     <module>../org.osate.xtext.aadl2.properties</module>
     <module>../org.osate.xtext.aadl2.properties.ui</module>
-    <module>../org.osate.xtext.aadl2.propertyset</module>
-    <module>../org.osate.xtext.aadl2.propertyset.ui</module>
     <module>../org.osate.xtext.aadl2.ui</module>
     <module>../../plugins/org.osate.analysis.architecture</module>
     <module>../../plugins/org.osate.analysis.flows</module>


### PR DESCRIPTION
projects org.osate.xtext.aadl2.propertyset and org.osate.xtext.aadl2.propertyset.ui have been replaced by org.osate.xtext.aadl2.properties and org.osate.xtext.aadl2.properties.ui

The org.osate.xtext.aadl2.propertyset and org.osate.xtext.aadl2.propertyset.ui were still referenced in the configuration of the maven build. This commit removed the corresponding lines in the pom.xml file
