### PR TITLE
Don't provide default label text for features

### DIFF
--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/labeling/Aadl2LabelProvider.java
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/labeling/Aadl2LabelProvider.java
@@ -52,7 +52,6 @@ import org.osate.aadl2.EndToEndFlow;
 import org.osate.aadl2.EnumerationLiteral;
 import org.osate.aadl2.EventDataPort;
 import org.osate.aadl2.EventPort;
-import org.osate.aadl2.Feature;
 import org.osate.aadl2.FeatureGroup;
 import org.osate.aadl2.FlowImplementation;
 import org.osate.aadl2.FlowSpecification;
@@ -387,10 +386,6 @@ public class Aadl2LabelProvider extends AnnexAwareEObjectLabelProvider {
 
 	String text(FeatureGroup ele) {
 		return "Feature Group " + ele.getName();
-	}
-
-	String text(Feature ele) {
-		return "Feature " + ele.getName();
 	}
 
 	String text(FlowImplementation flowimpl) {


### PR DESCRIPTION
Label text for class Feature in the outline label provider took
precedence over the text for the o.o.aadl2.edit plug-in.

fixes #2656 