### PR TITLE
Match nested end-to-end flow path variants 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
@@ -865,8 +865,22 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 						+ ": Missing connection instance to " + ((NamedElement) ete).getName());
 				connections.clear();
 			} else {
-				Iterator<ConnectionInstance> connIter = connis.iterator();
+				int compatibleCount = 0;
+				for (ConnectionInstance conni : connis) {
+					for (ETEInfo nested : nestedETEs) {
+						if (containsConnectionPath(conni, nested.preConns)) {
+							compatibleCount++;
+						}
+					}
+				}
+				if (compatibleCount == 0) {
+					error(etei, "Incomplete end-to-end flow instance " + etei.getName()
+							+ ": No compatible nested end to end flow instance for " + ete.getName());
+					connections.clear();
+					return;
+				}
 
+				Iterator<ConnectionInstance> connIter = connis.iterator();
 				state.push(iter);
 				while (connIter.hasNext()) {
 					EndToEndFlowInstance eteiClone = null;
@@ -876,7 +890,10 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 
 					while (nestedIter.hasNext()) {
 						ETEInfo nested = nestedIter.next();
-						boolean prepareNext = nestedIter.hasNext() || connIter.hasNext();
+						if (!containsConnectionPath(conni, nested.preConns)) {
+							continue;
+						}
+						boolean prepareNext = --compatibleCount > 0;
 
 						if (prepareNext) {
 							stateClone = clone(state);
@@ -917,6 +934,25 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 				}
 			}
 		}
+	}
+
+	private static boolean containsConnectionPath(ConnectionInstance connectionInstance,
+			List<Connection> connectionPath) {
+		if (connectionPath.isEmpty()) {
+			return true;
+		}
+
+		EList<ConnectionReference> references = connectionInstance.getConnectionReferences();
+		for (int start = 0; start <= references.size() - connectionPath.size(); start++) {
+			boolean match = true;
+			for (int offset = 0; match && offset < connectionPath.size(); offset++) {
+				match = references.get(start + offset).getConnection() == connectionPath.get(offset);
+			}
+			if (match) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private void addNestedETE(EndToEndFlowInstance etei, ETEInfo nested) {

--- a/core/org.osate.core.tests/models/issue2986/.gitignore
+++ b/core/org.osate.core.tests/models/issue2986/.gitignore
@@ -1,0 +1,1 @@
+/.aadlbin-gen/

--- a/core/org.osate.core.tests/models/issue2986/.project
+++ b/core/org.osate.core.tests/models/issue2986/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue2986</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue2986/Issue2986.aadl
+++ b/core/org.osate.core.tests/models/issue2986/Issue2986.aadl
@@ -1,0 +1,49 @@
+package Issue2986
+public
+
+	system Endpoint
+		features
+			i: in data port;
+			o: out data port;
+		flows
+			fsrc: flow source o;
+			fsnk: flow sink i;
+			fpath: flow path i -> o;
+	end Endpoint;
+
+	system Middle extends Endpoint
+	end Middle;
+
+	system implementation Middle.i
+		subcomponents
+			one: system Endpoint;
+			two: system Endpoint;
+		connections
+			in1: port i -> one.i;
+			out1: port one.o -> o;
+			in2: port i -> two.i;
+			out2: port two.o -> o;
+		flows
+			fpath: flow path i -> in1 -> one.fpath -> out1 -> o;
+			fpath: flow path i -> in2 -> two.fpath -> out2 -> o;
+	end Middle.i;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			src: system Endpoint;
+			middle: system Middle.i;
+			right: system Endpoint;
+			snk: system Endpoint;
+		connections
+			cin: port src.o -> middle.i;
+			cmid: port middle.o -> right.i;
+			cout: port right.o -> snk.i;
+		flows
+			nested: end to end flow middle.fpath -> cmid -> right.fpath;
+			parent: end to end flow src.fsrc -> cin -> nested -> cout -> snk.fsnk;
+	end Top.i;
+
+end Issue2986;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2986Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2986Test.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.SystemImplementation;
+import org.osate.aadl2.instance.ConnectionInstance;
+import org.osate.aadl2.instance.EndToEndFlowInstance;
+import org.osate.aadl2.instance.FlowSpecificationInstance;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue2986Test extends XtextTest {
+
+	private static final String FILE = "org.osate.core.tests/models/issue2986/Issue2986.aadl";
+
+	@Inject
+	TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	ValidationTestHelper validationHelper;
+
+	@Test
+	public void testNestedFlowPrefixConnections() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(FILE);
+		validationHelper.assertNoIssues(pkg);
+
+		SystemImplementation top = (SystemImplementation) pkg.getPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(c -> c.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		SystemInstance instance = InstantiateModel.instantiate(top);
+		List<EndToEndFlowInstance> parents = instance.getEndToEndFlows()
+				.stream()
+				.filter(etei -> etei.getEndToEndFlow().getName().equals("parent"))
+				.toList();
+
+		assertEquals(2, parents.size());
+		for (EndToEndFlowInstance parent : parents) {
+			ConnectionInstance incoming = (ConnectionInstance) parent.getFlowElements().get(1);
+			EndToEndFlowInstance nested = (EndToEndFlowInstance) parent.getFlowElements().get(2);
+			FlowSpecificationInstance nestedStart = (FlowSpecificationInstance) nested.getFlowElements().get(0);
+			assertSame(incoming.getDestination().getComponentInstance(), nestedStart.getComponentInstance());
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- pair incoming semantic connections only with nested end-to-end flow variants whose recorded prefix connections occur on the semantic path
- create clones only for compatible connection and nested-flow pairs
- add a regression model with two incoming paths and two corresponding nested variants

## Testing

- focused end-to-end-flow regressions: 3 tests passed
- complete org.osate.core.tests bundle: 541 tests passed

Fixes #2986