### PR TITLE
Catch exception on findMarkers method on IResource. 

### DIFF
--- a/alisa/org.osate.assure/src/org/osate/assure/util/AssureUtilExtension.xtend
+++ b/alisa/org.osate.assure/src/org/osate/assure/util/AssureUtilExtension.xtend
@@ -76,6 +76,7 @@ import static extension org.osate.aadl2.instantiation.InstantiateModel.instantia
 import static extension org.osate.alisa.common.util.CommonUtilExtension.*
 import static extension org.osate.verify.util.VerifyUtilExtension.*
 import org.osate.result.ResultType
+import org.eclipse.core.runtime.CoreException
 
 class AssureUtilExtension {
 
@@ -229,7 +230,13 @@ class AssureUtilExtension {
 		String markertype, VerificationMethod vm) {
 		val res = instance.eResource
 		val IResource irsrc = OsateResourceUtil.convertToIResource(res);
-		val markers = irsrc.findMarkers(markertype, true, IResource.DEPTH_INFINITE) // analysisMarkerType
+		var  IMarker[] markers
+		try {
+			markers = irsrc.findMarkers(markertype, true, IResource.DEPTH_INFINITE) // analysisMarkerType
+		} catch (CoreException e){
+			verificationActivityResult.setToError("Could not find Markers. Instance model was not saved.", instance)
+			return
+		}
 		val targetURI = EcoreUtil.getURI(instance).toString()
 		var targetmarkers = markers.filter [ IMarker m |
 			matchURI(m.getAttribute(AadlConstants.AADLURI) as String, targetURI)


### PR DESCRIPTION
Fixes #1596 
In the long term we should replace the Marker based approach with AnalysisResult return values for all plugin analyses.