### PR TITLE
Report missing flow implementations during instantiation 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
@@ -368,10 +368,13 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 
 		if (flowImpls.isEmpty()) {
 			// we are at a leaf
+			int errorsBefore = getErrorManager().getNumErrors();
 			processFlowStep(ci, etei, fs, iter);
-			if (subImpl != null && AadlUtil.hasPortComponents(subImpl)) {
-				warning(etei, "End-to-end flow " + etei.getName() + " contains component " + ci.getName()
-						+ " with subcomponents, but no flow implementation " + fs.getName() + " to them");
+			if (subImpl != null && AadlUtil.hasPortComponents(subImpl)
+					&& getErrorManager().getNumErrors() == errorsBefore) {
+				error(etei.getContainingComponentInstance(), "Cannot create end to end flow '" + etei.getName()
+						+ "' because component '" + ci.getName()
+						+ "' has subcomponents but no flow implementation for flow '" + fs.getName() + "'");
 			}
 		} else {
 			Iterator<FlowImplementation> itt = flowImpls.iterator();

--- a/core/org.osate.core.tests/models/issue2872/.gitignore
+++ b/core/org.osate.core.tests/models/issue2872/.gitignore
@@ -1,0 +1,1 @@
+/.aadlbin-gen/

--- a/core/org.osate.core.tests/models/issue2872/.project
+++ b/core/org.osate.core.tests/models/issue2872/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue2872</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue2872/Issue2872.aadl
+++ b/core/org.osate.core.tests/models/issue2872/Issue2872.aadl
@@ -1,0 +1,45 @@
+package flowdemo
+public
+	system integration
+	end integration;
+
+	system implementation integration.impl
+		subcomponents
+			a : system example.impl;
+			b : system example.impl;
+		connections
+			ab : feature a.outy -> b.inny;
+		flows
+			fab : end to end flow a.fouty -> ab -> b.finny;
+	end integration.impl;
+
+	system example
+		features
+			outy: feature group;
+			inny: feature group;
+		flows
+			fouty: flow source outy;
+			finny: flow sink inny;
+	end example;
+
+	system implementation example.impl
+		subcomponents
+			a : process ex_proc.impl;
+			b : process ex_proc.impl;
+		connections
+			couty: feature a.outy <-> outy;
+			cinny: feature inny -> b.inny;
+	end example.impl;
+
+	process ex_proc
+		features
+			outy: feature group;
+			inny: feature group;
+		flows
+			fouty: flow source outy;
+			finny: flow sink inny;
+	end ex_proc;
+
+	process implementation ex_proc.impl
+	end ex_proc.impl;
+end flowdemo;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2872Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2872Test.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.SystemImplementation;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter.Message;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue2872Test extends XtextTest {
+	private static final String FILE = "org.osate.core.tests/models/issue2872/Issue2872.aadl";
+
+	@Inject
+	TestHelper<AadlPackage> testHelper;
+
+	@Test
+	public void testMissingFlowImplementationIsReported() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(FILE);
+		SystemImplementation integration = (SystemImplementation) pkg.getPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(c -> c.getName().equals("integration.impl"))
+				.findFirst()
+				.orElseThrow();
+		AnalysisErrorReporterManager errorManager = new AnalysisErrorReporterManager(
+				QueuingAnalysisErrorReporter.factory);
+
+		SystemInstance instance = InstantiateModel.instantiate(integration, errorManager);
+
+		assertTrue(instance.getEndToEndFlows().isEmpty());
+		List<Message> messages = ((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource()))
+				.getErrors()
+				.stream()
+				.filter(message -> message.message.startsWith("Cannot create end to end flow 'fab'"))
+				.toList();
+		assertEquals(1, messages.size());
+		assertEquals(QueuingAnalysisErrorReporter.ERROR, messages.get(0).kind);
+		assertEquals("Cannot create end to end flow 'fab' because component 'b' has subcomponents but no flow "
+				+ "implementation for flow 'finny'", messages.get(0).message);
+	}
+}


### PR DESCRIPTION
## Summary

- preserve missing-flow-implementation diagnostics after incomplete end-to-end flow instances are discarded
- report the condition as an error on the containing component
- avoid duplicate diagnostics when continuation already reports a more specific failure
- add regression coverage using the original issue model

## Testing

- before fix: `Issue2872Test` failed because the flow was omitted with zero error-level diagnostics
- focused and nearby flow-instantiation regressions: 21 passed
- complete `org.osate.core.tests` plug-in: 541 passed

Fixes #2872