### PR TITLE
1961 priority and of out propagation condition

### DIFF
--- a/emv2/org.osate.aadl2.errormodel.faulttree.tests/models/FTATests/FTerrorlibrary.aadl
+++ b/emv2/org.osate.aadl2.errormodel.faulttree.tests/models/FTATests/FTerrorlibrary.aadl
@@ -18,6 +18,12 @@ transitions
 	SecondFailure : Degraded -[ Failure ]-> FailStop ;
 	DirectFailure : Operational -[ Failure ]-> FailStop ;
 end behavior ;
+	error behavior ThreeStates
+	  states 
+	    operational: initial state; 
+	    standby : state;
+	    failed : state;
+	end behavior;
 		
 	**};
 	

--- a/emv2/org.osate.aadl2.errormodel.faulttree.tests/models/FTATests/Issue1961.aadl
+++ b/emv2/org.osate.aadl2.errormodel.faulttree.tests/models/FTATests/Issue1961.aadl
@@ -1,0 +1,70 @@
+package Issue1961
+public
+	
+	abstract pilot
+		features
+			controlsurfacecmd: out feature;
+			annex emv2 {**
+				use types ErrorLibrary;
+				use behavior FTerrorlibrary::ThreeStates;
+				error propagations
+				controlsurfacecmd: out propagation { ServiceOmission};
+				end propagations;
+				component error behavior
+				events
+				unawareness: error event {ValueError,ServiceOmission};
+				mistakes: error event {TimingError,SequenceOmission};
+				transitions
+				Operational -[unawareness{ValueError}]-> standby; 
+				Operational -[unawareness{ServiceOmission}]-> failed; 
+				propagations
+				failed-[mistakes{TimingError}]-> controlsurfacecmd{ServiceOmission};
+				standby-[mistakes{SequenceOmission}]-> controlsurfacecmd{ServiceOmission};
+				end component;
+				**};
+	end pilot;
+	
+	
+	device Engine
+		features
+			thrust: out feature;
+			annex emv2 {**
+				use types ErrorLibrary;
+				error propagations
+				thrust: out propagation {ServiceOmission};
+				flows
+					engineFailure: error source thrust{ServiceOmission};
+				end propagations;
+			**};
+	end Engine;
+
+	system ac
+		features
+			aceffect: out feature;
+		annex emv2 {**
+			use types ErrorLibrary;
+			
+			error propagations
+				aceffect: out propagation {ServiceOmission};
+			end propagations;
+		**};
+	end ac;
+	
+	system implementation ac.impl
+		subcomponents
+			engine1: device engine;
+			pilot: abstract pilot;
+		connections
+			pilotctrl: feature pilot.controlsurfacecmd -> aceffect;
+			engine1conn: feature engine1.thrust -> aceffect;
+		annex emv2 {**
+			use types ErrorLibrary;
+			
+			component error behavior
+			propagations
+				all -[1 ormore (pilot.controlsurfacecmd {ServiceOmission}, engine1.thrust {ServiceOmission})]-> aceffect {ServiceOmission};
+			end component;
+		**};
+	end ac.impl;
+
+end Issue1961;

--- a/emv2/org.osate.aadl2.errormodel.faulttree.tests/src/org/osate/aadl2/errormodel/faulttree/tests/FTATest.xtend
+++ b/emv2/org.osate.aadl2.errormodel.faulttree.tests/src/org/osate/aadl2/errormodel/faulttree/tests/FTATest.xtend
@@ -659,12 +659,20 @@ class FTATest {
 	def void allFlowFaultTraceTest() {
 		val start = "outgoing propagation on outport{ValueProblem}"
 		val ft = CreateFTAModel.createFaultTrace(instanceAllFlows, start)
-		// Visualization shows more events but we have shared subtrees, thus, only 10.
-		assertEquals(10,ft.events.size)
+		assertEquals(11,ft.events.size)
 		assertEquals(ft.root.subEvents.size, 1)
 		val sube1 = ft.root.subEvents.get(0)
 		assertEquals(sube1.subEventLogic, LogicOperation.OR)
 		assertEquals(sube1.subEvents.size, 3)
+		val sube11 = sube1.subEvents.get(0)
+		assertTrue(sube11.relatedEMV2Object instanceof ErrorBehaviorState)
+		assertEquals((sube11.relatedEMV2Object as NamedElement).name, "FailStop")
+		val sube12 = sube1.subEvents.get(1)
+		assertTrue(sube12.relatedEMV2Object instanceof ErrorPropagation)
+		assertEquals(EMV2Util.getPrintName(sube12.relatedEMV2Object as NamedElement), "FromAP1Port")
+		val sube13 = sube1.subEvents.get(2)
+		assertTrue(sube13.relatedEMV2Object instanceof ErrorPropagation)
+		assertEquals(EMV2Util.getPrintName(sube13.relatedEMV2Object as NamedElement), "FromAP2Port")
 	}
 
 	@Test

--- a/emv2/org.osate.aadl2.errormodel.faulttree.tests/src/org/osate/aadl2/errormodel/faulttree/tests/FTATest.xtend
+++ b/emv2/org.osate.aadl2.errormodel.faulttree.tests/src/org/osate/aadl2/errormodel/faulttree/tests/FTATest.xtend
@@ -65,6 +65,7 @@ class FTATest {
 	var static SystemInstance instanceIssue1899
 	var static SystemInstance instanceIssue1837
 	var static SystemInstance instanceIssue1962
+	var static SystemInstance instanceIssue1961
 
 	val static stateFail = "state Failed"
 	val static stateFailStop = "state FailStop"
@@ -104,6 +105,7 @@ class FTATest {
 	val accessfeaturesFile = "accessfeatures.aadl"
 	val Issue1837file = "Issue1837.aadl"
 	val Issue1962file = "Issue1962.aadl"
+	val Issue1961file = "Issue1961.aadl"
 
 	@Before
 	def void initWorkspace() {
@@ -140,7 +142,8 @@ class FTATest {
 			modelroot + ScrubbedClFile,
 			modelroot + accessfeaturesFile,
 			modelroot + Issue1837file,
-			modelroot + Issue1962file
+			modelroot + Issue1962file,
+			modelroot + Issue1961file
 		)
 		instance1 = instanceGenerator(modelroot + fta1File, "main.i")
 		instance2 = instanceGenerator(modelroot + fta2File, "main.i")
@@ -171,6 +174,7 @@ class FTATest {
 		instanceIssue1899 = instanceGenerator(modelroot + accessfeaturesFile, "top.ii")
 		instanceIssue1837 = instanceGenerator(modelroot + Issue1837file, "TMR_Archetype.impl")
 		instanceIssue1962 = instanceGenerator(modelroot + Issue1962file, "ac.impl")
+		instanceIssue1961 = instanceGenerator(modelroot + Issue1961file, "ac.impl")
 	}
 
 	def SystemInstance instanceGenerator(String filename, String rootclassifier) {
@@ -964,6 +968,22 @@ class FTATest {
 		assertEquals((errorevent.relatedInstanceObject as NamedElement).name, "pilot")
 		assertEquals((errorevent.relatedEMV2Object as NamedElement).name, "mistakes")
 		assertEquals(EMV2Util.getName(errorevent.relatedErrorType as TypeToken), "TimingError")
+	}
+
+
+	@Test
+	def void issue1961Test() {
+		val ft = CreateFTAModel.createFaultTree(instanceIssue1961, "outgoing propagation on aceffect{ServiceOmission}")
+		assertEquals(ft.events.size, 8)
+		assertEquals(ft.root.subEvents.size,3)
+		val pilotand1 = ft.root.subEvents.get(0)
+		val pilotand2 = ft.root.subEvents.get(1)
+		val engine = ft.root.subEvents.get(2)
+		assertEquals(pilotand1.subEventLogic, LogicOperation.PRIORITY_AND)
+		assertEquals(pilotand2.subEventLogic, LogicOperation.PRIORITY_AND)
+		assertEquals((engine.relatedInstanceObject as NamedElement).name, "engine1")
+		assertEquals((engine.relatedEMV2Object as NamedElement).name, "engineFailure")
+		assertEquals(EMV2Util.getName(engine.relatedErrorType as TypeToken), "ServiceOmission")
 	}
 
 }

--- a/emv2/org.osate.aadl2.errormodel.faulttree.tests/src/org/osate/aadl2/errormodel/faulttree/tests/PropagationPointsTest.xtend
+++ b/emv2/org.osate.aadl2.errormodel.faulttree.tests/src/org/osate/aadl2/errormodel/faulttree/tests/PropagationPointsTest.xtend
@@ -70,7 +70,7 @@ class PropagationPointsTest  {
 		val start = "outgoing propagation on observation{ServiceOmission}"
 		val ft = CreateFTAModel.createFaultTree(instance, start)
 		assertEquals(ft.events.size, 6)
-		val andevent = FaultTreeUtils.findEvent(ft, "Intermediate1")
+		val andevent = ft.root.subEvents.get(1) 
 		assertEquals(andevent.subEventLogic, LogicOperation.AND)
 		val actual = ft.root.computedProbability
 		assertEquals(7.1e-8, actual.doubleValue, 0.1e-8)
@@ -127,7 +127,7 @@ class PropagationPointsTest  {
 		val start = "outgoing propagation on observation{ServiceOmission}"
 		val ft = CreateFTAModel.createFaultTree(instance2, start)
 		assertEquals(ft.events.size, 6)
-		val andevent = FaultTreeUtils.findEvent(ft, "Intermediate1")
+		val andevent = ft.root.subEvents.get(1) 
 		assertEquals(andevent.subEventLogic, LogicOperation.AND)
 		val actual = ft.root.computedProbability
 		assertEquals(7.1e-8, actual.doubleValue, 0.1e-8)

--- a/emv2/org.osate.aadl2.errormodel.faulttree/src/org/osate/aadl2/errormodel/FaultTree/util/FaultTreeUtils.java
+++ b/emv2/org.osate.aadl2.errormodel.faulttree/src/org/osate/aadl2/errormodel/FaultTree/util/FaultTreeUtils.java
@@ -42,15 +42,16 @@ public class FaultTreeUtils {
 		String identifier;
 
 		identifier = conni.getName();
-		identifier += "-";
 
 		if (namedElement == null) {
-			identifier += "unidentified";
+			identifier += "-unidentified";
 
 		} else {
-			identifier += EMV2Util.getPrintName(namedElement);
+			String name = EMV2Util.getDirectionName(namedElement);
+			if (!name.isEmpty()) {
+				identifier += "-" + name;
+			}
 		}
-
 		if (type != null) {
 			identifier += "-" + EMV2Util.getName(type);
 		}
@@ -67,14 +68,15 @@ public class FaultTreeUtils {
 		identifier = component instanceof SystemInstance
 				? component.getComponentClassifier().getQualifiedName().replaceAll("::", "_").replaceAll("\\.", "_")
 						: component.getComponentInstancePath();
-				identifier += "-";
 
-				if (namedElement == null) {
-					identifier += "unidentified";
-
-				} else {
-			identifier += EMV2Util.getDirectionName(namedElement);
-				}
+		if (namedElement == null) {
+			identifier += "-unidentified";
+		} else {
+			String name = EMV2Util.getDirectionName(namedElement);
+			if (!name.isEmpty()) {
+				identifier += "-" + name;
+			}
+		}
 
 		if (type != null) {
 			identifier += "-" + EMV2Util.getName(type);
@@ -217,7 +219,7 @@ public class FaultTreeUtils {
 			TypeToken type,
 			boolean unique) {
 		String name;
-		if (element instanceof NamedElement && !unique) {
+		if (element instanceof NamedElement && !unique && ((NamedElement) element).getName() != null) {
 			name = buildName(component, (NamedElement) element, type);
 			Event result = findEvent(ftaModel, name);
 			if (result != null && result.getType() == EventType.INTERMEDIATE) {


### PR DESCRIPTION
Fixes #1961 
Had to make sure FTA Event names are unique for different outgoing propagation conditions if these did not have a declarative name. My 737 example had such a situation.