### PR TITLE
Abort invalid end-to-end flow branches 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
@@ -181,6 +181,7 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 	private List<Connection> connections = new ArrayList<Connection>();
 	private List<EndToEndFlowInstance> removeETEI = new ArrayList<EndToEndFlowInstance>();
 	private List<EndToEndFlowInstance> addETEI = new ArrayList<EndToEndFlowInstance>();
+	private final Set<EndToEndFlowInstance> abortedETEI = new HashSet<>();
 
 	/**
 	 * All end to end flow instances created for an end to end flow.
@@ -244,6 +245,7 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 								}
 								removeETEI.clear();
 								addETEI.clear();
+								abortedETEI.clear();
 							}
 						}
 					}
@@ -475,7 +477,11 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 			FlowImplementation nextFlowImpl, FlowIterator iter) {
 		// add connection(s), will be empty when starting the ETE
 		if (connections.isEmpty()) {
-			addLeafElement(ci, etei, leaf);
+			if (!addLeafElement(ci, etei, leaf)) {
+				removeETEI.add(etei);
+				abortedETEI.add(etei);
+				return;
+			}
 			lastFlowImpl.push(nextFlowImpl);
 			continueFlow(ci.getContainingComponentInstance(), etei, iter, ci);
 			lastFlowImpl.pop();
@@ -561,30 +567,34 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 						}
 
 						etei.getFlowElements().add(conni);
-						addLeafElement(ci, etei, leaf);
+						if (addLeafElement(ci, etei, leaf)) {
+							// prepare next connection filter
+							connections.clear();
+							if (iter.hasNext()) {
+								Element obj = iter.next();
+								Connection conn = null;
+								if (obj instanceof FlowSegment) {
+									FlowElement fe = ((FlowSegment) obj).getFlowElement();
+									if (fe instanceof Connection) {
+										conn = (Connection) fe;
+									}
+								} else if (obj instanceof EndToEndFlowSegment) {
+									EndToEndFlowElement fe = ((EndToEndFlowSegment) obj).getFlowElement();
+									if (fe instanceof Connection) {
+										conn = (Connection) fe;
+									}
+								}
+								if (conn != null) {
+									connections.add(conn);
+								}
+							}
 
-						// prepare next connection filter
-						connections.clear();
-						if (iter.hasNext()) {
-							Element obj = iter.next();
-							Connection conn = null;
-							if (obj instanceof FlowSegment) {
-								FlowElement fe = ((FlowSegment) obj).getFlowElement();
-								if (fe instanceof Connection) {
-									conn = (Connection) fe;
-								}
-							} else if (obj instanceof EndToEndFlowSegment) {
-								EndToEndFlowElement fe = ((EndToEndFlowSegment) obj).getFlowElement();
-								if (fe instanceof Connection) {
-									conn = (Connection) fe;
-								}
-							}
-							if (conn != null) {
-								connections.add(conn);
-							}
+							continueFlow(ci.getContainingComponentInstance(), etei, iter, ci);
+						} else {
+							connections.clear();
+							removeETEI.add(etei);
+							abortedETEI.add(etei);
 						}
-
-						continueFlow(ci.getContainingComponentInstance(), etei, iter, ci);
 
 						lastFlowImpl.pop();
 
@@ -927,8 +937,9 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 	 * @param ci
 	 * @param etei
 	 * @param leaf
+	 * @return whether the leaf was added successfully
 	 */
-	private void addLeafElement(ComponentInstance ci, EndToEndFlowInstance etei, Element leaf) {
+	private boolean addLeafElement(ComponentInstance ci, EndToEndFlowInstance etei, Element leaf) {
 		FlowSpecification fs;
 		FlowSpecificationInstance fsi;
 		if (leaf instanceof FlowSpecification || leaf instanceof FlowImplementation) {
@@ -943,8 +954,9 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 			if (fsi != null) {
 				etei.getFlowElements().add(fsi);
 			} else if (fs != null) {
-				error(etei, "Incomplete end-to-end flow instance " + etei.getName() + ": Could not find flow spec "
-						+ fs.getName() + " of component " + ci.getName());
+				error(etei.getContainingComponentInstance(), "Incomplete end-to-end flow instance " + etei.getName()
+						+ ": Could not find flow spec " + fs.getName() + " of component " + ci.getName());
+				return false;
 			}
 		} else if (leaf instanceof Subcomponent) {
 			if (etei.getFlowElements().size() == 0) {
@@ -959,16 +971,15 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 					// append a subcomponent instance
 					etei.getFlowElements().add(ci);
 				} else {
-					error(etei,
+					error(etei.getContainingComponentInstance(),
 							"Invalid end-to-end flow instance " + etei.getName() + ": Connection "
 									+ preConn.getComponentInstancePath() + " continues into component "
 									+ ci.getInstanceObjectPath());
-					// append a subcomponent instance
-					// FIXME: should abort
-					etei.getFlowElements().add(ci);
+					return false;
 				}
 			}
 		}
+		return true;
 	}
 
 	private void continueFlow(ComponentInstance ci, EndToEndFlowInstance etei, FlowIterator iter,
@@ -982,6 +993,9 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 			while (iter.hasNext()) {
 				Element e = iter.next();
 				processETESegment(ci, etei, e, iter, errorElement);
+				if (abortedETEI.contains(etei)) {
+					return;
+				}
 			}
 			if (state.size() == 0) {
 				if (!completedETEI.contains(etei)) {

--- a/core/org.osate.core.tests/models/issue612/.gitignore
+++ b/core/org.osate.core.tests/models/issue612/.gitignore
@@ -1,0 +1,1 @@
+/.aadlbin-gen/

--- a/core/org.osate.core.tests/models/issue612/.project
+++ b/core/org.osate.core.tests/models/issue612/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue612</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue612/Issue612.aadl
+++ b/core/org.osate.core.tests/models/issue612/Issue612.aadl
@@ -1,0 +1,67 @@
+package Issue612
+public
+
+	data D
+	end D;
+
+	system Producer
+		features
+			output: out data port D;
+		flows
+			flow_source: flow source output;
+	end Producer;
+
+	system Consumer
+		features
+			input: in data port D;
+		flows
+			flow_sink: flow sink input;
+	end Consumer;
+
+	system Outer
+	end Outer;
+
+	system implementation Outer.i
+		subcomponents
+			src: system Producer;
+			inner: system Inner.i;
+			snk: system Consumer;
+		connections
+			c1: port src.output -> inner.input;
+			c2: port inner.output -> snk.input;
+		flows
+			invalid: end to end flow src.flow_source -> c1 -> inner -> c2 -> snk.flow_sink;
+			valid: end to end flow src.flow_source -> c1 -> inner.fpath -> c2 -> snk.flow_sink;
+	end Outer.i;
+
+	system Inner
+		features
+			input: in data port D;
+			output: out data port D;
+		flows
+			fpath: flow path input -> output;
+	end Inner;
+
+	system implementation Inner.i
+		subcomponents
+			left: system Leaf;
+			right: system Leaf;
+		connections
+			in_left: port input -> left.input;
+			out_left: port left.output -> output;
+			in_right: port input -> right.input;
+			out_right: port right.output -> output;
+		flows
+			fpath: flow path input -> in_left -> left.fpath -> out_left -> output;
+			fpath: flow path input -> in_right -> right.fpath -> out_right -> output;
+	end Inner.i;
+
+	system Leaf
+		features
+			input: in data port D;
+			output: out data port D;
+		flows
+			fpath: flow path input -> output;
+	end Leaf;
+
+end Issue612;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2780Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2780Test.java
@@ -95,7 +95,10 @@ public class Issue2780Test extends XtextTest {
 				QueuingAnalysisErrorReporter.factory);
 		SystemInstance instance = InstantiateModel.instantiate(s_i, errorManager);
 		assertEquals("S1_i_Instance", instance.getName());
-		assertEquals(6, instance.getEndToEndFlows().size());
+		assertEquals(List.of("e2e3", "e2e4", "e2e5"), instance.getEndToEndFlows()
+				.stream()
+				.map(etei -> etei.getName())
+				.toList());
 
 		List<Message> messages = ((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource()))
 				.getErrors();

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue612Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue612Test.java
@@ -74,7 +74,10 @@ public class Issue612Test extends XtextTest {
 
 		assertEquals(List.of("valid_1", "valid_2"), flowNames);
 		List<Message> messages = ((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource()))
-				.getErrors();
+				.getErrors()
+				.stream()
+				.filter(msg -> msg.message.startsWith("Invalid end-to-end flow instance invalid"))
+				.toList();
 		assertEquals(2, messages.size());
 		assertEquals(QueuingAnalysisErrorReporter.ERROR, messages.get(0).kind);
 		assertEquals(QueuingAnalysisErrorReporter.ERROR, messages.get(1).kind);

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue612Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue612Test.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.SystemImplementation;
+import org.osate.aadl2.instance.EndToEndFlowInstance;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter.Message;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue612Test extends XtextTest {
+
+	private static final String FILE = "org.osate.core.tests/models/issue612/Issue612.aadl";
+
+	@Inject
+	TestHelper<AadlPackage> testHelper;
+
+	@Test
+	public void testInvalidFlowBranchesAreDiscarded() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(FILE);
+		SystemImplementation outer = (SystemImplementation) pkg.getPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(c -> c.getName().equals("Outer.i"))
+				.findFirst()
+				.orElseThrow();
+		AnalysisErrorReporterManager errorManager = new AnalysisErrorReporterManager(
+				QueuingAnalysisErrorReporter.factory);
+
+		SystemInstance instance = InstantiateModel.instantiate(outer, errorManager);
+		List<String> flowNames = instance.getEndToEndFlows()
+				.stream()
+				.map(EndToEndFlowInstance::getName)
+				.toList();
+
+		assertEquals(List.of("valid_1", "valid_2"), flowNames);
+		List<Message> messages = ((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource()))
+				.getErrors();
+		assertEquals(2, messages.size());
+		assertEquals(QueuingAnalysisErrorReporter.ERROR, messages.get(0).kind);
+		assertEquals(QueuingAnalysisErrorReporter.ERROR, messages.get(1).kind);
+	}
+}


### PR DESCRIPTION
## Summary

- propagate leaf-instantiation failures through active end-to-end flow continuations
- discard invalid candidate instances without affecting sibling semantic paths
- continue with later valid end-to-end flow declarations
- preserve rejection diagnostics on the containing component
- add regression coverage for the original branching case and feature-group depth variants

## Testing

- before fix: `Issue612Test` retained 4 invalid instances and `Issue2780Test` retained 3 invalid instances
- focused issue regressions: 3 passed
- nearby flow-instantiation regressions: 22 passed
- complete `org.osate.core.tests` plug-in: 541 passed

Fixes #612