### PR TITLE
change condition for detecting cli vs gui implementation

### DIFF
--- a/org.osate.build.target/kepler.target
+++ b/org.osate.build.target/kepler.target
@@ -44,7 +44,6 @@
 <unit id="org.eclipse.ocl.all.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.transaction.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.transaction.sdk.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.m2e.logback.feature.feature.group" version="0.0.0"/>
 
 <repository location="http://download.eclipse.org/releases/kepler"/>
 </location>


### PR DESCRIPTION
Platform.isRunning is not a sufficient condition to detect if osate is running under cli (command line intercafe) or gui (graphical user interface): osgi based version of osate-cli will return true from isRunning but the implementation is based on cli. Added a boolean flag to be more precise on that front.
