### PR TITLE
Recreate start level configuration

### DIFF
--- a/core/org.osate.build.product/osate.product
+++ b/core/org.osate.build.product/osate.product
@@ -67,13 +67,11 @@
    </features>
 
    <configurations>
-      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
+      <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="0" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
-      <plugin id="org.eclipse.equinox.ds" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
-      <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
-      <plugin id="org.eclipse.update.configurator" autoStart="true" startLevel="4" />
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="preferenceCustomization" value="plugin_customization.ini" />
    </configurations>


### PR DESCRIPTION
see https://bugs.eclipse.org/bugs/show_bug.cgi?id=543428 for explanation

An exception during startup of OSATE prevented starting OSATE, even with a fresh workspace.

For testing: perform a local tycho build (launch config osate.build.local), extract archive (in org.osate.build.product/target/products/), and start OSATE. If OSATE starts the bug is fixed. 

fixes #1695