### PR TITLE
Added copyright headers for Model Statistics plugin 

### DIFF
--- a/analyses/org.osate.modelstats.tests/build.properties
+++ b/analyses/org.osate.modelstats.tests/build.properties
@@ -1,3 +1,26 @@
+###############################################################################
+# Copyright (c) 2004-2021 Carnegie Mellon University and others. (see Contributors file). 
+# All Rights Reserved.
+#
+# NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+# KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+# OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+# MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+#
+# This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+# SPDX-License-Identifier: EPL-2.0
+#
+# Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+#
+# This program includes and/or can make use of certain third party source code, object code, documentation and other
+# files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+# configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+# conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+# Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+# aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+# censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/analyses/org.osate.modelstats.tests/pom.xml
+++ b/analyses/org.osate.modelstats.tests/pom.xml
@@ -1,4 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2004-2021 Carnegie Mellon University and others. (see Contributors file). 
+    All Rights Reserved.
+   
+    NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+    KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+    OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+    MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+   
+    This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+    SPDX-License-Identifier: EPL-2.0
+   
+    Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+   
+    This program includes and/or can make use of certain third party source code, object code, documentation and other
+    files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+    configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+    conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+    Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+    aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+    censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/analyses/org.osate.modelstats.tests/src/org/osate/modelstats/tests/Activator.java
+++ b/analyses/org.osate.modelstats.tests/src/org/osate/modelstats/tests/Activator.java
@@ -1,3 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2004-2021 Carnegie Mellon University and others. (see Contributors file). 
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ *******************************************************************************/
 package org.osate.modelstats.tests;
 
 import org.osgi.framework.BundleActivator;

--- a/analyses/org.osate.modelstats.tests/src/org/osate/modelstats/tests/ComponentCounterTest.java
+++ b/analyses/org.osate.modelstats.tests/src/org/osate/modelstats/tests/ComponentCounterTest.java
@@ -1,3 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2004-2021 Carnegie Mellon University and others. (see Contributors file). 
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ *******************************************************************************/
 package org.osate.modelstats.tests;
 
 import org.eclipse.xtext.testing.InjectWith;

--- a/analyses/org.osate.modelstats.ui/META-INF/MANIFEST.MF
+++ b/analyses/org.osate.modelstats.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Model Statistics UI
 Bundle-SymbolicName: org.osate.modelstats.ui;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.1.qualifier
 Bundle-Activator: org.osate.modelstats.ui.Activator
 Require-Bundle: org.eclipse.ui;bundle-version="[3.117.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.18.0,4.0.0)",

--- a/analyses/org.osate.modelstats.ui/build.properties
+++ b/analyses/org.osate.modelstats.ui/build.properties
@@ -1,3 +1,26 @@
+###############################################################################
+# Copyright (c) 2004-2021 Carnegie Mellon University and others. (see Contributors file). 
+# All Rights Reserved.
+#
+# NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+# KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+# OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+# MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+#
+# This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+# SPDX-License-Identifier: EPL-2.0
+#
+# Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+#
+# This program includes and/or can make use of certain third party source code, object code, documentation and other
+# files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+# configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+# conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+# Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+# aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+# censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/analyses/org.osate.modelstats.ui/help/modelStatistics.xml
+++ b/analyses/org.osate.modelstats.ui/help/modelStatistics.xml
@@ -1,4 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2004-2021 Carnegie Mellon University and others. (see Contributors file). 
+    All Rights Reserved.
+   
+    NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+    KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+    OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+    MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+   
+    This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+    SPDX-License-Identifier: EPL-2.0
+   
+    Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+   
+    This program includes and/or can make use of certain third party source code, object code, documentation and other
+    files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+    configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+    conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+    Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+    aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+    censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ -->
+
 <contexts>
    <context id="help_dialog">
       <description>This dialog provides information about how to use the Model Statistics analyses.</description>

--- a/analyses/org.osate.modelstats.ui/plugin.xml
+++ b/analyses/org.osate.modelstats.ui/plugin.xml
@@ -1,5 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
+<!--
+    Copyright (c) 2004-2021 Carnegie Mellon University and others. (see Contributors file). 
+    All Rights Reserved.
+   
+    NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+    KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+    OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+    MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+   
+    This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+    SPDX-License-Identifier: EPL-2.0
+   
+    Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+   
+    This program includes and/or can make use of certain third party source code, object code, documentation and other
+    files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+    configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+    conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+    Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+    aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+    censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ -->
+
 <plugin>
    <extension
          point="org.eclipse.ui.commands">

--- a/analyses/org.osate.modelstats.ui/pom.xml
+++ b/analyses/org.osate.modelstats.ui/pom.xml
@@ -1,4 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2004-2021 Carnegie Mellon University and others. (see Contributors file). 
+    All Rights Reserved.
+   
+    NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+    KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+    OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+    MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+   
+    This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+    SPDX-License-Identifier: EPL-2.0
+   
+    Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+   
+    This program includes and/or can make use of certain third party source code, object code, documentation and other
+    files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+    configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+    conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+    Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+    aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+    censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -12,7 +36,7 @@
 
 	<groupId>org.osate</groupId>
 	<artifactId>org.osate.modelstats.ui</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.0.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<build>

--- a/analyses/org.osate.modelstats.ui/src/org/osate/modelstats/ui/Activator.java
+++ b/analyses/org.osate.modelstats.ui/src/org/osate/modelstats/ui/Activator.java
@@ -1,3 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2004-2021 Carnegie Mellon University and others. (see Contributors file). 
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ *******************************************************************************/
 package org.osate.modelstats.ui;
 
 import org.eclipse.ui.plugin.AbstractUIPlugin;

--- a/analyses/org.osate.modelstats.ui/src/org/osate/modelstats/ui/CountComponentsHandler.java
+++ b/analyses/org.osate.modelstats.ui/src/org/osate/modelstats/ui/CountComponentsHandler.java
@@ -1,3 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2004-2021 Carnegie Mellon University and others. (see Contributors file). 
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ *******************************************************************************/
 package org.osate.modelstats.ui;
 
 import org.eclipse.core.commands.ExecutionEvent;

--- a/analyses/org.osate.modelstats.ui/src/org/osate/modelstats/ui/CountComponentsUI.java
+++ b/analyses/org.osate.modelstats.ui/src/org/osate/modelstats/ui/CountComponentsUI.java
@@ -1,3 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2004-2021 Carnegie Mellon University and others. (see Contributors file). 
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ *******************************************************************************/
 package org.osate.modelstats.ui;
 
 import java.util.ArrayList;

--- a/analyses/org.osate.modelstats/META-INF/MANIFEST.MF
+++ b/analyses/org.osate.modelstats/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Model Statistics Plug-in
 Bundle-SymbolicName: org.osate.modelstats
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.1.qualifier
 Bundle-Activator: org.osate.modelstats.Activator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.18.0,4.0.0)",
  org.osate.aadl2;bundle-version="[4.0.0,5.0.0)"

--- a/analyses/org.osate.modelstats/build.properties
+++ b/analyses/org.osate.modelstats/build.properties
@@ -1,3 +1,26 @@
+###############################################################################
+# Copyright (c) 2004-2021 Carnegie Mellon University and others. (see Contributors file). 
+# All Rights Reserved.
+#
+# NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+# KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+# OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+# MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+#
+# This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+# SPDX-License-Identifier: EPL-2.0
+#
+# Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+#
+# This program includes and/or can make use of certain third party source code, object code, documentation and other
+# files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+# configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+# conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+# Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+# aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+# censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+###############################################################################
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\

--- a/analyses/org.osate.modelstats/pom.xml
+++ b/analyses/org.osate.modelstats/pom.xml
@@ -1,4 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2004-2021 Carnegie Mellon University and others. (see Contributors file). 
+    All Rights Reserved.
+   
+    NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+    KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+    OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+    MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+   
+    This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+    SPDX-License-Identifier: EPL-2.0
+   
+    Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+   
+    This program includes and/or can make use of certain third party source code, object code, documentation and other
+    files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+    configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+    conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+    Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+    aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+    censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -12,7 +36,7 @@
 
 	<groupId>org.osate</groupId>
 	<artifactId>org.osate.modelstats</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.0.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/analyses/org.osate.modelstats/src/org/osate/modelstats/Activator.java
+++ b/analyses/org.osate.modelstats/src/org/osate/modelstats/Activator.java
@@ -1,3 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2004-2021 Carnegie Mellon University and others. (see Contributors file). 
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ *******************************************************************************/
 package org.osate.modelstats;
 
 import org.osgi.framework.BundleActivator;

--- a/analyses/org.osate.modelstats/src/org/osate/modelstats/ComponentCounter.java
+++ b/analyses/org.osate.modelstats/src/org/osate/modelstats/ComponentCounter.java
@@ -1,3 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2004-2021 Carnegie Mellon University and others. (see Contributors file). 
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ *******************************************************************************/
 package org.osate.modelstats;
 
 import java.util.HashMap;

--- a/analyses/org.osate.modelstats/src/org/osate/modelstats/ElementsCounts.java
+++ b/analyses/org.osate.modelstats/src/org/osate/modelstats/ElementsCounts.java
@@ -1,3 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2004-2021 Carnegie Mellon University and others. (see Contributors file). 
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ *******************************************************************************/
 package org.osate.modelstats;
 
 import java.util.Map;

--- a/analyses/org.osate.plugins.feature/feature.xml
+++ b/analyses/org.osate.plugins.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.osate.plugins.feature"
       label="Open Source AADL Tool Environment Analysis Plug-ins"
-      version="6.0.0.qualifier"
+      version="6.0.1.qualifier"
       provider-name="CMU-SEI"
       plugin="org.osate.branding"
       image="icons/osateupdate_120.jpg"

--- a/analyses/org.osate.plugins.feature/pom.xml
+++ b/analyses/org.osate.plugins.feature/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>org.osate</groupId>
 	<artifactId>org.osate.plugins.feature</artifactId>
-	<version>6.0.0-SNAPSHOT</version>
+	<version>6.0.1-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 	<build>


### PR DESCRIPTION
Adds copyright headers to the model statistics plugin and updates versions. I am not sure if the versions for org.osate.plugins.feature/feature.xml and org.osate.plugins.feature/pom.xml should have been updated, but Eclipse was reporting an error for it after updating the other versions.