### PR TITLE
Physical property types as SEI contribution in OSATE

### DIFF
--- a/core/org.osate.contribution.sei/plugin.xml
+++ b/core/org.osate.contribution.sei/plugin.xml
@@ -8,6 +8,14 @@
             id="org.osate.contributes.SEI.aadlcontribution1">
       </aadlcontribution>
       <aadlcontribution
+            file="resources/properties/Physical.aadl"
+            id="org.osate.contributes.SEI.aadlcontribution2">
+      </aadlcontribution>
+      <aadlcontribution
+            file="resources/packages/PhysicalResources.aadl"
+            id="org.osate.contributes.SEI.aadlcontribution3">
+      </aadlcontribution>
+      <aadlcontribution
             file="resources/properties/Data_Model.aadl"
             id="org.osate.contributes.SAE.aadlcontribution2">
       </aadlcontribution>

--- a/core/org.osate.contribution.sei/resources/packages/PhysicalResources.aadl
+++ b/core/org.osate.contribution.sei/resources/packages/PhysicalResources.aadl
@@ -1,18 +1,19 @@
 -- Copyright 2016 Carnegie Mellon University. See Notice.txt
 -- Distribution Statement A: Approved for Public Release; Distribution is Unlimited.
+
 package PhysicalResources
 public
 	
-	abstract ElectricalPower
-	end ElectricalPower;
+  abstract ElectricalPower
+  end ElectricalPower;
 
-	abstract Mass
-	end Mass;
+  abstract Mass
+  end Mass;
 	
-	abstract PhysicalForce
-	end PhysicalForce;
+  abstract PhysicalForce
+  end PhysicalForce;
 	
-	Abstract HydraulicFlow
-	end HydraulicFlow;
+  Abstract HydraulicFlow
+  end HydraulicFlow;
 	
 end PhysicalResources;

--- a/core/org.osate.contribution.sei/resources/packages/PhysicalResources.aadl
+++ b/core/org.osate.contribution.sei/resources/packages/PhysicalResources.aadl
@@ -1,0 +1,18 @@
+-- Copyright 2016 Carnegie Mellon University. See Notice.txt
+-- Distribution Statement A: Approved for Public Release; Distribution is Unlimited.
+package PhysicalResources
+public
+	
+	abstract ElectricalPower
+	end ElectricalPower;
+
+	abstract Mass
+	end Mass;
+	
+	abstract PhysicalForce
+	end PhysicalForce;
+	
+	Abstract HydraulicFlow
+	end HydraulicFlow;
+	
+end PhysicalResources;

--- a/core/org.osate.contribution.sei/resources/properties/Physical.aadl
+++ b/core/org.osate.contribution.sei/resources/properties/Physical.aadl
@@ -1,0 +1,22 @@
+-- Copyright 2015 Carnegie Mellon University
+-- Distribution Statement A: Approved for Public Release; Distribution is Unlimited.
+
+property set Physical is
+
+  Voltage: Physical::Voltage_Type applies to (all); 
+
+  Voltage_Type: type aadlreal units Physical::Voltage_Units;
+  Voltage_Units: type units (mV, V => mV * 1000, KV => V * 1000);
+
+  Wattage: Physical::Wattage_Type applies to (all); 
+
+  Wattage_Type: type aadlreal units Physical::Wattage_Units;
+  Wattage_Units: type units (mW, W => mW * 1000, KW => W * 1000);
+
+  Weight_Type: type aadlreal units Physical::Weight_Units;
+  Weight_Units: type units (g, kg => g * 1000, t => kg * 1000);
+
+ Weight: Physical::Weight_Type applies to (all); 
+
+
+end Physical;

--- a/core/org.osate.contribution.sei/resources/properties/Physical.aadl
+++ b/core/org.osate.contribution.sei/resources/properties/Physical.aadl
@@ -16,7 +16,6 @@ property set Physical is
   Weight_Type: type aadlreal units Physical::Weight_Units;
   Weight_Units: type units (g, kg => g * 1000, t => kg * 1000);
 
- Weight: Physical::Weight_Type applies to (all); 
-
+  Weight: Physical::Weight_Type applies to (all); 
 
 end Physical;


### PR DESCRIPTION
Fixes #1703 
Added Physical properties, and PhysicalResources types as org.osate.contributions.sei.