### PR TITLE
Fix hash table key to avoid memory leak

### DIFF
--- a/core/org.osate.annexsupport/src/org/osate/annexsupport/AnnexParseUtil.java
+++ b/core/org.osate.annexsupport/src/org/osate/annexsupport/AnnexParseUtil.java
@@ -8,10 +8,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.xtext.ParserRule;
 import org.eclipse.xtext.diagnostics.Diagnostic;
 import org.eclipse.xtext.nodemodel.INode;
@@ -25,8 +23,8 @@ import org.osate.aadl2.modelsupport.errorreporting.ParseErrorReporter;
 
 public class AnnexParseUtil {
 
-	private static Map<URI, IParseResult> parseResults = Collections
-			.synchronizedMap(new HashMap<URI, IParseResult>());
+	private static Map<Integer, IParseResult> parseResults = Collections
+			.synchronizedMap(new HashMap<Integer, IParseResult>());
 
 	public static EObject parse(AbstractAntlrParser parser, String editString, ParserRule parserRule, String filename,
 			int line, int offset, ParseErrorReporter err) {
@@ -34,9 +32,9 @@ public class AnnexParseUtil {
 			IParseResult parseResult = parser.parse(parserRule, new StringReader(genWhitespace(offset) + editString));
 
 			if (parseResult.getRootASTElement() != null) {
-				URI uri = EcoreUtil.getURI(parseResult.getRootASTElement());
+				int id = parseResult.getRootASTElement().hashCode();
 
-				parseResults.put(uri, parseResult);
+				parseResults.put(id, parseResult);
 				if (parseResult.hasSyntaxErrors()) {
 					createDiagnostics(parseResult, filename, err);
 				}
@@ -48,8 +46,8 @@ public class AnnexParseUtil {
 	}
 
 	public static IParseResult getParseResult(EObject annexObject) {
-		URI uri = EcoreUtil.getURI(annexObject);
-		return parseResults.get(uri);
+		int id = annexObject.hashCode();
+		return parseResults.get(id);
 	}
 
 	public static String genWhitespace(int length) {

--- a/core/org.osate.annexsupport/src/org/osate/annexsupport/AnnexParseUtil.java
+++ b/core/org.osate.annexsupport/src/org/osate/annexsupport/AnnexParseUtil.java
@@ -8,8 +8,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
 
+import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.xtext.ParserRule;
 import org.eclipse.xtext.diagnostics.Diagnostic;
 import org.eclipse.xtext.nodemodel.INode;
@@ -23,8 +25,8 @@ import org.osate.aadl2.modelsupport.errorreporting.ParseErrorReporter;
 
 public class AnnexParseUtil {
 
-	private static Map<EObject, IParseResult> parseResults = Collections
-			.synchronizedMap(new WeakHashMap<EObject, IParseResult>());
+	private static Map<URI, IParseResult> parseResults = Collections
+			.synchronizedMap(new WeakHashMap<URI, IParseResult>());
 
 	public static EObject parse(AbstractAntlrParser parser, String editString, ParserRule parserRule, String filename,
 			int line, int offset, ParseErrorReporter err) {
@@ -34,7 +36,8 @@ public class AnnexParseUtil {
 			IParseResult parseResult = parser.parse(parserRule, new StringReader(editString));
 
 			if (parseResult.getRootASTElement() != null) {
-				parseResults.put(parseResult.getRootASTElement(), parseResult);
+				URI uri = EcoreUtil.getURI(parseResult.getRootASTElement());
+				parseResults.put(uri, parseResult);
 			}
 			EObject result = null;
 			if (isValidParseResult(parseResult)) {
@@ -55,7 +58,8 @@ public class AnnexParseUtil {
 	}
 
 	public static IParseResult getParseResult(EObject annexObject) {
-		return parseResults.get(annexObject);
+		URI uri = EcoreUtil.getURI(annexObject);
+		return parseResults.get(uri);
 	}
 
 	public static String genWhitespace(int length) {


### PR DESCRIPTION
fixes #1726 
Original implementation used an EObject as the key. Each parser run creates new EObjects, so the value was never updated.
Also, the key was referenced from the value, so the entry could not be garbage collected.
