### PR TITLE
getSubcomponentType does not invoke eIsProxy if subcomponentType is null...

### DIFF
--- a/org.osate.aadl2/src/org/osate/aadl2/impl/ComponentPrototypeActualImpl.java
+++ b/org.osate.aadl2/src/org/osate/aadl2/impl/ComponentPrototypeActualImpl.java
@@ -195,7 +195,7 @@ public class ComponentPrototypeActualImpl extends ElementImpl implements
 							oldSubcomponentType, subcomponentType));
 			}
 		}
-		return subcomponentType.eIsProxy() ? null : subcomponentType;
+		return (subcomponentType==null ||  subcomponentType.eIsProxy()) ? null : subcomponentType;
 	}
 
 	/**


### PR DESCRIPTION
...; return null in this case
