### PR TITLE
Preserve instantiation failures in headless environments 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstancePlugin.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstancePlugin.java
@@ -27,14 +27,14 @@ import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Plugin;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
 /**
- * The main plugin class to be used in the desktop.
+ * The instantiation bundle activator.
  */
-public class InstancePlugin extends AbstractUIPlugin {
+public class InstancePlugin extends Plugin {
 	// The shared instance.
 	private static InstancePlugin plugin;
 	// Resource bundle.

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
@@ -26,6 +26,7 @@ package org.osate.aadl2.instantiation;
 import static org.osate.aadl2.modelsupport.util.AadlUtil.getElementCount;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -40,9 +41,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ProjectScope;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.preferences.IScopeContext;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.TreeIterator;
@@ -383,17 +382,10 @@ public class InstantiateModel {
 			throw new InterruptedException();
 		}
 
-		try {
-			// We're done: Save the model.
-			// We don't respond to a cancel at this point
-			monitor.subTask("Saving instance model");
-			aadlResource.save(null);
-		} catch (IOException e) {
-			InstancePlugin.log(new Status(IStatus.ERROR, InstancePlugin.getPluginId(), IStatus.OK,
-					"Exception during instantiation", e));
-			setErrorMessage("Exception during instantiation, see error log");
-			return null;
-		}
+		// We're done: Save the model.
+		// We don't respond to a cancel at this point
+		monitor.subTask("Saving instance model");
+		aadlResource.save(null);
 
 		return result;
 	}
@@ -406,6 +398,8 @@ public class InstantiateModel {
 	 * @param aadlResource the Resource to store the instance model in
 	 *
 	 * @return SystemInstance or <code>null</code> if canceled.
+	 * @throws InterruptedException if instantiation is canceled
+	 * @throws RuntimeException if instantiation fails
 	 */
 	public SystemInstance createSystemInstanceInt(ComponentImplementation ci, Resource aadlResource, boolean save)
 			throws InterruptedException {
@@ -420,6 +414,7 @@ public class InstantiateModel {
 		aadlResource.getContents().add(root);
 		// Needed to save the root object because we may attach warnings to the
 		// IResource as we build it.
+		var origErrManager = errManager;
 		try {
 			if (save) {
 				aadlResource.save(null);
@@ -427,7 +422,6 @@ public class InstantiateModel {
 			// collect errors in list and transfer to original error manager later
 			// property associations can be added with an error but could then be removed
 			// see issue #2929
-			var origErrManager = errManager;
 			errManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
 			fillSystemInstance(root);
 			var errors = ((QueuingAnalysisErrorReporter) errManager.getReporter(aadlResource)).getErrors();
@@ -448,13 +442,10 @@ public class InstantiateModel {
 					}
 				}
 			}
-		} catch (InterruptedException e) {
-			throw e;
-		} catch (Exception e) {
-			InstancePlugin.log(new Status(IStatus.ERROR, InstancePlugin.getPluginId(), IStatus.OK,
-					"Exception during instantiation", e));
-			setErrorMessage("Exception during instantiation, see error log");
-			return null;
+		} catch (IOException e) {
+			throw new UncheckedIOException("Exception while saving the initial instance model", e);
+		} finally {
+			errManager = origErrManager;
 		}
 		return root;
 	}

--- a/core/org.osate.core.tests/models/issue2989/.gitignore
+++ b/core/org.osate.core.tests/models/issue2989/.gitignore
@@ -1,0 +1,1 @@
+/.aadlbin-gen/

--- a/core/org.osate.core.tests/models/issue2989/.project
+++ b/core/org.osate.core.tests/models/issue2989/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue2989</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue2989/Issue2989.aadl
+++ b/core/org.osate.core.tests/models/issue2989/Issue2989.aadl
@@ -1,0 +1,10 @@
+package Issue2989
+public
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+	end Top.i;
+
+end Issue2989;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2989Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2989Test.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.SystemImplementation;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue2989Test extends XtextTest {
+
+	private static final String FILE = "org.osate.core.tests/models/issue2989/Issue2989.aadl";
+
+	@Inject
+	TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	ValidationTestHelper validationHelper;
+
+	@Test
+	public void testOriginalInstantiationExceptionIsPropagated() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(FILE);
+		validationHelper.assertNoIssues(pkg);
+
+		SystemImplementation top = (SystemImplementation) pkg.getPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(c -> c.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		Resource instanceResource = pkg.eResource()
+				.getResourceSet()
+				.createResource(InstantiateModel.getInstanceModelURI(top));
+		IllegalStateException expected = new IllegalStateException("injected instantiation failure");
+		InstantiateModel instantiator = new InstantiateModel(new NullProgressMonitor(),
+				AnalysisErrorReporterManager.NULL_ERROR_MANANGER) {
+			@Override
+			public void fillSystemInstance(SystemInstance root) {
+				throw expected;
+			}
+		};
+
+		try {
+			instantiator.createSystemInstanceInt(top, instanceResource, false);
+			fail("Expected the original instantiation exception");
+		} catch (IllegalStateException actual) {
+			assertSame(expected, actual);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- propagate core instantiation failures instead of swallowing them and logging through the UI-based activator
- restore the original analysis error reporter after queued diagnostic collection
- make the instantiation bundle activator extend the headless Eclipse `Plugin` base
- add an external-model regression test that verifies the original exception reaches the caller

## Validation

- `Issue2989Test`: 1 test, 0 failures, 0 errors
- full 137-module Tycho reactor: `BUILD SUCCESS`
- patched `osate-cli` reports the underlying `Index -1 out of bounds for length 0` failure instead of `NoClassDefFoundError: AbstractUIPlugin`

Fixes #2989