### PR TITLE
Handle SOM reachability cancellation 🤖

### DIFF
--- a/analyses/org.osate.analysis.modes.tests/models/issue2982/.gitignore
+++ b/analyses/org.osate.analysis.modes.tests/models/issue2982/.gitignore
@@ -1,0 +1,1 @@
+/.aadlbin-gen/

--- a/analyses/org.osate.analysis.modes.tests/models/issue2982/.project
+++ b/analyses/org.osate.analysis.modes.tests/models/issue2982/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue2982</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/analyses/org.osate.analysis.modes.tests/models/issue2982/Issue2982.aadl
+++ b/analyses/org.osate.analysis.modes.tests/models/issue2982/Issue2982.aadl
@@ -1,0 +1,28 @@
+package Issue2982
+public
+	system S
+	end S;
+
+	system implementation S.i
+		modes
+			initial_mode: initial mode;
+	end S.i;
+
+	system Child
+	end Child;
+
+	system implementation Child.i
+		modes
+			initial_mode: initial mode;
+			other_mode: mode;
+	end Child.i;
+
+	system Nested
+	end Nested;
+
+	system implementation Nested.i
+		subcomponents
+			first: system Child.i;
+			second: system Child.i;
+	end Nested.i;
+end Issue2982;

--- a/analyses/org.osate.analysis.modes.tests/src/org/osate/analysis/modes/reachability/Issue2982Test.java
+++ b/analyses/org.osate.analysis.modes.tests/src/org/osate/analysis/modes/reachability/Issue2982Test.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.analysis.modes.reachability;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.extensions.InjectionExtension;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.result.ResultType;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@ExtendWith(InjectionExtension.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue2982Test extends XtextTest {
+
+	private static final String PATH = "org.osate.analysis.modes.tests/models/issue2982/Issue2982.aadl";
+
+	@Inject
+	TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	ValidationTestHelper validationHelper;
+
+	@Test
+	public void canceledBeforeAnalysisReturnsTbd() throws Exception {
+		var monitor = new CancellingProgressMonitor(1);
+		var result = new ReachabilityAnalyzer(instantiate("S.i")).analyzeModel(monitor);
+
+		assertAll(() -> assertEquals(ResultType.TBD, result.getResultType()),
+				() -> assertEquals("Analysis was cancelled", result.getMessage()), () -> assertTrue(monitor.done));
+	}
+
+	@Test
+	public void canceledDuringGraphConstructionStopsAnalysis() throws Exception {
+		var monitor = new CancellingProgressMonitor(3);
+		var result = new ReachabilityAnalyzer(instantiate("Nested.i")).analyzeModel(monitor);
+
+		assertAll(() -> assertEquals(ResultType.TBD, result.getResultType()),
+				() -> assertEquals("Analysis was cancelled", result.getMessage()),
+				() -> assertTrue(result.getDiagnostics().isEmpty()), () -> assertEquals(3, monitor.cancellationChecks),
+				() -> assertTrue(monitor.done));
+	}
+
+	private SystemInstance instantiate(String name) throws Exception {
+		var pkg = testHelper.parseFile(PATH);
+		validationHelper.assertNoIssues(pkg);
+		var implementation = pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(ComponentImplementation.class::isInstance)
+				.map(ComponentImplementation.class::cast)
+				.filter(ci -> ci.getName().equals(name))
+				.findFirst()
+				.orElseThrow();
+		return InstantiateModel.instantiate(implementation);
+	}
+
+	private static final class CancellingProgressMonitor implements IProgressMonitor {
+		private final int cancelOnCheck;
+		private int cancellationChecks;
+		private boolean canceled;
+		private boolean done;
+
+		private CancellingProgressMonitor(int cancelOnCheck) {
+			this.cancelOnCheck = cancelOnCheck;
+		}
+
+		@Override
+		public void beginTask(String name, int totalWork) {
+		}
+
+		@Override
+		public void done() {
+			done = true;
+		}
+
+		@Override
+		public void internalWorked(double work) {
+		}
+
+		@Override
+		public boolean isCanceled() {
+			return canceled || ++cancellationChecks >= cancelOnCheck;
+		}
+
+		@Override
+		public void setCanceled(boolean value) {
+			canceled = value;
+		}
+
+		@Override
+		public void setTaskName(String name) {
+		}
+
+		@Override
+		public void subTask(String name) {
+		}
+
+		@Override
+		public void worked(int work) {
+		}
+	}
+}

--- a/analyses/org.osate.analysis.modes/src/org/osate/analysis/modes/reachability/ModeDomain.java
+++ b/analyses/org.osate.analysis.modes/src/org/osate/analysis/modes/reachability/ModeDomain.java
@@ -56,6 +56,7 @@ import org.osate.analysis.modes.modemodel.SOMNode;
 import org.osate.analysis.modes.modemodel.Trigger;
 import org.osate.analysis.modes.modemodel.TriggerKey;
 import org.osate.result.Result;
+import org.osate.result.ResultType;
 
 public class ModeDomain {
 
@@ -135,7 +136,9 @@ public class ModeDomain {
 		graphs.getContents().add(graph);
 		analyzer = new ModeDomainAnalyzer(this, config);
 		var result = analyzer.analyze(split);
-		updateEnabled();
+		if (result.getResultType() == ResultType.SUCCESS) {
+			updateEnabled();
+		}
 		return result;
 	}
 

--- a/analyses/org.osate.analysis.modes/src/org/osate/analysis/modes/reachability/ReachabilityAnalyzer.java
+++ b/analyses/org.osate.analysis.modes/src/org/osate/analysis/modes/reachability/ReachabilityAnalyzer.java
@@ -33,6 +33,7 @@ import java.util.List;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.emf.common.util.URI;
@@ -99,6 +100,7 @@ public final class ReachabilityAnalyzer {
 	public AnalysisResult analyzeModel(IProgressMonitor monitor) {
 		ModeDomain.clearData();
 		initializeResult();
+		var safeMonitor = IProgressMonitor.nullSafe(monitor);
 		try {
 			if (!fillAndValidateModeDomains(root)) {
 				result.setMessage("Mode domains are not set up correctly, check instance model for problems");
@@ -106,16 +108,21 @@ public final class ReachabilityAnalyzer {
 				return result;
 			}
 
-			progress = SubMonitor.convert(monitor, 100);
+			progress = SubMonitor.convert(safeMonitor, 100);
 
-			while (!ModeDomain.toAnalyze.isEmpty()) {
-				var d = ModeDomain.toAnalyze.iterator().next();
-				ModeDomain.toAnalyze.remove(d);
-				var r = d.analyze(config, progress.split(1));
-				result.getResults().add(r);
+			try {
+				while (!ModeDomain.toAnalyze.isEmpty()) {
+					var d = ModeDomain.toAnalyze.iterator().next();
+					ModeDomain.toAnalyze.remove(d);
+					var r = d.analyze(config, progress.split(1));
+					result.getResults().add(r);
+					if (r.getResultType() == ResultType.TBD) {
+						return cancelAnalysis();
+					}
+				}
+			} catch (OperationCanceledException e) {
+				return cancelAnalysis();
 			}
-
-			monitor.done();
 
 			markUnreachableSOMs();
 
@@ -133,8 +140,18 @@ public final class ReachabilityAnalyzer {
 			}
 			return result;
 		} finally {
-			ModeDomain.cleanResource();
+			try {
+				safeMonitor.done();
+			} finally {
+				ModeDomain.cleanResource();
+			}
 		}
+	}
+
+	private AnalysisResult cancelAnalysis() {
+		result.setMessage("Analysis was cancelled");
+		result.setResultType(ResultType.TBD);
+		return result;
 	}
 
 	public IStatus writeReports() {


### PR DESCRIPTION
## Summary

- return a top-level TBD result when reachability analysis is canceled
- stop processing partial mode-domain graphs before updating enabled state or marking unreachable SOMs
- always complete the progress monitor and clean temporary resources
- add regression coverage for cancellation before analysis and during graph construction

## Testing

- Before the fix: `Issue2982Test` ran 2 tests with 1 failure and 1 error
- After the fix: `mvn -s releng/osate.releng/settings.xml -Plocal verify -Dtest=Issue2982Test -DfailIfNoTests=false -Dpr.build=true -Dtycho.localArtifacts=ignore -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false`
- Result: 2 tests run, 0 failures, 0 errors; BUILD SUCCESS

Fixes #2982