### PR TITLE
1036 getall of class in global scope utility method

### DIFF
--- a/alisa/org.osate.alisa.common/src/org/osate/alisa/common/scoping/CommonScopeProvider.xtend
+++ b/alisa/org.osate.alisa.common/src/org/osate/alisa/common/scoping/CommonScopeProvider.xtend
@@ -40,11 +40,9 @@ import org.osate.aadl2.UnitsType
 import org.eclipse.xtext.resource.EObjectDescription
 
 import static extension org.osate.aadl2.modelsupport.util.AadlUtil.isPredeclaredPropertySet
+import org.osate.aadl2.modelsupport.scoping.Aadl2GlobalScopeUtil
 
 class CommonScopeProvider extends AbstractDeclarativeScopeProvider {
-
-	@Inject
-	var IEClassGlobalScopeProvider globalScope;
 
 
 	def scopeFor(Iterable<? extends EObject> elements) {
@@ -68,8 +66,7 @@ class CommonScopeProvider extends AbstractDeclarativeScopeProvider {
 		// TODO: Scope literals by type, but how to do we know the type of an
 		// expression?
 		val Collection<UnitLiteral> result = new ArrayList<UnitLiteral>()
-		val scope = globalScope.getScope(context.eResource(), UNITS_TYPE)
-		for (IEObjectDescription desc : scope.allElements) {
+		for (IEObjectDescription desc : Aadl2GlobalScopeUtil.getAllEObjectDescriptions(context,UNITS_TYPE)) {
 			val unitsType = EcoreUtil.resolve(desc.getEObjectOrProxy(), context) as UnitsType;
 			unitsType.ownedLiterals.forall[lit|result += lit as UnitLiteral];
 		}

--- a/alisa/org.osate.alisa.common/src/org/osate/alisa/common/scoping/CommonScopeProvider.xtend
+++ b/alisa/org.osate.alisa.common/src/org/osate/alisa/common/scoping/CommonScopeProvider.xtend
@@ -16,31 +16,26 @@
 
 package org.osate.alisa.common.scoping
 
-import com.google.inject.Inject
-import com.google.inject.Injector
-import org.eclipse.emf.common.util.URI
-import org.eclipse.xtext.resource.IResourceServiceProvider
-import org.eclipse.xtext.scoping.impl.AbstractDeclarativeScopeProvider
-import org.osate.aadl2.modelsupport.scoping.IEClassGlobalScopeProvider
-import org.eclipse.xtext.scoping.impl.SimpleScope
+import java.util.ArrayList
+import java.util.Collection
+import org.eclipse.emf.ecore.EClass
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.emf.ecore.EReference
+import org.eclipse.emf.ecore.util.EcoreUtil
+import org.eclipse.xtext.naming.QualifiedName
+import org.eclipse.xtext.resource.EObjectDescription
+import org.eclipse.xtext.resource.IEObjectDescription
 import org.eclipse.xtext.scoping.IScope
 import org.eclipse.xtext.scoping.Scopes
-import org.eclipse.xtext.naming.QualifiedName
-import org.eclipse.emf.ecore.EObject
+import org.eclipse.xtext.scoping.impl.AbstractDeclarativeScopeProvider
+import org.eclipse.xtext.scoping.impl.SimpleScope
 import org.eclipse.xtext.util.SimpleAttributeResolver
-import org.eclipse.emf.ecore.EReference
-import org.eclipse.emf.ecore.EClass
 import org.osate.aadl2.Aadl2Package
-import java.util.Collection
 import org.osate.aadl2.UnitLiteral
-import java.util.ArrayList
-import org.eclipse.xtext.resource.IEObjectDescription
-import org.eclipse.emf.ecore.util.EcoreUtil
 import org.osate.aadl2.UnitsType
-import org.eclipse.xtext.resource.EObjectDescription
+import org.osate.aadl2.modelsupport.scoping.Aadl2GlobalScopeUtil
 
 import static extension org.osate.aadl2.modelsupport.util.AadlUtil.isPredeclaredPropertySet
-import org.osate.aadl2.modelsupport.scoping.Aadl2GlobalScopeUtil
 
 class CommonScopeProvider extends AbstractDeclarativeScopeProvider {
 

--- a/core/org.osate.aadl2.modelsupport/src/org/osate/aadl2/modelsupport/scoping/Aadl2GlobalScopeUtil.java
+++ b/core/org.osate.aadl2.modelsupport/src/org/osate/aadl2/modelsupport/scoping/Aadl2GlobalScopeUtil.java
@@ -1,5 +1,8 @@
 package org.osate.aadl2.modelsupport.scoping;
 
+import java.util.Collection;
+
+import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
@@ -67,6 +70,50 @@ public class Aadl2GlobalScopeUtil {
 			result = o.eIsProxy() ? null : (T) o;
 		}
 		return result;
+	}
+
+	/**
+	 * Find all AADL elements by EClass in the global scope.
+	 *
+	 * @since 2.3.5
+	 *
+	 * @param context The starting point for the global scope.
+	 * @param eClass The meta class of the element to find.
+	 * @return The collection of EObjects that match the class.
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T extends EObject> Collection<T> getAll(EObject context, EClass eClass) {
+		IScope scope = globalScope.getScope(context.eResource(), eClass);
+		Iterable<IEObjectDescription> descs = scope.getAllElements();
+		BasicEList<T> eobjs = new BasicEList<T>();
+		for (IEObjectDescription desc : descs) {
+			T result = null;
+			if (desc != null) {
+				EObject o = desc.getEObjectOrProxy();
+				if (o.eIsProxy()) {
+					o = EcoreUtil.resolve(o, context);
+				}
+				result = o.eIsProxy() ? null : (T) o;
+			}
+			if (result != null) {
+				eobjs.add(result);
+			}
+		}
+		return eobjs;
+	}
+
+	/**
+	 * Find all AADL element EObjectDescriptions by EClass in the global scope.
+	 *
+	 * @since 2.3.5
+	 *
+	 * @param context The starting point for the global scope.
+	 * @param eClass The meta class of the element to find.
+	 * @return The EObjectDescriptions that match the class.
+	 */
+	public static Iterable<IEObjectDescription> getAllEObjectDescriptions(EObject context, EClass eClass) {
+		IScope scope = globalScope.getScope(context.eResource(), eClass);
+		return scope.getAllElements();
 	}
 
 }


### PR DESCRIPTION
Utility method to help others move away from EMFIndexRetrieval when trying to get all global EObjects of a given eClass