### PR TITLE
1180 refine dirty state handling

### DIFF
--- a/ge/org.osate.ge/src/org/osate/ge/internal/diagram/runtime/AgeDiagram.java
+++ b/ge/org.osate.ge/src/org/osate/ge/internal/diagram/runtime/AgeDiagram.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (c) 2004-2020 Carnegie Mellon University and others. (see Contributors file). 
+ * Copyright (c) 2004-2020 Carnegie Mellon University and others. (see Contributors file).
  * All Rights Reserved.
- * 
+ *
  * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
  * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
  * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
  * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
- * 
+ *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
- * 
+ *
  * This program includes and/or can make use of certain third party source code, object code, documentation and other
  * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
  * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
@@ -683,9 +683,11 @@ public class AgeDiagram implements DiagramNode, ModifiableDiagramElementContaine
 
 			case RELATIVE_REFERENCE:
 				((AgeDiagramModification) m).setRelativeReference(element, (RelativeBusinessObjectReference) value);
+				break;
 
 			case EMBEDDED_BUSINESS_OBJECT:
 				m.updateBusinessObjectWithSameRelativeReference(element, value);
+				break;
 
 			default:
 				break;

--- a/ge/org.osate.ge/src/org/osate/ge/internal/ui/LtkRenameAction.java
+++ b/ge/org.osate.ge/src/org/osate/ge/internal/ui/LtkRenameAction.java
@@ -29,13 +29,10 @@ import java.util.Objects;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.window.Window;
@@ -47,8 +44,6 @@ import org.eclipse.ltk.ui.refactoring.RefactoringUI;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorReference;
-import org.eclipse.ui.IWorkbenchPage;
-import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.actions.WorkspaceModifyOperation;
 import org.eclipse.xtext.ui.editor.XtextEditor;
@@ -119,37 +114,6 @@ public class LtkRenameAction implements AgeAction {
 	 * @return
 	 */
 	private boolean renameWithLtk(final EObject bo, final String value) {
-		// TODO: Remove when issue regarding Xtext Dirty State has been resolved.
-		// https://github.com/osate/osate-ge/issues/210
-		// This works around the issue by saving the resource before trying to refactor.
-		if (bo instanceof EObject) {
-			final EObject eObj = bo;
-			if (eObj.eResource() != null) {
-				// Get the IResource for the current BO
-				final IResource boRes = ResourcesPlugin.getWorkspace().getRoot()
-						.getFile(new Path(eObj.eResource().getURI().toPlatformString(true)));
-
-				// Find and save the edit part
-				if (boRes != null && PlatformUI.getWorkbench() != null) {
-					for (final IWorkbenchWindow window : PlatformUI.getWorkbench().getWorkbenchWindows()) {
-						for (final IWorkbenchPage page : window.getPages()) {
-							for (final IEditorReference editorRef : page.getEditorReferences()) {
-								if (editorRef.isDirty()) {
-									final IEditorPart editorPart = editorRef.getEditor(false);
-									if (editorPart instanceof XtextEditor) {
-										final IResource editorRes = ((XtextEditor) editorPart).getResource();
-										if (boRes.equals(editorRes)) {
-											page.saveEditor(editorPart, false);
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-
 		// Lock the diagram to treat all model change notifications as part of the current action.
 		try (Lock lock = modelChangeNotifier.lock()) {
 			// Rename the element using LTK


### PR DESCRIPTION
Closes #1180. The updated fix is based on suggestion from Xtext developers. The workaround in renameWithLtk does not appear to be required any longer. Also fixes another bug with change management.