### PR TITLE
Issue with plugin dependency and Java based reflective calls

### DIFF
--- a/core/org.osate.aadl2.modelsupport/META-INF/MANIFEST.MF
+++ b/core/org.osate.aadl2.modelsupport/META-INF/MANIFEST.MF
@@ -6,7 +6,6 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: org.osate.aadl2.modelsupport.Activator
 Require-Bundle: org.osate.aadl2,
  org.osate.workspace;visibility:=reexport,
- org.osate.pluginsupport,
  org.apache.log4j,
  org.osate.core;visibility:=reexport,
  org.eclipse.xtext;bundle-version="2.0.1"

--- a/core/org.osate.contribution.sei/META-INF/MANIFEST.MF
+++ b/core/org.osate.contribution.sei/META-INF/MANIFEST.MF
@@ -5,8 +5,7 @@ Bundle-SymbolicName: org.osate.contribution.sei;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: org.osate.contribution.sei.Activator
 Bundle-Vendor: CMU-SEI
-Require-Bundle: org.eclipse.core.runtime,
- org.osate.pluginsupport;bundle-version="1.0.0"
+Require-Bundle: org.eclipse.core.runtime
 Bundle-ActivationPolicy: lazy
 Export-Package: org.osate.contribution.sei.names
 Bundle-ClassPath: .

--- a/core/org.osate.pluginsupport/META-INF/MANIFEST.MF
+++ b/core/org.osate.pluginsupport/META-INF/MANIFEST.MF
@@ -12,15 +12,15 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.xtend.lib,
  org.eclipse.xtend.lib.macro,
- org.osate.aadl2;bundle-version="1.0.0",
+ org.osate.aadl2;bundle-version="1.0.0";visibility:=reexport,
  org.eclipse.jdt.core;bundle-version="3.13.102",
  org.eclipse.core.resources;bundle-version="3.12.0",
- org.osate.results;bundle-version="1.0.0",
+ org.osate.results;bundle-version="1.0.0";visibility:=reexport,
  org.eclipse.ui.workbench,
  org.eclipse.ease;bundle-version="0.6.0",
  org.eclipse.core.commands,
  org.eclipse.emf.ecore,
- org.osate.xtext.aadl2.properties;bundle-version="1.0.0"
+ org.osate.xtext.aadl2.properties;bundle-version="1.0.0";visibility:=reexport
 Bundle-ActivationPolicy: lazy
 Export-Package: org.osate.pluginsupport
 Bundle-Vendor: CMU-SEI

--- a/core/org.osate.pluginsupport/META-INF/MANIFEST.MF
+++ b/core/org.osate.pluginsupport/META-INF/MANIFEST.MF
@@ -19,7 +19,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.workbench,
  org.eclipse.ease;bundle-version="0.6.0",
  org.eclipse.core.commands,
- org.eclipse.emf.ecore
+ org.eclipse.emf.ecore,
+ org.osate.xtext.aadl2.properties;bundle-version="1.0.0"
 Bundle-ActivationPolicy: lazy
 Export-Package: org.osate.pluginsupport
 Bundle-Vendor: CMU-SEI


### PR DESCRIPTION
Fixes #1638 

In OSATE 2.3.5 it worked because ExecuteJavaUtil was in one of the Alisa projects.  We moved it to org.osate.plugin support. This is also where ExecutePythonUtil resides.