### PR TITLE
Match flow paths in their declared context 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
@@ -511,7 +511,7 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 					if ((flowFilter == null || isValidContinuation(etei, flowFilter, ciToCheck))
 							&& (nextFlowImpl == null
 									? (leaf instanceof FlowSpecification
-											? isValidContinuation(etei, ciToCheck, (FlowSpecification) leaf)
+											? isValidContinuation(ci, ciToCheck, (FlowSpecification) leaf)
 											: true)
 									: isValidContinuation(etei, ciToCheck, nextFlowImpl))) {
 						connectionsToUse.add(ciToCheck);
@@ -630,18 +630,17 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 	 * There are three cases
 	 * - same feature instance
 	 * - connection end is a feature instance contained in the flow spec src feature instance
-	 * - sonnection end is a feature in an array and the flow spec src is the array without index
+	 * - connection end is a feature in an array and the flow spec src is the array without index
 	 *
-	 * @param etei
+	 * @param flowComponent
 	 * @param conni
 	 * @param fspec
 	 * @return
 	 */
-	boolean isValidContinuation(EndToEndFlowInstance etei, ConnectionInstance conni, FlowSpecification fspec) {
+	boolean isValidContinuation(ComponentInstance flowComponent, ConnectionInstance conni, FlowSpecification fspec) {
 		ConnectionInstanceEnd cie = conni.getDestination();
 		if (cie instanceof FeatureInstance conniFi) {
-			ComponentInstance ci = conniFi.getContainingComponentInstance();
-			FlowSpecificationInstance fsi = ci.findFlowSpecInstance(fspec);
+			FlowSpecificationInstance fsi = flowComponent.findFlowSpecInstance(fspec);
 			if (fsi != null) {
 				FeatureInstance fsSrcFi = fsi.getSource();
 				EObject e = conniFi;

--- a/core/org.osate.core.tests/models/issue2606/.gitignore
+++ b/core/org.osate.core.tests/models/issue2606/.gitignore
@@ -1,0 +1,1 @@
+/.aadlbin-gen/

--- a/core/org.osate.core.tests/models/issue2606/.project
+++ b/core/org.osate.core.tests/models/issue2606/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue2606</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue2606/Issue2606.aadl
+++ b/core/org.osate.core.tests/models/issue2606/Issue2606.aadl
@@ -1,0 +1,48 @@
+package Issue2606
+public
+
+	system S
+	end S;
+
+	system implementation S.i
+		subcomponents
+			l: system L;
+			m: system M.i;
+			r: system R;
+		connections
+			lm: feature l.o -> m.i;
+			mr: feature m.o -> r.i;
+		flows
+			ee: end to end flow l.src -> lm -> m.pth -> mr -> r.snk;
+	end S.i;
+
+	system L
+		features
+			o: out feature;
+		flows
+			src: flow source o;
+	end L;
+
+	system M
+		features
+			i: in feature;
+			o: out feature;
+		flows
+			pth: flow path i -> o;
+	end M;
+
+	system implementation M.i
+		subcomponents
+			mm: system M;
+		connections
+			imm: feature i -> mm.i;
+	end M.i;
+
+	system R
+		features
+			i: in feature;
+		flows
+			snk: flow sink i;
+	end R;
+
+end Issue2606;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2606Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2606Test.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.SystemImplementation;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter.Message;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue2606Test extends XtextTest {
+
+	private static final String FILE = "org.osate.core.tests/models/issue2606/Issue2606.aadl";
+
+	@Inject
+	TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	ValidationTestHelper validationHelper;
+
+	@Test
+	public void testDisconnectedFlowPathIsRejected() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(FILE);
+		validationHelper.assertNoIssues(pkg);
+
+		SystemImplementation implementation = (SystemImplementation) pkg.getPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(c -> c.getName().equals("S.i"))
+				.findFirst()
+				.orElseThrow();
+		AnalysisErrorReporterManager errorManager = new AnalysisErrorReporterManager(
+				QueuingAnalysisErrorReporter.factory);
+
+		SystemInstance instance = InstantiateModel.instantiate(implementation, errorManager);
+
+		assertTrue(instance.getEndToEndFlows().isEmpty());
+		List<Message> messages = ((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource()))
+				.getErrors();
+		assertEquals(1, messages.size());
+		Message message = messages.get(0);
+		assertEquals(QueuingAnalysisErrorReporter.ERROR, message.kind);
+		assertEquals("Cannot create end to end flow 'ee' because there are no semantic connections that connect to "
+				+ "the start of the flow 'pth' at feature 'i'", message.message);
+	}
+}


### PR DESCRIPTION
## Summary

- resolve flow specification continuations in the component named by the end-to-end flow segment
- reject semantic connections that bypass the declared flow path through a nested component
- omit invalid end-to-end flow instances and report the existing missing-continuation diagnostic
- add a regression model and test for issue #2606

## Testing

- before the fix, Issue2606Test failed because the invalid end-to-end flow was retained
- Issue2606Test: 1 test passed
- focused flow-instantiation regressions: 20 tests passed
- complete org.osate.core.tests plug-in: 541 tests passed

Fixes #2606