### PR TITLE
Force metaclass references to be styled as DEFAULT

### DIFF
--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/Aadl2UiModule.java
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/Aadl2UiModule.java
@@ -29,6 +29,7 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.eclipse.ui.views.contentoutline.IContentOutlinePage;
 import org.eclipse.xtext.builder.EclipseResourceFileSystemAccess2;
 import org.eclipse.xtext.generator.AbstractFileSystemAccess2;
+import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator;
 import org.eclipse.xtext.parser.IEncodingProvider;
 import org.eclipse.xtext.resource.containers.IAllContainersState;
 import org.eclipse.xtext.ui.LanguageSpecific;
@@ -78,7 +79,7 @@ public class Aadl2UiModule extends org.osate.xtext.aadl2.ui.AbstractAadl2UiModul
 		return org.osate.xtext.aadl2.ui.syntax.Aadl2SyntaxErrorMessageProvider.class;
 	}
 
-	public Class<? extends org.eclipse.xtext.ui.editor.syntaxcoloring.ISemanticHighlightingCalculator> bindSemanticHighlightingCalculator() {
+	public Class<? extends ISemanticHighlightingCalculator> bindSemanticHighlightingCalculator() {
 		return org.osate.xtext.aadl2.ui.highlighting.Aadl2SemanticHighlightingCalculator.class;
 	}
 


### PR DESCRIPTION
Metaclass references are styled as default.

Swapped out use of the deprecated class org.eclipse.xtext.ui.editor.syntaxcoloring.ISemanticHighlightingCalculator with the newer org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator.