### PR TITLE
Ignore GE user interface name changes when determining if a diagram change

### DIFF
--- a/ge/org.osate.ge/src/org/osate/ge/internal/diagram/runtime/AgeDiagram.java
+++ b/ge/org.osate.ge/src/org/osate/ge/internal/diagram/runtime/AgeDiagram.java
@@ -692,9 +692,9 @@ public class AgeDiagram implements DiagramNode, ModifiableDiagramElementContaine
 
 		@Override
 		public boolean affectsChangeNumber() {
-			if (field == ModifiableField.COMPLETENESS
-					|| (field == ModifiableField.LABEL_NAME
-					&& !(element.getBusinessObject() instanceof EmbeddedBusinessObject))
+			if (field == ModifiableField.COMPLETENESS || field == ModifiableField.USER_INTERFACE_NAME
+					|| ((field == ModifiableField.LABEL_NAME)
+							&& !(element.getBusinessObject() instanceof EmbeddedBusinessObject))
 					|| field == ModifiableField.GRAPHICAL_CONFIGURATION) {
 				return false;
 			}


### PR DESCRIPTION
Ignore user interface name changes when determining if a diagram change affects the change number.

Fixes #1682