### PR TITLE
The Resolute budget library now has its units resolved in JUnit tests.

### DIFF
--- a/alisa/org.osate.assure.tests/src/org/osate/assure/tests/AssureTests.xtend
+++ b/alisa/org.osate.assure.tests/src/org/osate/assure/tests/AssureTests.xtend
@@ -684,9 +684,7 @@ class AssureTests extends XtextTest {
 					22.assertEquals(definitions.size)
 			]
 		]	
-		// Resolute does not resolve 'kg'
-		// TODO uncomment once Resolute has been updated with the fix I provided not to use EMFIndexRetrieval
-//		assertNoIssues(pkg)	
+		assertNoIssues(pkg)	
 	}
 
 


### PR DESCRIPTION
Fixes #1469