### PR TITLE
prevent conversion unit to loop infinitly

### DIFF
--- a/org.osate.aadl2/src/org/osate/aadl2/impl/UnitLiteralImpl.java
+++ b/org.osate.aadl2/src/org/osate/aadl2/impl/UnitLiteralImpl.java
@@ -315,6 +315,8 @@ public class UnitLiteralImpl extends EnumerationLiteralImpl implements
 			current = current.getBaseUnit();
 			if (current == target)
 				return factor;
+			if(current == current.getBaseUnit())
+				break;
 		}
 		// did not find target. Let's go in opposite direction
 		factor = 1.0;
@@ -327,6 +329,9 @@ public class UnitLiteralImpl extends EnumerationLiteralImpl implements
 			current = current.getBaseUnit();
 			if (current == this)
 				return factor;
+			if(current == current.getBaseUnit())
+			    break;
+
 		}
 		return 1.0;
 	}


### PR DESCRIPTION
When the UnitLiteral object is the base unit, then getAbsoluteFactor loops infinitely. To prevent this, we add a break condition in the while loop.
