### PR TITLE
Fix for Plugin_Resources Appearing Multiple Times After Workspace Creation

### DIFF
--- a/org.osate.ui/src/org/osate/ui/navigator/AadlNavigatorSorter.java
+++ b/org.osate.ui/src/org/osate/ui/navigator/AadlNavigatorSorter.java
@@ -7,15 +7,17 @@ import org.osate.aadl2.modelsupport.resources.OsateResourceUtil;
 
 public class AadlNavigatorSorter extends ViewerSorter {
 	public int compare(Viewer viewer, Object e1, Object e2) {
-		if(e1 instanceof IProject
-				&& ((IProject)e1).getName().equals(OsateResourceUtil.PLUGIN_RESOURCES_DIRECTORY_NAME)) {
+		boolean e1IsPluginResources = e1 instanceof IProject && ((IProject)e1).getName().equals(OsateResourceUtil.PLUGIN_RESOURCES_DIRECTORY_NAME);
+		boolean e2IsPluginResources = e2 instanceof IProject && ((IProject)e2).getName().equals(OsateResourceUtil.PLUGIN_RESOURCES_DIRECTORY_NAME);
+				
+		if(e1IsPluginResources && e2IsPluginResources) {
+			return 0;
+		} else if(e1IsPluginResources) {
 			return 1;
-		} else if(e2 instanceof IProject
-				&& ((IProject)e2).getName().equals(OsateResourceUtil.PLUGIN_RESOURCES_DIRECTORY_NAME)) {
+		} else if(e2IsPluginResources) {
 			return -1;
 		} else {
 			return super.compare(viewer, e1, e2);
 		}
-
 	}
 }


### PR DESCRIPTION
This pull fixes the Plugin_Resources project appearing multiple times after creating a new workspace. Eclipse tries to sort the plugin resources folder with itself and that case was not handled appropriately. 
