### PR TITLE
Add Linux+ARM64 as a build environment.

### DIFF
--- a/core/org.osate.build.main/pom.xml
+++ b/core/org.osate.build.main/pom.xml
@@ -101,6 +101,11 @@
 									<arch>x86_64</arch>
 								</environment>
 								<environment>
+									<os>linux</os>
+									<ws>gtk</ws>
+									<arch>aarch64</arch>
+								</environment>
+								<environment>
 									<os>win32</os>
 									<ws>win32</ws>
 									<arch>x86_64</arch>


### PR DESCRIPTION
This will allow OSATE to be run in Docker containers running native on Apple silicon (and also on the Raspberry Pi, which was used to test the build).