### PR TITLE
Honor canceled analysis initialization 🤖

### DIFF
--- a/core/org.osate.core.tests/models/issue2981/.gitignore
+++ b/core/org.osate.core.tests/models/issue2981/.gitignore
@@ -1,0 +1,1 @@
+/.aadlbin-gen/

--- a/core/org.osate.core.tests/models/issue2981/.project
+++ b/core/org.osate.core.tests/models/issue2981/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue2981</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue2981/Issue2981.aadl
+++ b/core/org.osate.core.tests/models/issue2981/Issue2981.aadl
@@ -1,0 +1,10 @@
+package Issue2981
+public
+	system S
+	end S;
+
+	system implementation S.i
+		modes
+			initial_mode: initial mode;
+	end S.i;
+end Issue2981;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2981Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2981Test.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.Element;
+import org.osate.aadl2.NamedElement;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+import org.osate.ui.handlers.AbstractAaxlHandler;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue2981Test extends XtextTest {
+
+	private static final String FILE = "org.osate.core.tests/models/issue2981/Issue2981.aadl";
+
+	@Inject
+	TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	ValidationTestHelper validationHelper;
+
+	@Test
+	public void testCancelledInitializationStopsAction() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(FILE);
+		validationHelper.assertNoIssues(pkg);
+
+		CancellingHandler handler = new CancellingHandler();
+		handler.run(pkg);
+
+		assertTrue(handler.initializeCalled);
+		assertFalse(handler.actionCalled);
+		assertFalse(handler.finalizeCalled);
+	}
+
+	private static final class CancellingHandler extends AbstractAaxlHandler {
+		private boolean initializeCalled;
+		private boolean actionCalled;
+		private boolean finalizeCalled;
+
+		private void run(Element root) {
+			actionBody(new NullProgressMonitor(), root);
+		}
+
+		@Override
+		protected String getActionName() {
+			return "Issue 2981 test action";
+		}
+
+		@Override
+		protected Job createJob(Element root) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		protected boolean initializeAction(NamedElement object) {
+			initializeCalled = true;
+			return false;
+		}
+
+		@Override
+		protected void doAaxlAction(IProgressMonitor monitor, Element root) {
+			actionCalled = true;
+		}
+
+		@Override
+		protected boolean finalizeAction() {
+			finalizeCalled = true;
+			return true;
+		}
+	}
+}

--- a/core/org.osate.ui/src/org/osate/ui/handlers/AbstractAaxlHandler.java
+++ b/core/org.osate.ui/src/org/osate/ui/handlers/AbstractAaxlHandler.java
@@ -175,7 +175,9 @@ public abstract class AbstractAaxlHandler extends AbstractHandler {
 		// Init the properties
 		notFound.clear();
 		initPropertyReferences();
-		initializeAction((NamedElement) root);
+		if (!initializeAction((NamedElement) root)) {
+			return;
+		}
 		if (suppressErrorMessages() || !reportPropertyLookupErrors()) {
 			// Run the command (indirectly)
 			processAaxlAction(monitor, resource, root);


### PR DESCRIPTION
## Summary

- stop the shared analysis-handler lifecycle when initialization is canceled
- prevent canceled analyses from processing or finalizing with missing or stale settings
- add a framework regression test with a standalone AADL fixture

## Testing

- confirmed `Issue2981Test` fails before the production fix
- `mvn -s releng/osate.releng/settings.xml -Plocal verify -Dtest=Issue2981Test -DfailIfNoTests=false -Dpr.build=true -Dtycho.localArtifacts=ignore -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false`

Fixes #2981