### PR TITLE
Added ability to suppress creation of CSV files to NewBusLoadAnalysis

### DIFF
--- a/analyses/org.osate.analysis.resource.budgets.tests/src/org/osate/analysis/resource/budgets/tests/Issue2205Test.xtend
+++ b/analyses/org.osate.analysis.resource.budgets.tests/src/org/osate/analysis/resource/budgets/tests/Issue2205Test.xtend
@@ -66,7 +66,7 @@ class Issue2205Test extends XtextTest {
 
 		// check bus load
 		val checker = new NewBusLoadAnalysis()
-		val analysisResult = checker.invoke(null, instance)
+		val analysisResult = checker.invoke(null, instance, false)
 
 		val somResult = analysisResult.results.get(0)
 		val busResult = somResult.subResults.get(0)
@@ -102,7 +102,7 @@ class Issue2205Test extends XtextTest {
 
 		// check bus load
 		val checker = new NewBusLoadAnalysis()
-		val analysisResult = checker.invoke(null, instance)
+		val analysisResult = checker.invoke(null, instance, false)
 
 		// SOM 1
 		{
@@ -216,7 +216,7 @@ class Issue2205Test extends XtextTest {
 
 		// check bus load
 		val checker = new NewBusLoadAnalysis()
-		val analysisResult = checker.invoke(null, instance)
+		val analysisResult = checker.invoke(null, instance, false)
 
 		val somResult = analysisResult.results.get(0)
 		val busResult = somResult.subResults.get(0)
@@ -240,7 +240,7 @@ class Issue2205Test extends XtextTest {
 
 		// check bus load
 		val checker = new NewBusLoadAnalysis()
-		val analysisResult = checker.invoke(null, instance)
+		val analysisResult = checker.invoke(null, instance, false)
 
 		val somResult = analysisResult.results.get(0)
 		val busResult = somResult.subResults.get(0)
@@ -262,7 +262,7 @@ class Issue2205Test extends XtextTest {
 
 		// check bus load
 		val checker = new NewBusLoadAnalysis()
-		val analysisResult = checker.invoke(null, instance)
+		val analysisResult = checker.invoke(null, instance, false)
 
 		val somResult = analysisResult.results.get(0)
 		val busResult = somResult.subResults.get(0)
@@ -284,7 +284,7 @@ class Issue2205Test extends XtextTest {
 
 		// check bus load
 		val checker = new NewBusLoadAnalysis()
-		val analysisResult = checker.invoke(null, instance)
+		val analysisResult = checker.invoke(null, instance, false)
 
 		val somResult = analysisResult.results.get(0)
 		val busResult = somResult.subResults.get(0)
@@ -306,7 +306,7 @@ class Issue2205Test extends XtextTest {
 
 		// check bus load
 		val checker = new NewBusLoadAnalysis()
-		val analysisResult = checker.invoke(null, instance)
+		val analysisResult = checker.invoke(null, instance, false)
 
 		val somResult = analysisResult.results.get(0)
 		val busResult = somResult.subResults.get(0)
@@ -328,7 +328,7 @@ class Issue2205Test extends XtextTest {
 
 		// check bus load
 		val checker = new NewBusLoadAnalysis()
-		val analysisResult = checker.invoke(null, instance)
+		val analysisResult = checker.invoke(null, instance, false)
 
 		val somResult = analysisResult.results.get(0)
 		val busResult = somResult.subResults.get(0)
@@ -350,7 +350,7 @@ class Issue2205Test extends XtextTest {
 
 		// check bus load
 		val checker = new NewBusLoadAnalysis()
-		val analysisResult = checker.invoke(null, instance)
+		val analysisResult = checker.invoke(null, instance, false)
 
 		val somResult = analysisResult.results.get(0)
 		val busResult = somResult.subResults.get(0)
@@ -376,7 +376,7 @@ class Issue2205Test extends XtextTest {
 
 		// check bus load
 		val checker = new NewBusLoadAnalysis()
-		val analysisResult = checker.invoke(null, instance)
+		val analysisResult = checker.invoke(null, instance, false)
 
 		val somResult = analysisResult.results.get(0)
 		val busResult = somResult.subResults.get(0)
@@ -402,7 +402,7 @@ class Issue2205Test extends XtextTest {
 
 		// check bus load
 		val checker = new NewBusLoadAnalysis()
-		val analysisResult = checker.invoke(null, instance)
+		val analysisResult = checker.invoke(null, instance, false)
 
 		val somResult = analysisResult.results.get(0)
 		val busResult = somResult.subResults.get(0)
@@ -428,7 +428,7 @@ class Issue2205Test extends XtextTest {
 
 		// check bus load
 		val checker = new NewBusLoadAnalysis()
-		val analysisResult = checker.invoke(null, instance)
+		val analysisResult = checker.invoke(null, instance, false)
 
 		val somResult = analysisResult.results.get(0)
 		{
@@ -470,7 +470,7 @@ class Issue2205Test extends XtextTest {
 
 		// check bus load
 		val checker = new NewBusLoadAnalysis()
-		val analysisResult = checker.invoke(null, instance)
+		val analysisResult = checker.invoke(null, instance, false)
 
 		val somResult = analysisResult.results.get(0)
 		{
@@ -530,7 +530,7 @@ class Issue2205Test extends XtextTest {
 
 		// check bus load
 		val checker = new NewBusLoadAnalysis()
-		val analysisResult = checker.invoke(null, instance)
+		val analysisResult = checker.invoke(null, instance, false)
 
 		val somResult = analysisResult.results.get(0)
 		{
@@ -590,7 +590,7 @@ class Issue2205Test extends XtextTest {
 
 		// check bus load
 		val checker = new NewBusLoadAnalysis()
-		val analysisResult = checker.invoke(null, instance)
+		val analysisResult = checker.invoke(null, instance, false)
 
 		val somResult = analysisResult.results.get(0)
 		val busResult = somResult.subResults.get(0)

--- a/analyses/org.osate.analysis.resource.budgets/src/org/osate/analysis/resource/budgets/busload/NewBusLoadAnalysis.java
+++ b/analyses/org.osate.analysis.resource.budgets/src/org/osate/analysis/resource/budgets/busload/NewBusLoadAnalysis.java
@@ -172,11 +172,19 @@ public final class NewBusLoadAnalysis {
 	 * @return The results in a {@code AnalysisResult} object.
 	 */
 	public AnalysisResult invoke(final IProgressMonitor monitor, final SystemInstance systemInstance) {
-		final IProgressMonitor pm = monitor == null ? new NullProgressMonitor() : monitor;
-		return analyzeBody(pm, systemInstance);
+		return invoke(monitor, systemInstance, true);
 	}
 
-	private AnalysisResult analyzeBody(final IProgressMonitor monitor, final Element obj) {
+	/**
+	 * @since 4.2
+	 */
+	public AnalysisResult invoke(final IProgressMonitor monitor, final SystemInstance systemInstance,
+			final boolean createCSV) {
+		final IProgressMonitor pm = monitor == null ? new NullProgressMonitor() : monitor;
+		return analyzeBody(pm, systemInstance, createCSV);
+	}
+
+	private AnalysisResult analyzeBody(final IProgressMonitor monitor, final Element obj, final boolean createCSV) {
 		if (obj instanceof InstanceObject) {
 			final SystemInstance root = ((InstanceObject) obj).getSystemInstance();
 			final AnalysisResult analysisResult = ResultUtil.createAnalysisResult("Bus  Load", root);
@@ -195,7 +203,9 @@ public final class NewBusLoadAnalysis {
 				analyzeBusLoadModel(busLoadModel, somResult, monitor);
 			}
 
-			saveResults(root, analysisResult, monitor);
+			if (createCSV) {
+				saveResults(root, analysisResult, monitor);
+			}
 
 			monitor.done();
 


### PR DESCRIPTION
To prevent problems when automating the execution of the unit tests, the bus load analysis unit tests now invoke a version of the analyis that does not create CSV files.
