### PR TITLE
Improve handling of diagram context being invalid.

### DIFF
--- a/ge/org.osate.ge/src/org/osate/ge/internal/ui/editor/AgeDiagramBehavior.java
+++ b/ge/org.osate.ge/src/org/osate/ge/internal/ui/editor/AgeDiagramBehavior.java
@@ -717,9 +717,12 @@ public class AgeDiagramBehavior extends DiagramBehavior implements GraphitiAgeDi
 			Display.getDefault().asyncExec(() -> {
 				getPaletteBehavior().refreshPalette();
 
-				// Reset the selection if the diagram context isn't valid.
+				// Close the editor if the context isn't valid.
 				if (!diagramContextIsValid) {
-					selectPictogramElements(new PictogramElement[0]);
+					final IDiagramContainerUI container = getDiagramContainer();
+					if (container != null) {
+						container.close();
+					}
 				}
 			});
 		}

--- a/ge/org.osate.ge/src/org/osate/ge/internal/ui/handlers/DeleteHandler.java
+++ b/ge/org.osate.ge/src/org/osate/ge/internal/ui/handlers/DeleteHandler.java
@@ -234,7 +234,7 @@ public class DeleteHandler extends AbstractHandler {
 
 		if (boIsContext) {
 			// Close the editor if the context was deleted
-			Display.getDefault().asyncExec(() -> ageEditor.close());
+			Display.getDefault().syncExec(() -> ageEditor.close());
 		} else {
 			// Clear selection
 			ageEditor.selectPictogramElements(new PictogramElement[0]);


### PR DESCRIPTION
Close diagram if unable to relink context. If context is deleted using
the diagram, synchronously close the diagram. Closes #1359.