### PR TITLE
update xsemantics dependencies

### DIFF
--- a/core/org.osate.build.main/pom.xml
+++ b/core/org.osate.build.main/pom.xml
@@ -58,6 +58,52 @@
 	</scm>
 	<!-- End metadata for maven central, see https://central.sonatype.org/pages/requirements.html -->
 
+
+  <repositories>
+		<repository>
+			<!-- we also need this one because this is an eclipse project, so it needs to
+				resolve xsemantics runtime dependencies from the p2 repository -->
+			<id>Xsemantics</id>
+			<layout>p2</layout>
+			<url>http://download.eclipse.org/xsemantics/milestones/</url>
+		</repository>
+		<repository>
+			<id>eclipse</id>
+			<layout>p2</layout>
+			<url>http://download.eclipse.org/releases/oxygen</url>
+		</repository>
+		<repository>
+			<id>Xtext Update Site</id>
+			<layout>p2</layout>
+			<url>http://download.eclipse.org/modeling/tmf/xtext/updates/releases/${xtext.version}</url>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>sonatype_releases</id>
+			<url>https://oss.sonatype.org/content/repositories/releases/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+
+		<pluginRepository>
+			<id>sonatype_snapshots</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
+
 	<profiles>
 		<profile>
 			<id>pr-build</id>


### PR DESCRIPTION
I had trouble building osate via maven due to a change in the xsemantics dependency.  This change resolved the issue.  Copied from the xsemantics [example pom](https://github.com/eclipse/xsemantics/blob/master/tests/org.eclipse.xsemantics.example.maven.test/pom.xml)  .