### PR TITLE
"Link with Editor" fix

### DIFF
--- a/org.osate.ui/plugin.xml
+++ b/org.osate.ui/plugin.xml
@@ -294,6 +294,7 @@
 				<contentExtension pattern="org.eclipse.ui.navigator.resourceContent" />     	      
 				<contentExtension pattern="org.eclipse.ui.navigator.resources.filters.*"/>
 				<contentExtension pattern="org.osate.ui.navigator.content"/>
+				<contentExtension pattern="org.eclipse.ui.navigator.resources.linkHelper"/>
 			</includes>
 		</viewerContentBinding>
   		<viewerActionBinding


### PR DESCRIPTION
Adds the eclipse resource linkHelper to the content extension list for AADL navigator. The link helper is used to link between the editor and the navigator to implement the Link with Editor feature.
Fixes #442.
