### PR TITLE
Latency invoke issue

### DIFF
--- a/alisa/org.osate.verify/src/org/osate/verify/analysisplugins/AnalysisPluginInterface.xtend
+++ b/alisa/org.osate.verify/src/org/osate/verify/analysisplugins/AnalysisPluginInterface.xtend
@@ -35,29 +35,6 @@ import static org.osate.verify.util.VerifyUtilExtension.*
 
 class AnalysisPluginInterface {
 
-	def static AnalysisResult flowLatencyAnalysis(InstanceObject etefi, boolean[] prefs) {
-		var AnalysisResult res = null;
-		val root = etefi.systemInstance
-		val checker = new FlowLatencyAnalysisSwitch(root)
-		val markerType = "LatencyAnalysis"
-		if (!getHasRun(markerType, root)) {
-			val som = root.systemOperationModes.head
-			try {
-				if (prefs !== null && prefs.size === 4) {
-					res = checker.invokeAndSaveResult(root, som, prefs.get(0), prefs.get(1), prefs.get(2), prefs.get(3))
-				} else {
-					res = checker.invokeAndSaveResult(root, som, false, true, true, true)
-				}
-				setHasRun(markerType, root)
-				setAnalysisResult(root, res)
-			} catch (Throwable e) {
-				unsetHasRun(markerType, root)
-			}
-		} else {
-			res = getAnalysisResult(root)
-		}
-		res
-	}
 
 //=======================architecture.analysis========================//
 	def static String A429Consistency(InstanceObject ci) {

--- a/alisa/org.osate.verify/src/org/osate/verify/util/VerificationMethodDispatchers.xtend
+++ b/alisa/org.osate.verify/src/org/osate/verify/util/VerificationMethodDispatchers.xtend
@@ -36,12 +36,6 @@ class VerificationMethodDispatchers {
 	 */
 	def Object dispatchVerificationMethod(PluginMethod vm, InstanceObject target, List<PropertyExpression> parameters) {
 		switch (vm.methodID) {
-			case "FlowLatencyAnalysis",
-			case "FlowLatencyAnalysisParameterized",
-			case "MaxFlowLatencyAnalysis",
-			case "MinFlowLatencyAnalysis",
-			case "FlowLatencyJitterAnalysis":
-				if(target === null) true else target.flowLatencyAnalysis(parameters.map[p|(p as BooleanLiteral).isValue])
 			case "A429Consistency":
 				if(target === null) true else target.A429Consistency
 			case "ConnectionBindingConsistency":

--- a/analyses/org.osate.analysis.flows/src/org/osate/analysis/flows/FlowLatencyAnalysisSwitch.java
+++ b/analyses/org.osate.analysis.flows/src/org/osate/analysis/flows/FlowLatencyAnalysisSwitch.java
@@ -782,6 +782,9 @@ public class FlowLatencyAnalysisSwitch extends AadlProcessingSwitchWithProgress 
 		return results;
 	}
 
+	public AnalysisResult invoke(ComponentInstance ci) {
+		return invoke(ci, null, true, true, true, true);
+	}
 	/**
 	 * Invoke the analysis on all ETEF owned by the given component instance and return Result collection
 	 *
@@ -840,6 +843,9 @@ public class FlowLatencyAnalysisSwitch extends AadlProcessingSwitchWithProgress 
 		return results;
 	}
 
+	public AnalysisResult invoke(EndToEndFlowInstance etef) {
+		return invoke(etef, null, true, true, true, true);
+	}
 	/**
 	 * Invoke the analysis on all ETEF owned by the given component instance and return Result collection
 	 *


### PR DESCRIPTION
Fixes #1710 
Added the missing two methods.
Removed old code that called Latency Analysis directly rather than
through Java interface.