### PR TITLE
Fixes BehaviorVariables losing DataClassifier reference upon model

### DIFF
--- a/ba/org.osate.ba.feature/feature.xml
+++ b/ba/org.osate.ba.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.osate.ba.feature"
       label="AADL-BA-FrontEnd"
-      version="5.0.0.qualifier"
+      version="5.0.1.qualifier"
       provider-name="TELECOM ParisTech"
       plugin="org.osate.ba">
 

--- a/ba/org.osate.ba.feature/pom.xml
+++ b/ba/org.osate.ba.feature/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>org.osate</groupId>
 	<artifactId>org.osate.ba.feature</artifactId>
-	<version>5.0.0-SNAPSHOT</version>
+	<version>5.0.1-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 </project>

--- a/ba/org.osate.ba/META-INF/MANIFEST.MF
+++ b/ba/org.osate.ba/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.osate.ba;singleton:=true
-Bundle-Version: 5.0.0.qualifier
+Bundle-Version: 5.0.1.qualifier
 Bundle-ClassPath: .,
  resources/libs/antlr-runtime-4.4.jar
 Bundle-Vendor: %providerName

--- a/ba/org.osate.ba/pom.xml
+++ b/ba/org.osate.ba/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>org.osate</groupId>
 	<artifactId>org.osate.ba</artifactId>
-	<version>5.0.0-SNAPSHOT</version>
+	<version>5.0.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/ba/org.osate.ba/src/org/osate/ba/unparser/AadlBaUnparser.java
+++ b/ba/org.osate.ba/src/org/osate/ba/unparser/AadlBaUnparser.java
@@ -129,6 +129,8 @@ import org.osate.ba.utils.AadlBaVisitors;
 import org.osate.utils.internal.Aadl2Visitors;
 import org.osate.utils.internal.PropertyUtils;
 
+import com.google.common.base.Strings;
+
 public class AadlBaUnparser {
 
 	protected static final String DEFAULT_INDENT_OFFSET = "          ";
@@ -417,6 +419,7 @@ public class AadlBaUnparser {
 				aadlbaText.addOutput(" : ");
 				if (object.getDataClassifier() instanceof QualifiedNamedElement) {
 					QualifiedNamedElement qn = (QualifiedNamedElement) object.getDataClassifier();
+					aadlbaText.addOutput(getNamespace(qn));
 					process(qn);
 				} else if (object.getDataClassifier() instanceof DataClassifier) {
 					aadlbaText.addOutput(object.getDataClassifier().getQualifiedName());
@@ -424,6 +427,16 @@ public class AadlBaUnparser {
 
 				aadlbaText.addOutputNewline(";");
 				return DONE;
+			}
+
+			private String getNamespace(final QualifiedNamedElement qn) {
+				final Identifier baNameSpace = qn.getBaNamespace();
+				final StringBuilder nameSpace = new StringBuilder();
+				if (baNameSpace != null && !Strings.isNullOrEmpty(baNameSpace.getId())) {
+					nameSpace.append(baNameSpace.getId()).append("::");
+				}
+
+				return nameSpace.toString();
 			}
 
 			/**


### PR DESCRIPTION
Closes #2550 

The namespace is lost for a BehaviorVariable's DataClassifier when it is a QualifiedNamedElement.  The potential fix is to append the namespace to the source text before processing the QualifiedNamedElement.