### PR TITLE
Finalize forward-referenced nested flows 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
@@ -231,19 +231,7 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 					if (impl != null) {
 						for (EndToEndFlow ete : impl.getAllEndToEndFlows()) {
 							if (!ete2info.containsKey(ete)) {
-								instantiateEndToEndFlow(ci, ete, ete2info);
-								for (EndToEndFlowInstance etei : removeETEI) {
-									ci.getEndToEndFlows().remove(etei);
-									addETEI.remove(etei);
-								}
-								if (addETEI.size() > 1) {
-									resetETECloneCount();
-									for (EndToEndFlowInstance etei : addETEI) {
-										setCloneName(etei);
-									}
-								}
-								removeETEI.clear();
-								addETEI.clear();
+								instantiateAndCleanUpEndToEndFlow(ci, ete, ete2info);
 							}
 						}
 					}
@@ -263,6 +251,23 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 
 	protected void resetETECloneCount() {
 		ETEInstanceCloneCount = 1;
+	}
+
+	private void instantiateAndCleanUpEndToEndFlow(ComponentInstance ci, EndToEndFlow ete,
+			HashMap<EndToEndFlow, List<ETEInfo>> ete2info) {
+		instantiateEndToEndFlow(ci, ete, ete2info);
+		for (EndToEndFlowInstance etei : removeETEI) {
+			ci.getEndToEndFlows().remove(etei);
+			addETEI.remove(etei);
+		}
+		if (addETEI.size() > 1) {
+			resetETECloneCount();
+			for (EndToEndFlowInstance etei : addETEI) {
+				setCloneName(etei);
+			}
+		}
+		removeETEI.clear();
+		addETEI.clear();
 	}
 
 	protected void instantiateEndToEndFlow(ComponentInstance ci, EndToEndFlow ete,
@@ -801,8 +806,8 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 
 		// instantiate the nested ete if that hasn't been done already
 		if (!ete2info.containsKey(ete)) {
-			new CreateEndToEndFlowsSwitch(monitor, getErrorManager(), classifierCache).instantiateEndToEndFlow(ci, ete,
-					ete2info);
+			new CreateEndToEndFlowsSwitch(monitor, getErrorManager(), classifierCache)
+					.instantiateAndCleanUpEndToEndFlow(ci, ete, ete2info);
 		}
 		nestedETEs = ete2info.get(ete);
 

--- a/core/org.osate.core.tests/models/issue2985/.gitignore
+++ b/core/org.osate.core.tests/models/issue2985/.gitignore
@@ -1,0 +1,1 @@
+/.aadlbin-gen/

--- a/core/org.osate.core.tests/models/issue2985/.project
+++ b/core/org.osate.core.tests/models/issue2985/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue2985</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue2985/Issue2985.aadl
+++ b/core/org.osate.core.tests/models/issue2985/Issue2985.aadl
@@ -1,0 +1,50 @@
+package Issue2985
+public
+
+	feature group OutputGroup
+		features
+			a: out data port;
+			b: out data port;
+	end OutputGroup;
+
+	system Producer
+		features
+			o: feature group OutputGroup;
+		flows
+			fsrc: flow source o;
+	end Producer;
+
+	system PathComp
+		features
+			i: feature group inverse of OutputGroup;
+			o: feature group OutputGroup;
+		flows
+			fpath: flow path i -> o;
+	end PathComp;
+
+	system Consumer
+		features
+			i: feature group inverse of OutputGroup;
+		flows
+			fsnk: flow sink i;
+	end Consumer;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			src: system Producer;
+			left: system PathComp;
+			right: system PathComp;
+			snk: system Consumer;
+		connections
+			cin: feature group src.o -> left.i;
+			cmid: feature group left.o -> right.i;
+			cout: feature group right.o -> snk.i;
+		flows
+			parent: end to end flow src.fsrc -> cin -> nested -> cout -> snk.fsnk;
+			nested: end to end flow left.fpath -> cmid -> right.fpath;
+	end Top.i;
+
+end Issue2985;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2985Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2985Test.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.SystemImplementation;
+import org.osate.aadl2.instance.EndToEndFlowInstance;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue2985Test extends XtextTest {
+
+	private static final String FILE = "org.osate.core.tests/models/issue2985/Issue2985.aadl";
+
+	@Inject
+	TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	ValidationTestHelper validationHelper;
+
+	@Test
+	public void testForwardNestedFlowCloneCleanup() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(FILE);
+		validationHelper.assertNoIssues(pkg);
+
+		SystemImplementation top = (SystemImplementation) pkg.getPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(c -> c.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		SystemInstance instance = InstantiateModel.instantiate(top);
+		List<EndToEndFlowInstance> nested = instance.getEndToEndFlows()
+				.stream()
+				.filter(etei -> etei.getEndToEndFlow().getName().equals("nested"))
+				.toList();
+
+		assertTrue(nested.size() > 1);
+		Set<String> names = new HashSet<>();
+		for (EndToEndFlowInstance etei : nested) {
+			assertTrue(names.add(etei.getName()));
+		}
+		assertEquals(nested.size(), names.size());
+	}
+}


### PR DESCRIPTION
## Summary

- route normal and forward-referenced nested flow instantiation through the same finalization path
- remove incomplete instances and assign unique names to retained clones regardless of declaration order
- add regression coverage for a forward-referenced nested flow expanded through feature groups

## Testing

- Before the fix: `Issue2985Test` failed because retained nested flow instances had duplicate names
- After the fix: `mvn -s releng/osate.releng/settings.xml -Plocal verify -Dtest=Issue2985Test -DfailIfNoTests=false -Dpr.build=true -Dtycho.localArtifacts=ignore -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false`
- Result: 1 test run, 0 failures, 0 errors; BUILD SUCCESS

Fixes #2985