### PR TITLE
Cache resolved references to avoid duplicate resolution of references

### DIFF
--- a/core/osate.releng/OSATE2.launch
+++ b/core/osate.releng/OSATE2.launch
@@ -23,6 +23,7 @@
 <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.osate.linking.cache=false"/>
 <stringAttribute key="pde.version" value="3.3"/>
 <stringAttribute key="product" value="org.osate.branding.org.osate.product"/>
 <setAttribute key="selected_features">


### PR DESCRIPTION
References cached by string for global references (containing "::"),
otherwise by node object
Cache is cleared on resource changes
Caches core and (Xtext) annex references
Must be enabled via system property org.osate.linking.cache=true