### PR TITLE
Match flow connections by declaration 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
@@ -1037,15 +1037,13 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 		boolean match = false;
 
 		while (refIter.hasNext()) {
-			String name1 = refIter.next().getConnection().getName();
-			String name2 = connections.get(0).getName();
-			if (name1.equalsIgnoreCase(name2)) {
+			if (isSameOrRefinedConnection(refIter.next().getConnection(), connections.get(0))) {
 				Iterator<Connection> connIter = connections.iterator();
 
 				connIter.next();
 				match = true;
 				while (match && refIter.hasNext() && connIter.hasNext()) {
-					match &= refIter.next().getConnection().getName().equalsIgnoreCase(connIter.next().getName());
+					match &= isSameOrRefinedConnection(refIter.next().getConnection(), connIter.next());
 				}
 				if (!refIter.hasNext() && connIter.hasNext()) {
 					match = false;
@@ -1091,6 +1089,20 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 			}
 		}
 		return match;
+	}
+
+	private boolean isSameOrRefinedConnection(Connection first, Connection second) {
+		for (Connection connection = first; connection != null; connection = connection.getRefined()) {
+			if (connection == second) {
+				return true;
+			}
+		}
+		for (Connection connection = second; connection != null; connection = connection.getRefined()) {
+			if (connection == first) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private boolean isSameorContains(FeatureInstance flowFeature, FeatureInstance connFeature) {

--- a/core/org.osate.core.tests/models/issue2988/.gitignore
+++ b/core/org.osate.core.tests/models/issue2988/.gitignore
@@ -1,0 +1,1 @@
+/.aadlbin-gen/

--- a/core/org.osate.core.tests/models/issue2988/.project
+++ b/core/org.osate.core.tests/models/issue2988/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue2988</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue2988/Issue2988.aadl
+++ b/core/org.osate.core.tests/models/issue2988/Issue2988.aadl
@@ -1,0 +1,41 @@
+package Issue2988
+public
+
+	system Producer
+		features
+			o: out feature;
+	end Producer;
+
+	system Consumer
+		features
+			i: in feature;
+	end Consumer;
+
+	system Container
+		features
+			i: in feature;
+	end Container;
+
+	system implementation Container.i
+		subcomponents
+			inner: system Consumer;
+		connections
+			c: feature i -> inner.i;
+	end Container.i;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			src: system Producer;
+			wanted: system Consumer;
+			container: system Container.i;
+		connections
+			c: feature src.o -> wanted.i;
+			d: feature src.o -> container.i;
+		flows
+			e2e: end to end flow src -> c -> wanted;
+	end Top.i;
+
+end Issue2988;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2988Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2988Test.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.SystemImplementation;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.aadl2.instance.EndToEndFlowInstance;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue2988Test extends XtextTest {
+
+	private static final String FILE = "org.osate.core.tests/models/issue2988/Issue2988.aadl";
+
+	@Inject
+	TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	ValidationTestHelper validationHelper;
+
+	@Test
+	public void testConnectionsWithSameUnqualifiedName() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(FILE);
+		validationHelper.assertNoIssues(pkg);
+
+		SystemImplementation top = (SystemImplementation) pkg.getPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(c -> c.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		SystemInstance instance = InstantiateModel.instantiate(top);
+
+		assertEquals(1, instance.getEndToEndFlows().size());
+		EndToEndFlowInstance flow = instance.getEndToEndFlows().get(0);
+		assertEquals(3, flow.getFlowElements().size());
+		ComponentInstance destination = (ComponentInstance) flow.getFlowElements().get(2);
+		assertEquals("wanted", destination.getName());
+	}
+}


### PR DESCRIPTION
## Summary

- match end-to-end flow connection segments by declarative model identity instead of unqualified name
- preserve matching between connections related through refinement
- add regression coverage for same-named connections in different component contexts

## Testing

- Before the fix: `Issue2988Test` failed with 2 flow instances instead of 1
- After the fix: `mvn -s releng/osate.releng/settings.xml -Plocal verify -Dtest=Issue2988Test -DfailIfNoTests=false -Dpr.build=true -Dtycho.localArtifacts=ignore -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false`
- Result: 1 test run, 0 failures, 0 errors; BUILD SUCCESS

Fixes #2988