### PR TITLE
Fix nested end-to-end flow continuation (#2991) 🤖

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,38 @@ Cross-cutting concerns:
 - **Baseline / API tooling**: API baseline is currently 2.18.0 (recent commit `Set API baseline 2.18.0`); changes that break API should be weighed against that baseline. The (currently commented-out) `tycho-p2-extras-plugin` compares against `lastStableRepository`.
 - **SpotBugs + FindSecBugs**: activated with `-Dspotbugs=true`; config lives under `releng/org.osate.build.main/src/main/resources/spotbugs/`.
 
+## Issue-driven regression workflow
+
+Use these rules when a review or investigation produces defects that need GitHub issues and isolated regression-test branches.
+
+### GitHub issues
+
+- Create one issue in `osate/osate2` for each independently fixable defect. Search open and closed issues first to avoid duplicates.
+- Authenticate the GitHub CLI before creating issues. If authentication is missing or expired, stop and ask the user to authenticate; do not work around authentication or silently omit issue creation.
+- Create the issue before finalizing test names so the real issue number is available. Replace all temporary identifiers such as `XXX1` with that number; do not commit placeholders.
+- Use a concise, behavior-oriented title. Structure the body with `Summary`, `Reproduction`, `Expected behavior`, and `Relevant code` sections.
+- In `Summary`, describe the observable failure and the implementation mechanism that causes it. In `Reproduction`, give the smallest model shape or execution path that triggers it and include the exception text when relevant. In `Expected behavior`, state a testable result. In `Relevant code`, name the files, classes, and methods implicated by the investigation.
+- Distinguish confirmed behavior from inferred causes. For headless failures, preserve the intended headless dependency boundary; do not propose adding UI bundles merely to satisfy an error path.
+
+### Regression tests and AADL models
+
+- Name an issue regression test `Issue<number>Test.java` and place core tests under `core/org.osate.core.tests/src/org/osate/core/tests/issues/`.
+- Store AADL fixtures as a separate OSATE project under `core/org.osate.core.tests/models/issue<number>/`; never embed the AADL model as a Java string.
+- Each model project must include a `.project` whose project name is `issue<number>` and a `.gitignore` containing `/.aadlbin-gen/`. Name the primary fixture `Issue<number>.aadl` unless an established nearby test requires multiple descriptive fixture files.
+- Follow the surrounding Xtext test pattern: use `XtextRunner`, `Aadl2InjectorProvider`, `XtextTest`, injected `TestHelper`, and `ValidationTestHelper.assertNoIssues` before exercising the behavior.
+- Make the assertion specific to the reported defect. The regression must fail for the defect, pass after its fix, and avoid depending on another unresolved issue. For error-path tests, inject a deterministic failure at the narrowest overridable boundary when a realistic model would first trigger a different known defect.
+- Validate the standalone AADL project when practical, then run tests from the repository root with the Tycho reactor. Use `-Dtest=Issue<number>Test -DfailIfNoTests=false` to select the test; use a lifecycle phase that actually executes Tycho tests, and report separately whether a command only compiled the test.
+- Add only the new issue test and its model-project files to the issue branch. Do not include the production fix unless the user explicitly requests it.
+
+### Issue branches and commits
+
+- Create one sibling branch per issue from the same requested base commit; do not stack one issue's test branch on another.
+- Name the branch `<issue-number>_<3-to-5-word-description>`, using a lowercase `snake_case` description, for example `2988_connection_context_matching`.
+- Unless the user requests a different history, put the issue's regression test and external model project in one commit. Use the subject `Add regression test for issue #<number>`, followed by a blank line and a body that explains what the test models, what it asserts, and why.
+- Before committing, run `git diff --cached --check` and confirm that only files for that issue are staged. Preserve unrelated user changes.
+- After committing, verify that the branch has exactly one commit relative to its base, its parent is the intended base, and its diff contains only that issue's test assets. Return the shared checkout to the branch it was on before the issue branch was created, normally `master`, and confirm the worktree is clean.
+- Do not push branches or open pull requests unless the user asks.
+
 ## Versioning
 
 Version is `2.19.0-SNAPSHOT` across the reactor. Bumps are done by the scripts in `releng/version-management/`, not by hand-editing POMs and MANIFESTs — mismatches between a bundle's `Bundle-Version`, its feature inclusion, and its pom `<version>` will break the Tycho build.

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
@@ -794,7 +794,6 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 	 * @param iter
 	 */
 	// TODO-LW: Detect cyclic dependencies between ETEs
-	// restore iterator after each nested
 	// add preConn before addNested
 	private void processEndToEndFlow(ComponentInstance ci, EndToEndFlowInstance etei, EndToEndFlow ete,
 			FlowIterator iter) {
@@ -829,32 +828,21 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 					etei.setName(etei.getEndToEndFlow().getName());
 					eteiClone.getModesList().addAll(etei.getModesList());
 				}
+				FlowIterator continuation = state.pop();
 
 				addNestedETE(etei, nested);
 
 				// prepare next connection filter
 				connections.clear();
 				connections.addAll(nested.postConns);
-				if (iter.hasNext()) {
-					Element obj = iter.next();
-					Connection conn = null;
-					if (obj instanceof FlowSegment) {
-						FlowElement fe = ((FlowSegment) obj).getFlowElement();
-						if (fe instanceof Connection) {
-							conn = (Connection) fe;
-						}
-					} else if (obj instanceof EndToEndFlowSegment) {
-						EndToEndFlowElement fe = ((EndToEndFlowSegment) obj).getFlowElement();
-						if (fe instanceof Connection) {
-							conn = (Connection) fe;
-						}
-					}
+				if (continuation.hasNext()) {
+					Connection conn = getConnection(continuation.next());
 					if (conn != null) {
 						connections.add(conn);
 					}
 				}
 
-				continueFlow(ci, etei, state.pop(), ci);
+				continueFlow(ci, etei, continuation, ci);
 
 				if (prepareNext) {
 					// add clone
@@ -896,6 +884,7 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 							etei.setName(etei.getEndToEndFlow().getName());
 							eteiClone.getModesList().addAll(etei.getModesList());
 						}
+						FlowIterator continuation = state.pop();
 
 						etei.getFlowElements().add(conni);
 						addNestedETE(etei, nested);
@@ -903,11 +892,14 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 						// prepare next connection filter
 						connections.clear();
 						connections.addAll(nested.postConns);
-						if (iter.hasNext()) {
-							connections.add((Connection) iter.next());
+						if (continuation.hasNext()) {
+							Connection nextConnection = getConnection(continuation.next());
+							if (nextConnection != null) {
+								connections.add(nextConnection);
+							}
 						}
 
-						continueFlow(ci, etei, state.pop(), ci);
+						continueFlow(ci, etei, continuation, ci);
 
 						if (prepareNext) {
 							// add clone
@@ -1009,6 +1001,16 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 	// -------------------------------------------------------------------------
 	// Helper methods
 	// -------------------------------------------------------------------------
+
+	private static Connection getConnection(Element segment) {
+		if (segment instanceof FlowSegment fs) {
+			return fs.getFlowElement() instanceof Connection connection ? connection : null;
+		}
+		if (segment instanceof EndToEndFlowSegment eefs) {
+			return eefs.getFlowElement() instanceof Connection connection ? connection : null;
+		}
+		return null;
+	}
 
 	/**
 	 * Get all connection instances that pass through the sequence of

--- a/core/org.osate.core.tests/models/issue2991/.gitignore
+++ b/core/org.osate.core.tests/models/issue2991/.gitignore
@@ -1,0 +1,1 @@
+/.aadlbin-gen/

--- a/core/org.osate.core.tests/models/issue2991/.project
+++ b/core/org.osate.core.tests/models/issue2991/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue2991</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue2991/Issue2991.aadl
+++ b/core/org.osate.core.tests/models/issue2991/Issue2991.aadl
@@ -1,0 +1,49 @@
+package Issue2991
+public
+
+	system Endpoint
+		features
+			i: in data port;
+			o: out data port;
+		flows
+			fsrc: flow source o;
+			fsnk: flow sink i;
+			fpath: flow path i -> o;
+	end Endpoint;
+
+	system Middle extends Endpoint
+	end Middle;
+
+	system implementation Middle.i
+		subcomponents
+			one: system Endpoint;
+			two: system Endpoint;
+		connections
+			in1: port i -> one.i;
+			out1: port one.o -> o;
+			in2: port i -> two.i;
+			out2: port two.o -> o;
+		flows
+			fpath: flow path i -> in1 -> one.fpath -> out1 -> o;
+			fpath: flow path i -> in2 -> two.fpath -> out2 -> o;
+	end Middle.i;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			src: system Endpoint;
+			middle: system Middle.i;
+			right: system Endpoint;
+			snk: system Endpoint;
+		connections
+			cin: port src.o -> middle.i;
+			cmid: port middle.o -> right.i;
+			cout: port right.o -> snk.i;
+		flows
+			nested: end to end flow middle.fpath -> cmid -> right.fpath;
+			parent: end to end flow src.fsrc -> cin -> nested -> cout -> snk.fsnk;
+	end Top.i;
+
+end Issue2991;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2991Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2991Test.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.SystemImplementation;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue2991Test extends XtextTest {
+
+	private static final String FILE = "org.osate.core.tests/models/issue2991/Issue2991.aadl";
+
+	@Inject
+	TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	ValidationTestHelper validationHelper;
+
+	@Test
+	public void testConnectionAfterNestedEndToEndFlow() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(FILE);
+		validationHelper.assertNoIssues(pkg);
+
+		SystemImplementation top = (SystemImplementation) pkg.getPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(c -> c.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		SystemInstance instance = InstantiateModel.instantiate(top);
+
+		assertNotNull(instance);
+	}
+}


### PR DESCRIPTION
## Summary

- resolve flow-segment wrappers before using their referenced connections
- restore and advance the same branch-local iterator when continuing nested end-to-end flow variants
- add an external AADL regression project and focused test for the ClassCastException

## Testing

- mvn -s releng/osate.releng/settings.xml -Plocal verify -Dtest=Issue2991Test -DfailIfNoTests=false -Dpr.build=true -Dtycho.localArtifacts=ignore -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false

Fixes #2991