### PR TITLE
Handle multiple access connection candidates 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
@@ -703,6 +703,7 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 				while (connIter.hasNext()) {
 					EndToEndFlowInstance eteiClone = null;
 					Stack<FlowIterator> stateClone = null;
+					List<Connection> connectionsClone = new ArrayList<Connection>();
 					ConnectionInstance conni = connIter.next();
 					boolean prepareNext = connIter.hasNext();
 					EndToEndFlowElement leaf = null;
@@ -727,6 +728,7 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 						if (prepareNext) {
 							stateClone = clone(state);
 							eteiClone = EcoreUtil.copy(etei);
+							connectionsClone = new ArrayList<Connection>(connections);
 							etei.setName(etei.getEndToEndFlow().getName());
 							eteiClone.getModesList().addAll(etei.getModesList());
 						}
@@ -773,6 +775,7 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 							etei.getContainingComponentInstance().getEndToEndFlows().add(eteiClone);
 							etei = eteiClone;
 							state = stateClone;
+							connections = connectionsClone;
 							addETEI.add(etei);
 							if (etei.getFlowElements() == null || etei.getFlowElements().isEmpty()) {
 								created.add(myInfo = new ETEInfo(etei));

--- a/core/org.osate.core.tests/models/issue2984/.gitignore
+++ b/core/org.osate.core.tests/models/issue2984/.gitignore
@@ -1,0 +1,1 @@
+/.aadlbin-gen/

--- a/core/org.osate.core.tests/models/issue2984/.project
+++ b/core/org.osate.core.tests/models/issue2984/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue2984</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue2984/Issue2984.aadl
+++ b/core/org.osate.core.tests/models/issue2984/Issue2984.aadl
@@ -1,0 +1,50 @@
+package Issue2984
+public
+
+	data D
+	end D;
+
+	system Producer
+		features
+			a: requires data access D;
+		flows
+			fsrc: flow source a;
+	end Producer;
+
+	system Consumer
+		features
+			a: requires data access D;
+		flows
+			fsnk: flow sink a;
+	end Consumer;
+
+	system Middle
+		features
+			a: requires data access D;
+	end Middle;
+
+	system implementation Middle.i
+		subcomponents
+			src: system Producer;
+			snk: system Consumer;
+		connections
+			c1: data access src.a -> a;
+			c2: data access a -> snk.a;
+		flows
+			e2e: end to end flow src.fsrc -> c1 -> a -> c2 -> snk.fsnk;
+	end Middle.i;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			d1: data D;
+			d2: data D;
+			m: system Middle.i;
+		connections
+			c1: data access d1 <-> m.a;
+			c2: data access d2 <-> m.a;
+	end Top.i;
+
+end Issue2984;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2984Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2984Test.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.SystemImplementation;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue2984Test extends XtextTest {
+
+	private static final String FILE = "org.osate.core.tests/models/issue2984/Issue2984.aadl";
+
+	@Inject
+	TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	ValidationTestHelper validationHelper;
+
+	@Test
+	public void testMultipleAccessConnectionCandidates() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(FILE);
+		validationHelper.assertNoIssues(pkg);
+
+		SystemImplementation top = (SystemImplementation) pkg.getPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(c -> c.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		SystemInstance instance = InstantiateModel.instantiate(top);
+		ComponentInstance middle = instance.getComponentInstances()
+				.stream()
+				.filter(ci -> ci.getName().equals("m"))
+				.findFirst()
+				.orElseThrow();
+
+		assertEquals(2, middle.getEndToEndFlows().size());
+		assertEquals("e2e_1", middle.getEndToEndFlows().get(0).getName());
+		assertEquals("e2e_2", middle.getEndToEndFlows().get(1).getName());
+		assertEquals(5, middle.getEndToEndFlows().get(0).getFlowElements().size());
+		assertEquals(5, middle.getEndToEndFlows().get(1).getFlowElements().size());
+	}
+}


### PR DESCRIPTION
## Summary

- preserve the declarative connection filter when end-to-end flow instantiation branches over access connection candidates
- restore that filter with the cloned flow instance and iterator stack so each candidate traverses independently
- add regression coverage requiring two correctly named, complete end-to-end flow instances

## Testing

- `mvn -s releng/osate.releng/settings.xml -Plocal verify -Dtest=Issue2984Test -DfailIfNoTests=false -Dpr.build=true -Dtycho.localArtifacts=ignore -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false`
- Result: 1 test run, 0 failures, 0 errors; BUILD SUCCESS

Fixes #2984