### PR TITLE
Fixes #1223

### DIFF
--- a/analyses/org.osate.analysis.flows/src/org/osate/analysis/flows/handlers/CheckFlowLatency.java
+++ b/analyses/org.osate.analysis.flows/src/org/osate/analysis/flows/handlers/CheckFlowLatency.java
@@ -131,8 +131,9 @@ public final class CheckFlowLatency extends AbstractInstanceOrDeclarativeModelRe
 
 	public void invoke(IProgressMonitor monitor, SystemInstance root, SystemOperationMode som) {
 		initializeAnalysis(root);
-		this.errManager = errManager != null ? errManager
-				: new AnalysisErrorReporterManager(getAnalysisErrorReporterFactory());
+		if (this.errManager == null) {
+			this.errManager = new AnalysisErrorReporterManager(getAnalysisErrorReporterFactory());
+		}
 		analyzeInstanceModel(monitor, null, root, som);
 		finalizeAnalysis(); // uses error report manager to generate markers
 	}

--- a/analyses/org.osate.analysis.flows/src/org/osate/analysis/flows/handlers/CheckFlowLatency.java
+++ b/analyses/org.osate.analysis.flows/src/org/osate/analysis/flows/handlers/CheckFlowLatency.java
@@ -131,8 +131,10 @@ public final class CheckFlowLatency extends AbstractInstanceOrDeclarativeModelRe
 
 	public void invoke(IProgressMonitor monitor, SystemInstance root, SystemOperationMode som) {
 		initializeAnalysis(root);
+		this.errManager = errManager != null ? errManager
+				: new AnalysisErrorReporterManager(getAnalysisErrorReporterFactory());
 		analyzeInstanceModel(monitor, null, root, som);
-		finalizeAnalysis();
+		finalizeAnalysis(); // uses error report manager to generate markers
 	}
 
 


### PR DESCRIPTION
Fixes #1223
Added setting of error reporter manager back in. 
It is used in marker generation and the current interface to plugin analysis interprets
markers for the result.