### PR TITLE
1952 missing reference processor only

### DIFF
--- a/analyses/org.osate.analysis.resource.budgets/src/org/osate/analysis/resource/budgets/handlers/DoBoundResourceAnalysis.java
+++ b/analyses/org.osate.analysis.resource.budgets/src/org/osate/analysis/resource/budgets/handlers/DoBoundResourceAnalysis.java
@@ -86,11 +86,6 @@ public class DoBoundResourceAnalysis extends AaxlReadOnlyHandlerAsJob {
 	@Override
 	public final void doAaxlAction(final IProgressMonitor monitor, final Element obj) {
 		InstanceModelUtil.clearCache();
-		InstanceValidation iv = new InstanceValidation(this);
-		if (!iv.checkReferenceProcessor(((InstanceObject) obj).getSystemInstance())) {
-			errManager.error(obj, "Model contains thread execution times without reference processor.");
-			return;
-		}
 		getLogicObject().analysisBody(monitor, obj);
 	}
 

--- a/analyses/org.osate.analysis.resource.budgets/src/org/osate/analysis/resource/budgets/handlers/DoResourceBudget.java
+++ b/analyses/org.osate.analysis.resource.budgets/src/org/osate/analysis/resource/budgets/handlers/DoResourceBudget.java
@@ -90,13 +90,6 @@ public class DoResourceBudget extends AaxlReadOnlyHandlerAsJob {
 			monitor.beginTask(getActionName(), IProgressMonitor.UNKNOWN);
 			DoResourceBudgetLogic logic = null;
 
-			InstanceValidation iv = new InstanceValidation(this);
-			if (!iv.checkReferenceProcessor(si)) {
-				Dialog.showWarning("Resource Budget Analysis",
-						"Model contains thread execution times without reference processor.");
-				return;
-			}
-
 			logic = new DoResourceBudgetLogic(this);
 			final SOMIterator soms = new SOMIterator(si);
 			while (soms.hasNext()) {

--- a/core/org.osate.xtext.aadl2.properties/src/org/osate/xtext/aadl2/properties/util/GetProperties.java
+++ b/core/org.osate.xtext.aadl2.properties/src/org/osate/xtext/aadl2/properties/util/GetProperties.java
@@ -999,6 +999,9 @@ public class GetProperties {
 			double exectimeval = getMaximumComputeExecutionTimeinSec(threadinstance);
 			if (exectimeval > 0 && period > 0) {
 				double mipspersec = getReferenceMIPS(threadinstance);
+				if (mipspersec == 0) {
+					mipspersec = getBoundProcessorMIPS(threadinstance);
+				}
 				double time = exectimeval / period;
 				mips = time * mipspersec;
 			}


### PR DESCRIPTION
Fixes #1952 

I cannot write a test because this is a plugin that does not have an invoke interface without Eclipse GUI (one of the budget analyses even brings up a dialog box). The handler calls on the validation enforcing the presence of the Reference_Processor property.