### PR TITLE
add shift key to hide element shortcut

### DIFF
--- a/ge/org.osate.ge/plugin.xml
+++ b/ge/org.osate.ge/plugin.xml
@@ -1488,7 +1488,7 @@
           commandId="org.osate.ge.hideElement"
           contextId="org.osate.ge.context"
           schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-          sequence="M1+H">
+          sequence="M1+M2+H">
     </key>
   </extension>
   


### PR DESCRIPTION
Added shift key to hide element shortcut.  Was conflicting with existing key binding.