### PR TITLE
Remove memory leaks from BA plugin

### DIFF
--- a/ba/org.osate.ba.feature/feature.xml
+++ b/ba/org.osate.ba.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.osate.ba.feature"
       label="AADL-BA-FrontEnd"
-      version="3.0.1.qualifier"
+      version="3.1.0.qualifier"
       provider-name="TELECOM ParisTech"
       plugin="org.osate.ba">
 

--- a/ba/org.osate.ba.feature/pom.xml
+++ b/ba/org.osate.ba.feature/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>org.osate</groupId>
 	<artifactId>org.osate.ba.feature</artifactId>
-	<version>3.0.1-SNAPSHOT</version>
+	<version>3.1.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 </project>

--- a/ba/org.osate.ba/META-INF/MANIFEST.MF
+++ b/ba/org.osate.ba/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.osate.ba;singleton:=true
-Bundle-Version: 3.0.1.qualifier
+Bundle-Version: 3.1.0.qualifier
 Bundle-ClassPath: .,
  resources/libs/antlr-runtime-4.4.jar
 Bundle-Vendor: %providerName

--- a/ba/org.osate.ba/pom.xml
+++ b/ba/org.osate.ba/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>org.osate</groupId>
 	<artifactId>org.osate.ba</artifactId>
-	<version>3.0.1-SNAPSHOT</version>
+	<version>3.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/ba/org.osate.ba/src/org/osate/ba/aadlba/impl/BehaviorAnnexImpl.java
+++ b/ba/org.osate.ba/src/org/osate/ba/aadlba/impl/BehaviorAnnexImpl.java
@@ -20,8 +20,8 @@
 package org.osate.ba.aadlba.impl;
 
 import java.util.Collection ;
-import java.util.HashMap ;
 import java.util.Map ;
+import java.util.WeakHashMap ;
 
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain ;
@@ -170,7 +170,10 @@ public class BehaviorAnnexImpl extends AnnexSubclauseImpl implements BehaviorAnn
   @Override
   public void unsetVariables()
   {
-    if (variables != null) ((InternalEList.Unsettable<?>)variables).unset();
+    if (variables != null)
+    {
+      ((InternalEList.Unsettable<?>)variables).unset();
+    }
   }
 
   /**
@@ -207,7 +210,10 @@ public class BehaviorAnnexImpl extends AnnexSubclauseImpl implements BehaviorAnn
   @Override
   public void unsetStates()
   {
-    if (states != null) ((InternalEList.Unsettable<?>)states).unset();
+    if (states != null)
+    {
+      ((InternalEList.Unsettable<?>)states).unset();
+    }
   }
 
   /**
@@ -244,7 +250,10 @@ public class BehaviorAnnexImpl extends AnnexSubclauseImpl implements BehaviorAnn
   @Override
   public void unsetTransitions()
   {
-    if (transitions != null) ((InternalEList.Unsettable<?>)transitions).unset();
+    if (transitions != null)
+    {
+      ((InternalEList.Unsettable<?>)transitions).unset();
+    }
   }
 
   /**
@@ -303,7 +312,9 @@ public class BehaviorAnnexImpl extends AnnexSubclauseImpl implements BehaviorAnn
       if (initialState != oldInitialState)
       {
         if (eNotificationRequired())
+        {
           eNotify(new ENotificationImpl(this, Notification.RESOLVE, AadlBaPackage.BEHAVIOR_ANNEX__INITIAL_STATE, oldInitialState, initialState));
+        }
       }
     }
     return initialState;
@@ -330,7 +341,9 @@ public class BehaviorAnnexImpl extends AnnexSubclauseImpl implements BehaviorAnn
     BehaviorState oldInitialState = initialState;
     initialState = newInitialState;
     if (eNotificationRequired())
+    {
       eNotify(new ENotificationImpl(this, Notification.SET, AadlBaPackage.BEHAVIOR_ANNEX__INITIAL_STATE, oldInitialState, initialState));
+    }
   }
 
   /**
@@ -378,7 +391,10 @@ public class BehaviorAnnexImpl extends AnnexSubclauseImpl implements BehaviorAnn
       case AadlBaPackage.BEHAVIOR_ANNEX__CONDITIONS:
         return getConditions();
       case AadlBaPackage.BEHAVIOR_ANNEX__INITIAL_STATE:
-        if (resolve) return getInitialState();
+        if (resolve)
+        {
+          return getInitialState();
+        }
         return basicGetInitialState();
     }
     return super.eGet(featureID, resolve, coreType);
@@ -490,16 +506,17 @@ public class BehaviorAnnexImpl extends AnnexSubclauseImpl implements BehaviorAnn
    * @generated NOT
    */
   
-  private Map<AadlBaLocationReference, Element> _links = new HashMap
+  private Map<AadlBaLocationReference, Element> _links = new WeakHashMap
           <AadlBaLocationReference, Element>() ;
   
+  @Override
   public Map<AadlBaLocationReference, Element> getLinks()
   {
     return _links;
   }
   
   private Map<BehaviorAnnex, AadlBaHighlighter> _annexHighlighters = 
-       new HashMap<BehaviorAnnex, AadlBaHighlighter>();
+       new WeakHashMap<BehaviorAnnex, AadlBaHighlighter>();
  
   public Map<BehaviorAnnex, AadlBaHighlighter> getHighlighters()
   {

--- a/ba/org.osate.ba/src/org/osate/ba/analyzers/AadlBaLegalityRulesChecker.java
+++ b/ba/org.osate.ba/src/org/osate/ba/analyzers/AadlBaLegalityRulesChecker.java
@@ -1,13 +1,13 @@
 /**
  * AADL-BA-FrontEnd
- * 
+ *
  * Copyright (c) 2011-2020 TELECOM ParisTech and CNRS
- * 
+ *
  * TELECOM ParisTech/LTCI
- * 
+ *
  * Authors: see AUTHORS
- * 
- * This program is free software: you can redistribute it and/or modify 
+ *
+ * This program is free software: you can redistribute it and/or modify
  * it under the terms of the Eclipse Public License as published by Eclipse,
  * either version 2.0 of the License, or (at your option) any later version.
  * This program is distributed in the hope that it will be useful,
@@ -15,7 +15,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * Eclipse Public License for more details.
  * You should have received a copy of the Eclipse Public License
- * along with this program.  If not, see 
+ * along with this program.  If not, see
  * https://www.eclipse.org/legal/epl-2.0/
  */
 
@@ -23,16 +23,13 @@ package org.osate.ba.analyzers ;
 
 import java.util.ArrayList ;
 import java.util.Comparator ;
-import java.util.HashMap ;
 import java.util.HashSet ;
 import java.util.List ;
 import java.util.Map ;
 import java.util.Set ;
+import java.util.WeakHashMap ;
 
 import org.eclipse.emf.common.util.EList ;
-import org.eclipse.emf.ecore.EObject ;
-import org.eclipse.emf.ecore.EReference ;
-import org.osate.aadl2.Aadl2Package ;
 import org.osate.aadl2.ComponentCategory ;
 import org.osate.aadl2.ComponentClassifier ;
 import org.osate.aadl2.DeviceClassifier ;
@@ -42,8 +39,6 @@ import org.osate.aadl2.MetaclassReference ;
 import org.osate.aadl2.NamedValue ;
 import org.osate.aadl2.PackageSection ;
 import org.osate.aadl2.Property ;
-import org.osate.aadl2.PropertyOwner ;
-import org.osate.aadl2.PropertySet ;
 import org.osate.aadl2.SubprogramClassifier ;
 import org.osate.aadl2.ThreadClassifier ;
 import org.osate.aadl2.VirtualProcessorClassifier ;
@@ -87,13 +82,13 @@ public class AadlBaLegalityRulesChecker
   private BehaviorAnnex _ba ;
   private ComponentClassifier _baParentContainer ;
   private AnalysisErrorReporterManager _errManager ;
-  private final static String LIST_SEPARATOR =", " ; 
+  private final static String LIST_SEPARATOR =", " ;
 
   private Map<BehaviorState, BehaviorTransition> _alreadyFoundCompletionRelativeTimeoutConditionCatchTransition =
-        new HashMap<BehaviorState, BehaviorTransition>();
+                                                                                                                new WeakHashMap<BehaviorState, BehaviorTransition>() ;
   private Map<BehaviorState, BehaviorTransition> _alreadyFoundDispatchRelativeTimeoutTransition =
-        new HashMap<BehaviorState, BehaviorTransition>();
-  private List<BehaviorTransition> _alreadyReportedErroneousTransition = 
+                                                                                                new WeakHashMap<BehaviorState, BehaviorTransition>() ;
+  private List<BehaviorTransition> _alreadyReportedErroneousTransition =
         new ArrayList<BehaviorTransition>();
   public AadlBaLegalityRulesChecker(BehaviorAnnex ba,
                                     AnalysisErrorReporterManager errManager)
@@ -104,11 +99,11 @@ public class AadlBaLegalityRulesChecker
   }
 
   /**
-   * Document: AADL Behavior Annex draft 
-   * Version : 0.94 
+   * Document: AADL Behavior Annex draft
+   * Version : 0.94
    * Type : Legality rule
-   * Section : D.3 Behavior Specification 
-   * Object : Check legality rules D.3.(L1), D.3.(L2) 
+   * Section : D.3 Behavior Specification
+   * Object : Check legality rules D.3.(L1), D.3.(L2)
    * Keys : subprogram components initial complete final states
    */
   public boolean D_3_L1_And_L2_Check (EList<BehaviorState> initialStates,
@@ -134,7 +129,7 @@ public class AadlBaLegalityRulesChecker
         if(initialStates.size() == 0)
         {
           result = false ;
-          this.reportLegalityError(_ba, 
+          this.reportLegalityError(_ba,
                                    _baParentContainer.getQualifiedName() + " has no initial" +
                 "state : Behavior Annex D.3.(L1) legality rule failed") ;
         }
@@ -163,7 +158,7 @@ public class AadlBaLegalityRulesChecker
         if(finalStates.size() == 0)
         {
           result = false ;
-          this.reportLegalityError(_ba, 
+          this.reportLegalityError(_ba,
                                    _baParentContainer.getQualifiedName() + " has no final " +
                 "state : Behavior Annex D.3.(L1) legality rule failed") ;
         }
@@ -174,11 +169,11 @@ public class AadlBaLegalityRulesChecker
   }
 
   /**
-   * Document: AADL Behavior Annex draft 
-   * Version : 0.94 
+   * Document: AADL Behavior Annex draft
+   * Version : 0.94
    * Type : Legality rule
-   * Section : D.3 Behavior Specification 
-   * Object : Check legality rule D.3.(L3) 
+   * Section : D.3 Behavior Specification
+   * Object : Check legality rule D.3.(L3)
    * Keys : threads, suspendable devices initial complete states
    */
   public boolean D_3_L3_Check (EList<BehaviorState> initialStates,
@@ -213,7 +208,7 @@ public class AadlBaLegalityRulesChecker
       if(completeStates.size() == 0)
       {
         result = false ;
-        this.reportLegalityError(_ba, _baParentContainer.getQualifiedName() + 
+        this.reportLegalityError(_ba, _baParentContainer.getQualifiedName() +
                                  " has no complete state : " +
               "Behavior Annex D.3.(L3) legality rule failed") ;
       }
@@ -223,11 +218,11 @@ public class AadlBaLegalityRulesChecker
   }
 
   /**
-   * Document: AADL Behavior Annex draft 
-   * Version : 0.94 
+   * Document: AADL Behavior Annex draft
+   * Version : 0.94
    * Type : Legality rule
-   * Section : D.3 Behavior Specification 
-   * Object : Check legality rule D.3.(L4) 
+   * Section : D.3 Behavior Specification
+   * Object : Check legality rule D.3.(L4)
    * Keys : threads, components initialization finalization entrypoints initial
    * final states
    */
@@ -258,7 +253,7 @@ public class AadlBaLegalityRulesChecker
                                       INITIALIZE_ENTRYPOINT_PROPERTY_NAME);
       }
 
-      ArrayList<Class<? extends org.osate.aadl2.Element>> klassl = 
+      ArrayList<Class<? extends org.osate.aadl2.Element>> klassl =
          new ArrayList<Class<? extends org.osate.aadl2.Element>>() ;
 
       Class<? extends org.osate.aadl2.Element> klass ;
@@ -270,7 +265,7 @@ public class AadlBaLegalityRulesChecker
 
       if (ne != null)
       {
-    	  EList<PropertyOwner> pol = ((Property) ne).getAppliesTos() ; 
+    	  EList<PropertyOwner> pol = ((Property) ne).getAppliesTos() ;
     	  // For each component that the initialize entrypoint property is applied
           // to, gets the component's name and transform into the corresponding
           // class name and populates the class list.
@@ -294,7 +289,7 @@ public class AadlBaLegalityRulesChecker
 
              try
              {
-                klass = (Class<? extends org.osate.aadl2.Element>) 
+                klass = (Class<? extends org.osate.aadl2.Element>)
                             Class.forName(klassName.toString()) ;
 
                 klassl.add(klass);
@@ -313,7 +308,7 @@ public class AadlBaLegalityRulesChecker
           for(Class<? extends org.osate.aadl2.Element> tmp : klassl)
           {
              if(tmp.isAssignableFrom(_baParentContainer.getClass()))
-             {  
+             {
                 String reportElements = null ;
 
                 if(initialStates.size() > 1)
@@ -340,12 +335,12 @@ public class AadlBaLegalityRulesChecker
                 {
                    result = false ;
                    this.reportLegalityWarning(_ba,
-                      _baParentContainer.getQualifiedName() + 
+                      _baParentContainer.getQualifiedName() +
                          " has no final state : Behavior Annex D.3.(L4)"+
                             " legality rules warning") ;
                 }
 
-                return result ; 
+                return result ;
              }
           }
       }
@@ -376,7 +371,7 @@ public class AadlBaLegalityRulesChecker
           {
              result = false ;
              this.reportLegalityWarning(_ba,
-                _baParentContainer.getQualifiedName() + 
+                _baParentContainer.getQualifiedName() +
                    " has no final state : Behavior Annex D.3.(L4)"+
                       " legality rules failed") ;
           }
@@ -388,10 +383,10 @@ public class AadlBaLegalityRulesChecker
   }
 
   /**
-   * Document: AADL Behavior Annex draft 
-   * Version : 0.94 
+   * Document: AADL Behavior Annex draft
+   * Version : 0.94
    * Type : Legality rule
-   * Section : D.3 Behavior Specification 
+   * Section : D.3 Behavior Specification
    * Object : Check legality rule D.3.(L5)
    * Keys : subprogram dispatch condition transition
    */
@@ -401,8 +396,8 @@ public class AadlBaLegalityRulesChecker
     // Only accept dispatch conditions on components for which a Dispatch_Protocl can be associated
     PackageSection[] contextsTab =AadlBaVisitors.getBaPackageSections(_ba);
     PropertiesLinkingService pls = Aadl2Visitors.getPropertiesLinkingService(contextsTab[0]) ;
-    
-    Property dispatchProtocolProperty = pls.findPropertyDefinition(_baParentContainer, 
+
+    Property dispatchProtocolProperty = pls.findPropertyDefinition(_baParentContainer,
                                                                    AadlBaVisitors.DISPATCH_PROTOCOL_PROPERTY_NAME);
     if(dispatchProtocolProperty!=null)
     {
@@ -428,20 +423,20 @@ public class AadlBaLegalityRulesChecker
     else if(canBeDispatched==false)
     {
       this.reportLegalityError(dc, cc.getName()+" components cannot contain" +
-          " a dispatch condition in any of their transitions: they cannot be dispatched " + 
+          " a dispatch condition in any of their transitions: they cannot be dispatched " +
           "(extension of Behavior Annex D.3.(L5) legality rule)") ;
 
       return false ;
     }
     return true;
-    
+
   }
 
   /**
-   * Document: AADL Behavior Annex draft 
-   * Version : 0.94 
+   * Document: AADL Behavior Annex draft
+   * Version : 0.94
    * Type : Legality rule
-   * Section : D.3 Behavior Specification 
+   * Section : D.3 Behavior Specification
    * Object : Check legality rule D.3.(L6)
    * Keys : transition complete state dispatch condition
    */
@@ -464,13 +459,13 @@ public class AadlBaLegalityRulesChecker
     {
       return true ;
     }
-  }   
+  }
 
   /**
-   * Document: AADL Behavior Annex draft 
-   * Version : 0.94 
+   * Document: AADL Behavior Annex draft
+   * Version : 0.94
    * Type : Legality rule
-   * Section : D.3 Behavior Specification 
+   * Section : D.3 Behavior Specification
    * Object : Check legality rule D.3.(L7)
    * Keys : transition complete state dispatch condition
    */
@@ -480,7 +475,7 @@ public class AadlBaLegalityRulesChecker
     BehaviorState tmp = (BehaviorState) transSrcStateIdentifier.getBaRef() ;
 
     // D.3.(L7) error case.
-    if(tmp.isComplete() && (! (bt.getCondition() 
+    if(tmp.isComplete() && (! (bt.getCondition()
           instanceof DispatchCondition)) && (tmp.getBindedMode()==null ))
     {
       this.reportLegalityError(transSrcStateIdentifier, "Transitions out " +
@@ -489,14 +484,16 @@ public class AadlBaLegalityRulesChecker
       return false ;
     }
     else
+    {
       return true ;
+    }
   }
 
   /**
-   * Document: AADL Behavior Annex draft 
-   * Version : 0.94 
+   * Document: AADL Behavior Annex draft
+   * Version : 0.94
    * Type : Legality rule
-   * Section : D.3 Behavior Specification 
+   * Section : D.3 Behavior Specification
    * Object : Check legality rule D.3.(L8)
    * Keys : transition out final state
    */
@@ -513,12 +510,14 @@ public class AadlBaLegalityRulesChecker
       return false ;
     }
     else
+    {
       return true ;
+    }
   }
 
   /**
-   * Document: AADL Behavior Annex draft 
-   * Version : 0.94 
+   * Document: AADL Behavior Annex draft
+   * Version : 0.94
    * Type : Legality rule and Semantic rule
    * Section : D.4 Thread Dispatch Behavior Specification
    * Object : Check legality rule D.4.(L1) and semantic rule D.4.(5)
@@ -528,7 +527,7 @@ public class AadlBaLegalityRulesChecker
   public boolean D_4_L1_Check(DispatchRelativeTimeout tc,
                               DeclarativeBehaviorTransition bt)
   {
-    List<Identifier> sourceState = bt.getSrcStates()  ; 
+    List<Identifier> sourceState = bt.getSrcStates()  ;
 
     if(sourceState.size() == 1)
     {
@@ -545,14 +544,14 @@ public class AadlBaLegalityRulesChecker
                                                  ThreadProperties.DISPATCH_PROTOCOL) ;
         if(vl.size() > 0)
         {
-          org.osate.aadl2.PropertyExpression value = 
+          org.osate.aadl2.PropertyExpression value =
                 vl.get(vl.size()-1) ;
 
           if(value instanceof NamedValue &&
                 ((NamedValue) value).getNamedValue()
-                instanceof EnumerationLiteral) 
+                instanceof EnumerationLiteral)
           {
-            EnumerationLiteral el = (EnumerationLiteral) 
+            EnumerationLiteral el = (EnumerationLiteral)
                   ((NamedValue) value).getNamedValue() ;
 
             String literal = el.getName() ;
@@ -578,7 +577,7 @@ public class AadlBaLegalityRulesChecker
                       " thread with a period property properly set: " +
                       " Behavior Annex D.4.(5) semantic rule failed") ;
 
-                // Early exit to skip the next error reporting. 
+                // Early exit to skip the next error reporting.
                 return false ;
               }
             }
@@ -605,7 +604,7 @@ public class AadlBaLegalityRulesChecker
     }
     else // Error case : It must be declared in only one transition of the source state.
     {
-      // If transition source states list is > 1, report errors for the 
+      // If transition source states list is > 1, report errors for the
       // furthers timeout catch.
       this.reportLegalityError(tc, "The dispatch relative timeout and catch"+
             " statement must be declared in only one transition: " +
@@ -616,8 +615,8 @@ public class AadlBaLegalityRulesChecker
   }
 
   /**
-   * Document: AADL Behavior Annex draft 
-   * Version : 0.94 
+   * Document: AADL Behavior Annex draft
+   * Version : 0.94
    * Type : Legality rule
    * Section : D.4 Thread Dispatch Behavior Specification
    * Object : Check legality rule D.4.(L2)
@@ -644,14 +643,14 @@ public class AadlBaLegalityRulesChecker
                                                  ThreadProperties.DISPATCH_PROTOCOL) ;
         if(vl.size() > 0)
         {
-          org.osate.aadl2.PropertyExpression value = 
+          org.osate.aadl2.PropertyExpression value =
                 vl.get(vl.size()-1) ;
 
           if(value instanceof NamedValue &&
                 ((NamedValue) value).getNamedValue()
-                instanceof EnumerationLiteral) 
+                instanceof EnumerationLiteral)
           {
-            EnumerationLiteral el = (EnumerationLiteral) 
+            EnumerationLiteral el = (EnumerationLiteral)
                   ((NamedValue) value).getNamedValue() ;
 
             String literal = el.getName() ;
@@ -666,15 +665,17 @@ public class AadlBaLegalityRulesChecker
               Long timeoutConstantValue = null;
               IntegerValue iv = crtcac.getIntegerValue();
               if(iv instanceof IntegerLiteral)
+              {
                 timeoutConstantValue = ((IntegerLiteral) iv).getValue();
+              }
               boolean timeoutIsConstant = timeoutConstantValue!=null;
               // Check that timeout is lower than period,
               // otherwise it is inconsistent.
-              if(hasPeriod 
+              if(hasPeriod
                     && timeoutIsConstant
                     && period<timeoutConstantValue)
               {
-                this.reportLegalityError(crtcac, "The completion relative timeout" + 
+                this.reportLegalityError(crtcac, "The completion relative timeout" +
                       " condition and catch statement must have a value greater or" +
                       " equal to the Period of the thread it is defined in (otherwise)" +
                       " timeout condition can never occur") ;
@@ -688,20 +689,20 @@ public class AadlBaLegalityRulesChecker
       else // Error case : it must be declared in an outgoing transition of
         // a complete state.
       {
-        this.reportLegalityError(crtcac, "The completion relative timeout" + 
-              " condition and catch statement must be declared in an " + 
+        this.reportLegalityError(crtcac, "The completion relative timeout" +
+              " condition and catch statement must be declared in an " +
               "outgoing transition of a complete state: Behavior Annex" +
               " D.4.(L2) legality rule failed") ;
       }
     }
     else // Error case : it must be declared in at most one transition.
     {
-      // If transition source states list is > 1, report errors for the 
+      // If transition source states list is > 1, report errors for the
       // furthers completion timeout catch.
       if(false==_alreadyReportedErroneousTransition.contains(bt))
       {
-        this.reportLegalityError(crtcac, "The completion relative timeout " + 
-              "condition and catch statement must be declared in only one " + 
+        this.reportLegalityError(crtcac, "The completion relative timeout " +
+              "condition and catch statement must be declared in only one " +
               "transition: Behavior Annex D.4.(L2) legality rule failed") ;
         _alreadyReportedErroneousTransition.add(bt);
       }
@@ -715,7 +716,7 @@ public class AadlBaLegalityRulesChecker
    * Version : 0.94
    * Type    : Legality rule
    * Section : D.6 Behavior Action Language
-   * Object  : Check legality rules D.6.(L3), D.6.(L4) 
+   * Object  : Check legality rules D.6.(L3), D.6.(L4)
    * Keys    : local variable port variable assigned action set
    */
   public boolean D_6_L3_And_L4_Check(BehaviorActionBlock bab)
@@ -733,7 +734,7 @@ public class AadlBaLegalityRulesChecker
                                       lActionSetTar,
                                       lDuplicates) ;
     String localVariableErrorMsg = "The same local variable must not be " +
-          "assigned to in different actions of an action set" + 
+          "assigned to in different actions of an action set" +
           ": Behavior Annex D.6.(L3) legality rules failed" ;
     String portErrorMsg = "The same port variable must not be assigned to " +
           "in different actions of an action set: "+
@@ -750,10 +751,10 @@ public class AadlBaLegalityRulesChecker
       }
       else // Port case.
       {
-        tmp = portErrorMsg ; 
+        tmp = portErrorMsg ;
       }
 
-      reportLegalityError(tar, tmp); 
+      reportLegalityError(tar, tmp);
     }
 
     return lDuplicates.isEmpty() ;
@@ -762,13 +763,13 @@ public class AadlBaLegalityRulesChecker
   /**
    * Recursively builds a list of assigned target contained
    * in a given BehaviorActions tree and checks for duplicated targets every time
-   * it meet a Behavior Action Set node. It populates the given set with 
+   * it meet a Behavior Action Set node. It populates the given set with
    * duplicated targets.<BR><BR>
-   * 
+   *
    * A special attention is given to report legality rules D.6.(L3) and (L4)
    * failures : in order to help the user to correct his errors, the duplicates
-   * list contains all instances of duplicated assigned targets. 
-   * 
+   * list contains all instances of duplicated assigned targets.
+   *
    * @param beActions The given BehaviorActions tree.
    * @param lActionSetDcr The list of assigned targets
    * @param lDuplicates The set of duplicated assigned targets.
@@ -842,7 +843,7 @@ public class AadlBaLegalityRulesChecker
       return ;
     }
 
-    // ***** Processing containers: 
+    // ***** Processing containers:
 
     // List of BehaviorAction objects contained in the given BehaviorActions
     // tree.
@@ -886,7 +887,7 @@ public class AadlBaLegalityRulesChecker
     List<Target> lCurrent = null ;
     List<Target> lOther = null ;
 
-    // Optimization flag to avoid adding the same target to the duplicates 
+    // Optimization flag to avoid adding the same target to the duplicates
     // set.
     boolean hasToAdd = true ;
 
@@ -925,7 +926,7 @@ public class AadlBaLegalityRulesChecker
       }
     }
 
-    // Add all assigned targets in the recursively transmitted list for any 
+    // Add all assigned targets in the recursively transmitted list for any
     // higher level action set checking.
     for (List<Target> l : llActionSetTar)
     {
@@ -940,7 +941,7 @@ public class AadlBaLegalityRulesChecker
    * Section : D.6 Behavior Action Language
    * Object  : Check legality rule D.6.(L8)
    * Keys    : timed actions, max min time values
-   * 
+   *
    * At static analysis phase, D.6.(L8) can only be
    * checked with behavior time objects that contain IntegerLiteral objects.
    * Otherwise (with IntegerValueVariable objects), this checker returns
@@ -949,7 +950,7 @@ public class AadlBaLegalityRulesChecker
   public boolean D_6_L8_Check(TimedAction timedAct)
   {
     BehaviorTime btMin = timedAct.getLowerTime();
-    BehaviorTime btMax = timedAct.getUpperTime();     
+    BehaviorTime btMax = timedAct.getUpperTime();
 
     if (btMax != null)
     {
@@ -966,7 +967,7 @@ public class AadlBaLegalityRulesChecker
         // On exception, D_6_L8_Check returns true and don't report error as
         // the rule can only be checked at runtime when behavior time objects
         // contain IntegerValueVariable objects.
-        compResult = 0 ;            
+        compResult = 0 ;
       }
 
       // Error case : max time value is strictly lesser than min time value.

--- a/ba/org.osate.ba/src/org/osate/ba/texteditor/Aadl2ColorProvider.java
+++ b/ba/org.osate.ba/src/org/osate/ba/texteditor/Aadl2ColorProvider.java
@@ -33,7 +33,8 @@
  */
 package org.osate.ba.texteditor;
 
-import java.util.HashMap;
+import java.util.Map ;
+import java.util.WeakHashMap ;
 
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
@@ -47,15 +48,17 @@ public class Aadl2ColorProvider
 	public static final RGB STRING = new RGB(0, 128, 0);
 	public static final RGB SIGN = new RGB(0, 0, 128);
 	public static final RGB DEFAULT = new RGB(0, 0, 0);
-	
-	private final HashMap<RGB, Color> colorTable = new HashMap<RGB, Color>();
-	
+
+  private final Map<RGB, Color> colorTable = new WeakHashMap<RGB, Color>() ;
+
 	public void dispose()
 	{
 		for (Color color : colorTable.values())
-			color.dispose();
+    {
+      color.dispose();
+    }
 	}
-	
+
 	public Color getColor(RGB rgb)
 	{
 		Color color = colorTable.get(rgb);

--- a/ba/org.osate.ba/src/org/osate/ba/texteditor/AadlBaSemanticHighlighter.java
+++ b/ba/org.osate.ba/src/org/osate/ba/texteditor/AadlBaSemanticHighlighter.java
@@ -25,8 +25,6 @@ import org.osate.aadl2.AnnexLibrary;
 import org.osate.aadl2.AnnexSubclause;
 import org.osate.annexsupport.AnnexHighlighter;
 import org.osate.annexsupport.AnnexHighlighterPositionAcceptor;
-import org.osate.annexsupport.AnnexUtil ;
-import org.osate.ba.aadlba.BehaviorAnnex ;
 import org.osate.ba.utils.AadlBaLocationReference ;
 
 

--- a/ba/org.osate.ba/src/org/osate/ba/texteditor/XtextAadlBaHighlighter.java
+++ b/ba/org.osate.ba/src/org/osate/ba/texteditor/XtextAadlBaHighlighter.java
@@ -1,13 +1,13 @@
 /**
  * AADL-BA-FrontEnd
- * 
+ *
  * Copyright © 2013 TELECOM ParisTech and CNRS
- * 
+ *
  * TELECOM ParisTech/LTCI
- * 
+ *
  * Authors: see AUTHORS
- * 
- * This program is free software: you can redistribute it and/or modify 
+ *
+ * This program is free software: you can redistribute it and/or modify
  * it under the terms of the Eclipse Public License as published by Eclipse,
  * either version 2.0 of the License, or (at your option) any later version.
  * This program is distributed in the hope that it will be useful,
@@ -15,7 +15,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * Eclipse Public License for more details.
  * You should have received a copy of the Eclipse Public License
- * along with this program.  If not, see 
+ * along with this program.  If not, see
  * https://www.eclipse.org/legal/epl-2.0/
  */
 
@@ -26,29 +26,29 @@ import java.util.List ;
 import java.util.Map ;
 import java.util.WeakHashMap ;
 
-import org.antlr.v4.runtime.Token ;
 import org.antlr.v4.runtime.CommonToken ;
+import org.antlr.v4.runtime.Token ;
 import org.osate.aadl2.AnnexSubclause ;
 import org.osate.ba.utils.AadlBaLocationReference ;
 
 
 public class XtextAadlBaHighlighter implements AadlBaHighlighter
 {
-  
+
   private List<AadlBaLocationReference> _elementToHighlight =
         new ArrayList<AadlBaLocationReference>() ;
-  
+
   @Override
   public void addToHighlighting(int annexOffset, Token token, String id)
   {
     int offset = ((CommonToken)token).getStartIndex();
     int length = token.getText().length() ;
     int column = token.getCharPositionInLine() ;
-    
+
     _elementToHighlight.add(new AadlBaLocationReference(annexOffset, offset, length, column,
                                                         id));
   }
-  
+
   public List<AadlBaLocationReference> getElementsToHighlitght()
   {
 	  return _elementToHighlight;
@@ -59,18 +59,18 @@ public class XtextAadlBaHighlighter implements AadlBaHighlighter
 	_elementToHighlight.add(new AadlBaLocationReference(annexOffset, relativeOffset, length, 0,
               id));
   }
-  
+
   private XtextAadlBaHighlighter() {}
 
-  private static Map<AnnexSubclause, XtextAadlBaHighlighter> _highlighterPerAnnex = 
-      new WeakHashMap<AnnexSubclause, XtextAadlBaHighlighter>();
-  
+  private static Map<AnnexSubclause, XtextAadlBaHighlighter> _highlighterPerAnnex =
+                                                                                  new WeakHashMap<AnnexSubclause, XtextAadlBaHighlighter>() ;
+
   public static XtextAadlBaHighlighter getHighlighter(AnnexSubclause as)
   {
-    if(_highlighterPerAnnex.get(as)==null)
+    if(_highlighterPerAnnex.get(as) == null)
     {
-      XtextAadlBaHighlighter ht = new XtextAadlBaHighlighter();
-      _highlighterPerAnnex.put(as, ht);
+      XtextAadlBaHighlighter ht = new XtextAadlBaHighlighter() ;
+      _highlighterPerAnnex.put(as, ht) ;
     }
     return _highlighterPerAnnex.get(as) ;
   }
@@ -79,5 +79,5 @@ public class XtextAadlBaHighlighter implements AadlBaHighlighter
   {
     _elementToHighlight.clear();
   }
-  
+
 }

--- a/ba/org.osate.ba/src/org/osate/ba/utils/AadlBaVisitors.java
+++ b/ba/org.osate.ba/src/org/osate/ba/utils/AadlBaVisitors.java
@@ -1,13 +1,13 @@
 /**
  * AADL-BA-FrontEnd
- * 
+ *
  * Copyright (c) 2011-2020 TELECOM ParisTech and CNRS
- * 
+ *
  * TELECOM ParisTech/LTCI
- * 
+ *
  * Authors: see AUTHORS
- * 
- * This program is free software: you can redistribute it and/or modify 
+ *
+ * This program is free software: you can redistribute it and/or modify
  * it under the terms of the Eclipse Public License as published by Eclipse,
  * either version 2.0 of the License, or (at your option) any later version.
  * This program is distributed in the hope that it will be useful,
@@ -15,28 +15,40 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * Eclipse Public License for more details.
  * You should have received a copy of the Eclipse Public License
- * along with this program.  If not, see 
+ * along with this program.  If not, see
  * https://www.eclipse.org/legal/epl-2.0/
  */
 
 package org.osate.ba.utils ;
 
-import java.util.ArrayList ;
-import java.util.HashMap ;
 import java.util.HashSet ;
 import java.util.List ;
 import java.util.Map ;
 import java.util.Set ;
+import java.util.WeakHashMap ;
 
 import org.eclipse.emf.common.util.BasicEList ;
 import org.eclipse.emf.common.util.EList ;
-
 import org.osate.aadl2.AadlPackage ;
 import org.osate.aadl2.ComponentClassifier ;
 import org.osate.aadl2.PackageSection ;
 import org.osate.aadl2.Port ;
 import org.osate.aadl2.PrivatePackageSection ;
-import org.osate.ba.aadlba.* ;
+import org.osate.ba.aadlba.AadlBaFactory ;
+import org.osate.ba.aadlba.BasicAction ;
+import org.osate.ba.aadlba.BehaviorAction ;
+import org.osate.ba.aadlba.BehaviorActionCollection ;
+import org.osate.ba.aadlba.BehaviorActions ;
+import org.osate.ba.aadlba.BehaviorAnnex ;
+import org.osate.ba.aadlba.BehaviorState ;
+import org.osate.ba.aadlba.BehaviorTransition ;
+import org.osate.ba.aadlba.BehaviorVariable ;
+import org.osate.ba.aadlba.DispatchConjunction ;
+import org.osate.ba.aadlba.DispatchTrigger ;
+import org.osate.ba.aadlba.DispatchTriggerLogicalExpression ;
+import org.osate.ba.aadlba.ElseStatement ;
+import org.osate.ba.aadlba.IfStatement ;
+import org.osate.ba.aadlba.LoopStatement ;
 import org.osate.utils.Aadl2Visitors ;
 
 
@@ -46,30 +58,30 @@ import org.osate.utils.Aadl2Visitors ;
 public class AadlBaVisitors
 {
    // Some names.
-   
-   public static final String INITIALIZE_ENTRYPOINT_PROPERTYSET = 
+
+   public static final String INITIALIZE_ENTRYPOINT_PROPERTYSET =
                                                        "Programming_Properties";
    public static final String INITIALIZE_ENTRYPOINT_PROPERTY_NAME =
                                                        "Initialize_Entrypoint" ;
-   
+
    public static final String DISPATCH_PROTOCOL_PROPERTY_NAME = "Dispatch_Protocol";
-   
+
    public static final String SEI_AADL2_PACKAGE_NAME = "org.osate.aadl2";
-   
+
    public static final String SEI_AADL2_CLASSIFIER_SUFFIX = "Classifier" ;
-   
+
    public static final long DEFAULT_TRANSITION_PRIORITY ;
-   
-   static 
+
+   static
    {
      DEFAULT_TRANSITION_PRIORITY = AadlBaFactory.eINSTANCE.
                                       createBehaviorTransition().getPriority() ;
    }
-   
+
    /**
     * Returns a list of basic action contained in the given behavior
-    * action (recursively). 
-    * 
+    * action (recursively).
+    *
     * @param BehAction the given behavior action
     * @return a list of basic action contained in the given behavior
     * action
@@ -77,7 +89,7 @@ public class AadlBaVisitors
    public static EList<BasicAction> getBasicActions(BehaviorAction BehAction)
    {
       EList<BasicAction> result = null ;
-      
+
       if(BehAction instanceof BasicAction)
       {
          result = new BasicEList<BasicAction>() ;
@@ -94,9 +106,9 @@ public class AadlBaVisitors
          else if(BehAction instanceof IfStatement)
          {
             IfStatement stat = (IfStatement) BehAction ;
-            
+
             result = getBasicActions(stat.getBehaviorActions()) ;
-            
+
             if(stat.getElseStatement() != null)
             {
               result.addAll(getBasicActions(stat.getElseStatement().
@@ -109,15 +121,15 @@ public class AadlBaVisitors
            result = getBasicActions(elseStat.getBehaviorActions()) ;
          }
       }
-      
+
       return result ;
    }
-   
+
    /**
     * Return a list of the BasicAction objects contained in a given BehaviorActions
     * object (recursively). If the given BehaviorActions object is {@code null},
     * the returned list is empty.
-    * 
+    *
     * @param BehActions the given BehaviorActions object or {@code null} (for
     * batch processing purpose)
     * @return the list of BasicAction contained in the given BehaviorActions
@@ -126,7 +138,7 @@ public class AadlBaVisitors
    public static EList<BasicAction> getBasicActions(BehaviorActions BehActions)
    {
       EList<BasicAction> result = new BasicEList<BasicAction>() ;
-      
+
       // A behavior transition may have no behavior actions.
       if(BehActions != null)
       {
@@ -143,20 +155,20 @@ public class AadlBaVisitors
                result.addAll(getBasicActions(BehAct)) ;
             }
          }
-      }   
-      
+      }
+
       return result ;
    }
-   
+
    /**
-    * Return the package sections related to a given BehaviorAnnex. As 
+    * Return the package sections related to a given BehaviorAnnex. As
     * "Classifier declarations in public sections are accessible to other
     * packages, while classifiers in private sections can only be referenced
     * within the private section of the same package".<br><br>
     * table[0] always refers to public section.
-    * If the given BehaviorAnnex is declared in a private section, table's 
+    * If the given BehaviorAnnex is declared in a private section, table's
     * length equals to 2 and table[1] refers to the private section.
-    * 
+    *
     * @param ba The given BehaviorAnnex
     * @return the package sections related to the given BehaviorAnnex.
     */
@@ -164,11 +176,11 @@ public class AadlBaVisitors
    {
       PackageSection result[] ;
       PackageSection container = Aadl2Visitors.getContainingPackageSection(
-    		                                (org.osate.aadl2.Element)ba);
+    		                                ba);
 
       // Init contexts tab with current package's sections.
       // Private section is also investigated only if ba is declared in
-      // package's private section. 
+      // package's private section.
       if(container instanceof PrivatePackageSection)
       {
          result = new PackageSection[2] ;
@@ -189,7 +201,7 @@ public class AadlBaVisitors
     * Find the first occurrence of an BehaviorVariable within a given
     * BehaviorAnnex which name equals to the given name. Return {@code null}
     * if no BehaviorVariable is found.
-    * 
+    *
     * @param ba the given BehaviorAnnex
     * @param variableName the given name
     * @return the first occurrence of an BehaviorVariable related to the given
@@ -210,9 +222,9 @@ public class AadlBaVisitors
 
    /**
     * Find the first occurrence of an BehaviorState within a given BehaviorAnnex
-    * which name equals to a given name. Return {@code null} if no 
+    * which name equals to a given name. Return {@code null} if no
     * BehaviorState is found.
-    * 
+    *
     * @param ba the given BehaviorAnnex
     * @param stateName the given name
     * @return the first occurrence of an BehaviorState related to the given name
@@ -230,12 +242,12 @@ public class AadlBaVisitors
       }
       return null ;
    }
-   
+
    /**
     * Return a list of DispatchTrigger objects contained in the given
-    * DispatchTriggerLogicelExpression object. The list may be empty but not 
+    * DispatchTriggerLogicelExpression object. The list may be empty but not
     * {@code null}.
-    * 
+    *
     * @param dtle the given DispatchTriggerLogicelExpression object
     * @return a list of DispatchTrigger objects, eventually empty.
     */
@@ -243,18 +255,18 @@ public class AadlBaVisitors
                                           DispatchTriggerLogicalExpression dtle)
    {
       EList<DispatchTrigger> result = new BasicEList<DispatchTrigger>();
-      
+
       for(DispatchConjunction dc : dtle.getDispatchConjunctions())
       {
          result.addAll(dc.getDispatchTriggers()) ;
       }
-      
+
       return result;
    }
 
    /**
     * Returns the behavior annex's parent component.
-    * 
+    *
     * @param ba the behavior annex
     * @return the behavior annex's parent component
     */
@@ -263,14 +275,14 @@ public class AadlBaVisitors
      return (ComponentClassifier) ba.getContainingClassifier() ;
    }
 
-  protected static final Map<BehaviorAnnex, Set<Port>> _IS_FRESH = 
-                                       new HashMap<BehaviorAnnex, Set<Port>>() ;
+  protected static final Map<BehaviorAnnex, Set<Port>> _IS_FRESH =
+                                                                 new WeakHashMap<BehaviorAnnex, Set<Port>>() ;
 
   /**
-   * Return {@code true} if the given port which is contained in the given 
-   * BehaviorAnnex object is used as a fresh port value. Otherwise return 
+   * Return {@code true} if the given port which is contained in the given
+   * BehaviorAnnex object is used as a fresh port value. Otherwise return
    * {@code false}.
-   * 
+   *
    * @param ba the given BehaviorAnnex object which contains the given port
    * @param port the given port
    * @return {@code true} if the given is used as a fresh port value.
@@ -288,10 +300,10 @@ public class AadlBaVisitors
       return false ;
     }
   }
-  
+
   /**
    * Tag the given port as a port used as a fresh port value.
-   * 
+   *
    * @param ba the BehaviorAnnex object which contains the given port
    * @param port the given port
    */
@@ -307,76 +319,77 @@ public class AadlBaVisitors
     ports.add(port) ;
   }
 
-  protected static final Map<BehaviorState, List<BehaviorTransition>> 
-    _SRC_IN_TRANS = new HashMap<BehaviorState, List<BehaviorTransition>>() ;
 
-  
-  
+
   /**
-   * Return a list of behavior transitions where the given behavior state is 
+   * Return a list of behavior transitions where the given behavior state is
    * the source state. May return empty list.<br><br>
-   * 
+   *
    * The list of behavior transitions is sorted according to:<br><br>
    * _ the behavior priority (highest to the lowest).<br>
    * _ the behavior transitions which have "otherwise" execution condition are
    *   set at the end of the list.<br>
    * _ in case of equality, the order of behavior transition appearance in the
    *   aadl code is applied.<br><br>
-   * 
+   *
    * @param state the given behavior state
-   * @return the list of behavior transitions where the given behavior state is 
+   * @return the list of behavior transitions where the given behavior state is
    * the source state or an empty list
    */
   public static List<BehaviorTransition> getTransitionWhereSrc(BehaviorState
                                                                 state)
   {
-    List<BehaviorTransition> result = _SRC_IN_TRANS.get(state) ;
-    if(result == null)
-    {
-      result = new BasicEList<BehaviorTransition>(0) ;
-    }
-
+    List<BehaviorTransition> result = new BasicEList<BehaviorTransition>(state
+                                                                              .getOutgoingTransitions()) ;
+    sort(result) ;
     return result ;
   }
 
   /**
    * Specify that the given behavior state is the source state of the given
-   * behavior transition. 
-   * 
+   * behavior transition.
+   *
    * @param state the given behavior state
    * @param bt the given behavior transition where the the given behavior state
    * is source
    */
+  @Deprecated
   public static void putTransitionWhereSrc(BehaviorState state,
                                            BehaviorTransition bt)
   {
-    List<BehaviorTransition> list = _SRC_IN_TRANS.get(state) ;
-    
+    List<BehaviorTransition> list = state.getOutgoingTransitions() ;
+
     if(list == null)
     {
-      list = new ArrayList<BehaviorTransition>() ;
-      _SRC_IN_TRANS.put(state, list) ;
+      return ;
     }
-    
+
     if(false == list.contains(bt))
     {
       addAndSort(list, bt) ;
     }
   }
-  
+
   // Add the given behavior transition to the given list and sort the list.
-  // Sort (insertion) behavior transitions list 
-  // according to their priority (highest to the lowest).
-  // In case of equality, the order of transition appearance in the aadl
-  // code is applied.
-  // Behavior transition which have execution condition set to "otherwise"
-  // will be set at the end of the list.
   protected static void addAndSort(List<BehaviorTransition> btl,
                                    BehaviorTransition bt)
   {
     // TODO to be optimized.
     btl.add(bt) ;
-    
+    sort(btl) ;
+  }
+
+  // Sort (insertion) behavior transitions list
+  // according to their priority (highest to the lowest).
+  // In case of equality, the order of transition appearance in the aadl
+  // code is applied.
+  // Behavior transition which have execution condition set to "otherwise"
+  // will be set at the end of the list.
+  /**
+   * @since 3.1
+   */
+  protected static void sort(List<BehaviorTransition> btl)
+  {
     BehaviorTransition tmp = null ;
     int i ;
     int j ;
@@ -385,7 +398,7 @@ public class AadlBaVisitors
     {
       tmp = btl.get(i) ;
       j = i ;
-      
+
       while(j < btl.size() - 1 &&
             AadlBaUtils.compareBehaviorTransitionPriority(btl.get(j + 1), tmp))
       {
@@ -396,4 +409,5 @@ public class AadlBaVisitors
       btl.set(j, tmp) ;
     }
   }
+
 }

--- a/ba/org.osate.ba/src/org/osate/ba/wizards/AadlBaAbstractWizard.java
+++ b/ba/org.osate.ba/src/org/osate/ba/wizards/AadlBaAbstractWizard.java
@@ -25,10 +25,10 @@ package org.osate.ba.wizards;
 import java.io.File ;
 import java.util.ArrayList ;
 import java.util.Collection ;
-import java.util.HashMap ;
 import java.util.List ;
 import java.util.Map ;
 import java.util.Map.Entry ;
+import java.util.WeakHashMap ;
 
 import org.eclipse.core.runtime.IStatus ;
 import org.eclipse.core.runtime.MultiStatus ;
@@ -37,7 +37,6 @@ import org.eclipse.jface.dialogs.ErrorDialog ;
 import org.eclipse.jface.layout.TreeColumnLayout ;
 import org.eclipse.jface.viewers.ColumnWeightData ;
 import org.eclipse.jface.viewers.DoubleClickEvent ;
-import org.eclipse.jface.viewers.IDoubleClickListener ;
 import org.eclipse.jface.viewers.IStructuredSelection ;
 import org.eclipse.jface.viewers.ITreeContentProvider ;
 import org.eclipse.jface.viewers.LabelProvider ;
@@ -69,11 +68,11 @@ public abstract class AadlBaAbstractWizard extends AadlProjectWizard
   protected static List<String> _EXCLUDED_DIRECTORIES = new ArrayList<String>();
 
   protected Map<String, List<Integer>> _SelectedExamplesTreeContent = 
-      new HashMap<String, List<Integer>>() ;
+      new WeakHashMap<String, List<Integer>>() ;
 
   protected List<File> _files = new ArrayList<File>() ;
 
-  protected static Map<String, File> _ALREADY_SELECTED = new HashMap<String, File>();
+  protected static Map<String, File> _ALREADY_SELECTED = new WeakHashMap<String, File>();
 
   public AadlBaAbstractWizard ()
   {
@@ -119,6 +118,7 @@ public abstract class AadlBaAbstractWizard extends AadlProjectWizard
     {
       Map<String, List<Integer>> _treeContent ; 
 
+      @Override
       public void dispose()
       {
         // Nothing to do.
@@ -278,23 +278,9 @@ public abstract class AadlBaAbstractWizard extends AadlProjectWizard
       pickTree.setSorter(new ViewerSorter()) ;
       selectionTree.setSorter(new ViewerSorter()) ;
 
-      pickTree.addDoubleClickListener(new IDoubleClickListener()
-      {
-        @Override
-        public void doubleClick(DoubleClickEvent event)
-        {
-          swap(pickTree, selectionTree, event) ;
-        }
-      }) ;
+      pickTree.addDoubleClickListener(event -> swap(pickTree, selectionTree, event)) ;
 
-      selectionTree.addDoubleClickListener(new IDoubleClickListener()
-      {
-        @Override
-        public void doubleClick(DoubleClickEvent event)
-        {
-          swap(selectionTree, pickTree, event) ;
-        }
-      }) ;
+      selectionTree.addDoubleClickListener(event -> swap(selectionTree, pickTree, event)) ;
 
       Image imgRemove = null ;
       Image imgAdd = null ;
@@ -434,7 +420,7 @@ public abstract class AadlBaAbstractWizard extends AadlProjectWizard
                                                examplesPath) ;
       if (rootPath.isDirectory())
       {
-        Map<String, List<Integer>> result = new HashMap<String, List<Integer>>();
+        Map<String, List<Integer>> result = new WeakHashMap<String, List<Integer>>();
         int count = 0 ;
 
         for(File f : rootPath.listFiles())


### PR DESCRIPTION
fixes #2352 
- remove _SRC_IN_TRANS map while trying to preserve API;
- some is deprecated (but kept implementation for it): information is retrieved from the meta-model;
- change HashMap to WeakHashMap

No tests added cause fixing a memory leak.