### PR TITLE
Reject cyclic nested end-to-end flows 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
@@ -188,6 +188,8 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 	private List<ETEInfo> created;
 
 	private HashMap<EndToEndFlow, List<ETEInfo>> ete2info;
+	private final List<EndToEndFlow> activeEndToEndFlows;
+	private final Set<EndToEndFlow> failedEndToEndFlows;
 
 	/**
 	 * The last flow implementation to match connection start
@@ -206,8 +208,16 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 	 */
 	public CreateEndToEndFlowsSwitch(final IProgressMonitor pm, final AnalysisErrorReporterManager errMgr,
 			HashMap<InstanceObject, InstantiatedClassifier> classifierCache) {
+		this(pm, errMgr, classifierCache, new ArrayList<>(), new HashSet<>());
+	}
+
+	private CreateEndToEndFlowsSwitch(final IProgressMonitor pm, final AnalysisErrorReporterManager errMgr,
+			HashMap<InstanceObject, InstantiatedClassifier> classifierCache,
+			List<EndToEndFlow> activeEndToEndFlows, Set<EndToEndFlow> failedEndToEndFlows) {
 		super(pm, PROCESS_PRE_ORDER_ALL, errMgr);
 		this.classifierCache = classifierCache;
+		this.activeEndToEndFlows = activeEndToEndFlows;
+		this.failedEndToEndFlows = failedEndToEndFlows;
 	}
 
 	@Override
@@ -249,6 +259,8 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 					}
 				} finally {
 					ete2info.clear();
+					activeEndToEndFlows.clear();
+					failedEndToEndFlows.clear();
 				}
 				return DONE;
 			}
@@ -281,8 +293,22 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 		EList<EList<ModeInstance>> ml = etei.getModesList();
 		ml.clear();
 		ml.add(getModeInstances(ci, ete));
-		processETE(ci, etei, ete);
-		ml.clear();
+		activeEndToEndFlows.add(ete);
+		try {
+			processETE(ci, etei, ete);
+		} finally {
+			activeEndToEndFlows.remove(activeEndToEndFlows.size() - 1);
+			ml.clear();
+			if (failedEndToEndFlows.contains(ete)) {
+				for (ETEInfo info : created) {
+					ci.getEndToEndFlows().remove(info.etei);
+					addETEI.remove(info.etei);
+					removeETEI.remove(info.etei);
+					completedETEI.remove(info.etei);
+				}
+				created.clear();
+			}
+		}
 	}
 
 	protected void processETE(final ComponentInstance ci, final EndToEndFlowInstance etei, final EndToEndFlow ete) {
@@ -793,16 +819,28 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 	 * @param ete
 	 * @param iter
 	 */
-	// TODO-LW: Detect cyclic dependencies between ETEs
 	// add preConn before addNested
 	private void processEndToEndFlow(ComponentInstance ci, EndToEndFlowInstance etei, EndToEndFlow ete,
 			FlowIterator iter) {
 		List<ETEInfo> nestedETEs;
 
+		int cycleStart = activeEndToEndFlows.indexOf(ete);
+		if (cycleStart >= 0) {
+			failedEndToEndFlows.addAll(activeEndToEndFlows.subList(cycleStart, activeEndToEndFlows.size()));
+			error(etei, "Cyclic dependency between end to end flows involving " + ete.getQualifiedName());
+			connections.clear();
+			return;
+		}
+
 		// instantiate the nested ete if that hasn't been done already
 		if (!ete2info.containsKey(ete)) {
-			new CreateEndToEndFlowsSwitch(monitor, getErrorManager(), classifierCache).instantiateEndToEndFlow(ci, ete,
-					ete2info);
+			new CreateEndToEndFlowsSwitch(monitor, getErrorManager(), classifierCache, activeEndToEndFlows,
+					failedEndToEndFlows).instantiateEndToEndFlow(ci, ete, ete2info);
+		}
+		if (failedEndToEndFlows.contains(ete)) {
+			failedEndToEndFlows.add(etei.getEndToEndFlow());
+			connections.clear();
+			return;
 		}
 		nestedETEs = ete2info.get(ete);
 

--- a/core/org.osate.core.tests/models/issue2987/.gitignore
+++ b/core/org.osate.core.tests/models/issue2987/.gitignore
@@ -1,0 +1,1 @@
+/.aadlbin-gen/

--- a/core/org.osate.core.tests/models/issue2987/.project
+++ b/core/org.osate.core.tests/models/issue2987/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue2987</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue2987/Issue2987.aadl
+++ b/core/org.osate.core.tests/models/issue2987/Issue2987.aadl
@@ -1,0 +1,26 @@
+package Issue2987
+public
+
+	system Node
+		features
+			i: in data port;
+			o: out data port;
+		flows
+			fpath: flow path i -> o;
+	end Node;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			n: system Node;
+		connections
+			loop: port n.o -> n.i;
+		flows
+			a: end to end flow n.fpath -> loop -> b;
+			b: end to end flow n.fpath -> loop -> a;
+			outer: end to end flow a -> loop -> n.fpath;
+	end Top.i;
+
+end Issue2987;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2987Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2987Test.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertFalse;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.SystemImplementation;
+import org.osate.aadl2.instance.EndToEndFlowInstance;
+import org.osate.aadl2.instance.FlowElementInstance;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue2987Test extends XtextTest {
+
+	private static final String FILE = "org.osate.core.tests/models/issue2987/Issue2987.aadl";
+
+	@Inject
+	TestHelper<AadlPackage> testHelper;
+
+	@Test(timeout = 30_000)
+	public void testCyclicNestedFlows() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(FILE);
+		SystemImplementation top = (SystemImplementation) pkg.getPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(c -> c.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+
+		SystemInstance instance = InstantiateModel.instantiate(top);
+		for (EndToEndFlowInstance etei : instance.getEndToEndFlows()) {
+			Set<EndToEndFlowInstance> path = Collections.newSetFromMap(new IdentityHashMap<>());
+			assertFalse(hasNestedCycle(etei, path));
+		}
+	}
+
+	private static boolean hasNestedCycle(EndToEndFlowInstance etei, Set<EndToEndFlowInstance> path) {
+		if (!path.add(etei)) {
+			return true;
+		}
+		for (FlowElementInstance element : etei.getFlowElements()) {
+			if (element instanceof EndToEndFlowInstance nested && hasNestedCycle(nested, path)) {
+				return true;
+			}
+		}
+		path.remove(etei);
+		return false;
+	}
+}


### PR DESCRIPTION
## Summary

- track active end-to-end flow declarations across recursive nested-flow instantiation
- detect back-references, report a cycle, and propagate failure to dependent flows
- remove partial instances so cyclic or incomplete instance graphs are not retained
- guard the regression with a 30-second timeout against unbounded recursion

## Testing

- before the fix, Issue2987Test timed out after 30 seconds
- after the fix, the timeout-guarded regression completed in about 3 seconds
- focused end-to-end-flow regressions: 3 tests passed
- complete org.osate.core.tests bundle: 541 tests passed

Fixes #2987