### PR TITLE
Prevent subprogram call context from being treated as a transient value.

### DIFF
--- a/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/serializing/Aadl2TransientValueService.java
+++ b/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/serializing/Aadl2TransientValueService.java
@@ -46,7 +46,6 @@ public class Aadl2TransientValueService extends DefaultTransientValueService {
 	public boolean isTransient(EObject owner, EStructuralFeature feature, int index) {
 		if (feature == Aadl2Package.eINSTANCE.getAadlPackage_PublicSection()
 				|| feature == Aadl2Package.eINSTANCE.getAadlPackage_PrivateSection()
-				|| feature == Aadl2Package.eINSTANCE.getSubprogramCall_Context()
 				|| (feature == Aadl2Package.eINSTANCE.getModalElement_InMode() && !(owner instanceof DefaultAnnexSubclause))
 				|| feature == Aadl2Package.eINSTANCE.getElement_OwnedComment()
 				|| feature == Aadl2Package.eINSTANCE.getDefaultAnnexLibrary_ParsedAnnexLibrary()


### PR DESCRIPTION
Prevents subprogram call context from being treated as a transient value. Fixes serialization issues.
