### PR TITLE
Property view exceptions

### DIFF
--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/CachePropertyLookupJob.xtend
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/CachePropertyLookupJob.xtend
@@ -106,7 +106,7 @@ package class CachePropertyLookupJob extends Job {
 					].entrySet.map[key.URI -> value]).unmodifiableView
 				}
 			]
-		} catch (NullPointerException e) {
+		} catch (RuntimeException e) {
 		}
 		if (monitor.canceled) {
 			Status.CANCEL_STATUS


### PR DESCRIPTION
Fixes #2191.

This fix prevents a dialog from being opened when these exceptions are thrown. It does not prevent all exceptions from being logged. Logging to the console still happens because these exceptions are being caught and logged in `LazyLinkingResource.getEObject(String)`.