### PR TITLE
implement prototype binding resolver for data component references

### DIFF
--- a/ba/org.osate.ba/src/org/osate/ba/analyzers/AadlBaNameResolver.java
+++ b/ba/org.osate.ba/src/org/osate/ba/analyzers/AadlBaNameResolver.java
@@ -55,6 +55,7 @@ import org.osate.aadl2.PrototypeBinding ;
 import org.osate.aadl2.RecordType ;
 import org.osate.aadl2.StringLiteral ;
 import org.osate.aadl2.Subcomponent ;
+import org.osate.aadl2.UnitLiteral ;
 import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager ;
 import org.osate.ba.aadlba.AadlBaPackage ;
 import org.osate.ba.aadlba.Any ;
@@ -653,8 +654,14 @@ public class AadlBaNameResolver
      Identifier timeUnit = bt.getUnitId() ;
      
      
-     return integerValueResolver(bt.getIntegerValue()) &
-            timeUnitResolver(timeUnit);
+     boolean result = integerValueResolver(bt.getIntegerValue());
+     result &= timeUnitResolver(timeUnit);
+     if(result && bt.getIntegerValue() instanceof BehaviorIntegerLiteral)
+     {
+       BehaviorIntegerLiteral bil = (BehaviorIntegerLiteral) bt.getIntegerValue();
+       bil.setUnit((UnitLiteral) timeUnit.getOsateRef());
+     }
+     return result;
    }
 
    private boolean communicationActionResolver(CommAction act)

--- a/ba/org.osate.utils/src/org/osate/utils/Aadl2Utils.java
+++ b/ba/org.osate.utils/src/org/osate/utils/Aadl2Utils.java
@@ -316,7 +316,7 @@ public class Aadl2Utils
     String result = PropertyUtils.getEnumValue(ne, "Parameter_Usage") ;
     if(result == null)
     {
-      Property prop = GetProperties.lookupPropertyDefinition(ne, "Generation_Properties", "Parameter_Usage");
+      Property prop = GetProperties.lookupPropertyDefinition(ne, "Code_Generation_Properties", "Parameter_Usage");
       if(prop != null)
       {
         NamedValue nv = (NamedValue) prop.getDefaultValue() ;

--- a/ba/org.osate.utils/src/org/osate/utils/PropertyUtils.java
+++ b/ba/org.osate.utils/src/org/osate/utils/PropertyUtils.java
@@ -218,6 +218,52 @@ public class PropertyUtils {
   }
   
   /**
+   * Extract integer value from a specified property. Convert it
+   * to a given unit. 
+   * May return null
+   * 
+   * @param i
+   *            component instance.
+   * @param propertyName
+   *            property name.
+   * @param unit
+   * 			target unit for conversion
+   * @return property value.
+   */
+  public static Long getIntValue(NamedElement i, String propertyName, String targetUnit) {
+	    PropertyAssociation pa = findPropertyAssociation(propertyName, i);
+
+	    if (pa != null) {
+	      Property p = pa.getProperty();
+
+	      if (p.getName().equalsIgnoreCase(propertyName)) {
+	        List<ModalPropertyValue> values = pa.getOwnedValues();
+
+	        if (values.size() == 1) {
+	          ModalPropertyValue v = values.get(0);
+	          PropertyExpression expr = v.getOwnedValue();
+
+	          if (expr instanceof IntegerLiteral) {
+	            IntegerLiteral il = (IntegerLiteral) expr;
+	            final UnitLiteral unit = il.getUnit();
+	            if (unit != null) {
+	              // Warning: the cast from double to long is licit
+	              // only if the result of the conversion is an
+	              // integer
+	              return (long) il.getScaledValue(targetUnit);
+	            }
+
+	            return ((IntegerLiteral) expr).getValue();
+	          }
+	        }
+	      }
+	    }
+
+	    return null ;
+	  }
+  
+  
+  /**
    * Extract integer value from a specified property. May return null
    * 
    * @param i
@@ -240,26 +286,6 @@ public class PropertyUtils {
           PropertyExpression expr = v.getOwnedValue();
 
           if (expr instanceof IntegerLiteral) {
-            IntegerLiteral il = (IntegerLiteral) expr;
-            final UnitLiteral unit = il.getUnit();
-            if (unit != null) {
-              if (pa.getProperty().getPropertyType() instanceof AadlInteger) {
-                // XXX: Ms and Bytes are chosen for base units;
-                // this is specific for POK
-                AadlInteger ai = (AadlInteger) pa.getProperty().getPropertyType();
-                if (ai.getUnitsType().getName().equalsIgnoreCase(AadlProject.SIZE_UNITS))
-                  unit.setBaseUnit(GetProperties.findUnitLiteral(p,
-                                                        AadlProject.B_LITERAL));
-                if (ai.getUnitsType().getName().equalsIgnoreCase(AadlProject.TIME_UNITS))
-                  unit.setBaseUnit(GetProperties.findUnitLiteral(p,
-                      AadlProject.MS_LITERAL));
-              }
-              // Warning: the cast from double to long is licit
-              // only if the result of the conversion is an
-              // integer
-              return (long) il.getScaledValue(unit.getBaseUnit());
-            }
-
             return ((IntegerLiteral) expr).getValue();
           }
         }


### PR DESCRIPTION
fixes #1631  
fixes #1632 

Here is an example of aadl+ba code where this is useful:

```
data implementation PortReferenceType.impl
prototypes
   data_type: data;
subcomponents
  transmitted_data: data data_type;
properties
  Classifier_Substitution_Rule => Type_Extension;
end PortReferenceType.impl;

data implementation PortReferenceType.int extends PortReferenceType.impl
  (data_type => data Integer)
end PortReferenceType.int;


subprogram SendOutputFifo
features
	src: requires data access PortReferenceType.impl;
	dst: requires data access PortReferenceType.impl;
annex behavior_specification {**
	STATES
		singleton: initial final state;
	TRANSITIONS
  		t: singleton -[]-> singleton
   		{
   			computation(4 us .. 5 us);
			dst!<;
			dst.transmitted_data := src.transmitted_data;
			dst!>;
			computation(4 us .. 5 us)
  		};
**};
end SendOutputFifo;

subprogram SendOutputFifo_Integer
features
	src: refined to requires data access PortReferenceType.int;
	dst: refined to requires data access PortReferenceType.int;
end SendOutputFifo_Integer;
```

getDataClassifier called with (dst.transmitted_data, SendOutputFifo_Integer) returned null in previous version.

