### PR TITLE
Mark occurrences improvements

### DIFF
--- a/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/Aadl2RuntimeModule.java
+++ b/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/Aadl2RuntimeModule.java
@@ -36,6 +36,7 @@ package org.osate.xtext.aadl2;
 
 import org.eclipse.xtext.conversion.IValueConverterService;
 import org.eclipse.xtext.documentation.IEObjectDocumentationProvider;
+import org.eclipse.xtext.findReferences.TargetURICollector;
 import org.eclipse.xtext.formatting2.regionaccess.TextRegionAccessBuilder;
 import org.eclipse.xtext.generator.AbstractFileSystemAccess2;
 import org.eclipse.xtext.generator.IOutputConfigurationProvider;
@@ -53,6 +54,7 @@ import org.eclipse.xtext.serializer.tokens.SerializerScopeProviderBinding;
 import org.eclipse.xtext.validation.IConcreteSyntaxValidator;
 import org.osate.xtext.aadl2.documentation.Aadl2DocumentationProvider;
 import org.osate.xtext.aadl2.findReferences.Aadl2ReferenceFinder;
+import org.osate.xtext.aadl2.findReferences.Aadl2TargetURICollector;
 import org.osate.xtext.aadl2.formatting2.regionaccess.Aadl2TextRegionAccessBuilder;
 import org.osate.xtext.aadl2.generator.Aadl2OutputConfigurationProvider;
 import org.osate.xtext.aadl2.parsing.AnnexParserAgent;
@@ -239,4 +241,7 @@ public class Aadl2RuntimeModule extends org.osate.xtext.aadl2.AbstractAadl2Runti
 		return Aadl2ResourceServiceProvider.class;
 	}
 
+	public Class<? extends TargetURICollector> bindTargetURICollector() {
+		return Aadl2TargetURICollector.class;
+	}
 }

--- a/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/findReferences/Aadl2TargetURICollector.java
+++ b/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/findReferences/Aadl2TargetURICollector.java
@@ -1,0 +1,46 @@
+package org.osate.xtext.aadl2.findReferences;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.EcoreUtil2;
+import org.eclipse.xtext.findReferences.TargetURICollector;
+import org.eclipse.xtext.findReferences.TargetURIs;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.Classifier;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.ComponentType;
+import org.osate.aadl2.Property;
+import org.osate.aadl2.PropertyConstant;
+import org.osate.aadl2.PropertySet;
+import org.osate.aadl2.PropertyType;
+
+public class Aadl2TargetURICollector extends TargetURICollector {
+
+	@Override
+	protected void doAdd(EObject object, TargetURIs targetURIs) {
+		super.doAdd(object, targetURIs);
+
+		if (object instanceof ComponentType) {
+			AadlPackage pkg = EcoreUtil2.getContainerOfType(object, AadlPackage.class);
+			for (ComponentImplementation impl : EcoreUtil2.getAllContentsOfType(pkg, ComponentImplementation.class)) {
+				if (impl.getType() == object) {
+					super.doAdd(impl, targetURIs);
+				}
+			}
+		} else if (object instanceof AadlPackage) {
+			for (Classifier cl : EcoreUtil2.getAllContentsOfType(object, Classifier.class)) {
+				super.doAdd(cl, targetURIs);
+			}
+		} else if (object instanceof PropertySet) {
+			for (PropertyType p : EcoreUtil2.getAllContentsOfType(object, PropertyType.class)) {
+				super.doAdd(p, targetURIs);
+			}
+			for (PropertyConstant p : EcoreUtil2.getAllContentsOfType(object, PropertyConstant.class)) {
+				super.doAdd(p, targetURIs);
+			}
+			for (Property p : EcoreUtil2.getAllContentsOfType(object, Property.class)) {
+				super.doAdd(p, targetURIs);
+			}
+		}
+	}
+
+}

--- a/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/util/Aadl2LocationInFile.java
+++ b/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/util/Aadl2LocationInFile.java
@@ -1,5 +1,6 @@
 package org.osate.xtext.aadl2.util;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -11,6 +12,7 @@ import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.eclipse.xtext.resource.DefaultLocationInFileProvider;
 import org.eclipse.xtext.util.ITextRegion;
 import org.eclipse.xtext.util.TextRegion;
+import org.osate.aadl2.AadlPackage;
 import org.osate.aadl2.Classifier;
 import org.osate.aadl2.ModelUnit;
 import org.osate.aadl2.parsesupport.AObject;
@@ -60,24 +62,43 @@ public class Aadl2LocationInFile extends DefaultLocationInFileProvider {
 		if (obj instanceof ModelUnit || obj instanceof Classifier) {
 			ICompositeNode node = NodeModelUtils.getNode(obj);
 			INode endID = node.getLastChild().getPreviousSibling();
+			List<INode> nodes = null;
 			while (endID instanceof HiddenLeafNode) {
 				endID = endID.getPreviousSibling();
 			}
+			nodes = Collections.<INode> singletonList(endID);
 			if (endID instanceof ICompositeNode) {
 				ICompositeNode fullName = (ICompositeNode) endID;
-				if (typeName) {
+				if (obj instanceof AadlPackage) {
+					nodes = new ArrayList<INode>();
+					endID = fullName.getLastChild();
+					while (endID instanceof HiddenLeafNode) {
+						endID = endID.getPreviousSibling();
+					}
+					INode id = fullName.getFirstChild();
+					while (id instanceof HiddenLeafNode) {
+						id = id.getNextSibling();
+					}
+					nodes.add(id);
+					while (id != endID) {
+						id = id.getNextSibling();
+						nodes.add(id);
+					}
+				} else if (typeName) {
 					endID = fullName.getFirstChild();
 					while (endID instanceof HiddenLeafNode) {
 						endID = endID.getNextSibling();
 					}
+					nodes = Collections.<INode> singletonList(endID);
 				} else {
 					endID = fullName.getLastChild();
 					while (endID instanceof HiddenLeafNode) {
 						endID = endID.getPreviousSibling();
 					}
+					nodes = Collections.<INode> singletonList(endID);
 				}
 			}
-			return createRegion(Collections.<INode> singletonList(endID));
+			return createRegion(nodes);
 		} else {
 			return null;
 		}


### PR DESCRIPTION
- mark implementation name only in references to implementation
- mark property (type, const) name only in references to them
- mark type name in name at implementation end
- mark type name in references to implementations
- mark package name in fully qualified references
- mark property set name in fully qualified references
- mark full name at end for multi-part package name

fixes #2086 