### PR TITLE
missing flow implementation name in osate outline view

### DIFF
--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/labeling/Aadl2LabelProvider.java
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/labeling/Aadl2LabelProvider.java
@@ -397,9 +397,11 @@ public class Aadl2LabelProvider extends AnnexAwareEObjectLabelProvider {
 		String ret;
 
 		ret = "Flow Implementation";
-		if (flowimpl.getName() != null) {
-			ret += " " + flowimpl.getName();
+
+		if (flowimpl.getSpecification() != null) {
+			ret += " " + flowimpl.getSpecification().getName();
 		}
+
 		return ret;
 	}
 


### PR DESCRIPTION
Show flow specification name for flow implementation element in osate outline view

fixes #2441 