### PR TITLE
Fix resource URI in SiriusUtil to load proper representation from aird file

### DIFF
--- a/emv2/org.osate.aadl2.errormodel.faulttree.generation/src/org/osate/aadl2/errormodel/faulttree/util/SiriusUtil.java
+++ b/emv2/org.osate.aadl2.errormodel.faulttree.generation/src/org/osate/aadl2/errormodel/faulttree/util/SiriusUtil.java
@@ -12,7 +12,6 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.transaction.RecordingCommand;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.sirius.business.api.componentization.ViewpointRegistry;
@@ -350,7 +349,7 @@ public class SiriusUtil {
 		IProgressMonitor monitor = new NullProgressMonitor();
 		URI viewpointURI = URI.createURI(viewPoint);
 
-		URI semanticResourceURI = EcoreUtil.getURI(targetroot);
+		URI semanticResourceURI = targetroot.eResource().getURI();
 		// enable Modeling Nature
 		if (!ModelingProject.hasModelingProjectNature(project)) {
 			try {
@@ -372,6 +371,7 @@ public class SiriusUtil {
 			String modelRootName = getPrintName(model);
 			String representationName = modelRootName + " " + representation;
 			DRepresentation rep = findRepresentation(existingSession, vPoint, description, representationName);
+
 			if (rep == null) {
 				try {
 					createAndOpenRepresentation(existingSession, vPoint, description, representationName, model,


### PR DESCRIPTION
EcoreUtil appends suffix to resource URI that prevents loading proper resource later. This means that on model updates (say constants in aadl file) we'll keep showing original representation with old values and the only way to bypass this is to delete representations.aird file. With this update it will be enough to just instantiate model