### PR TITLE
Attach connection diagnostics to connection ends 🤖

### DIFF
--- a/core/org.osate.core.tests/src/org/osate/core/tests/aadl2javavalidator/ConnectionAndFlowTypesTest.xtend
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/aadl2javavalidator/ConnectionAndFlowTypesTest.xtend
@@ -1689,7 +1689,7 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"fconn2".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "A 'data subcomponent' is not a valid feature connection end.")
-				assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+				destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(2) => [
 					"fconn3".assertEquals(name)
@@ -1700,33 +1700,33 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"fconn4".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "A 'subprogram subcomponent' is not a valid feature connection end.")
-				assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
+				destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
 				]
 				ownedFeatureConnections.get(4) => [
 					"fconn5".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "A 'subprogram proxy' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
 				]
 				ownedFeatureConnections.get(8) => [
 					"fconn9".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::fgt1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::fgt1'")
 				]
 				ownedFeatureConnections.get(10) => [
 					"fconn11".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(12) => [
 					"fconn13".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::a1.i'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::a1.i'")
 				]
 				ownedFeatureConnections.get(13) => [
 					"fconn14".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::a1.i'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::a1.i'")
 				]
 				ownedFeatureConnections.get(14) => [
 					"fconn15".assertEquals(name)
@@ -1737,7 +1737,7 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"fconn16".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "Anything in a 'data port' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(16) => [
 					"fconn17".assertEquals(name)
@@ -1748,13 +1748,13 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"fconn18".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "Anything in a 'data port' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
 				]
 				ownedFeatureConnections.get(18) => [
 					"fconn19".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "Anything in a 'data port' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
 				]
 				ownedFeatureConnections.get(19) => [
 					"fconn20".assertEquals(name)
@@ -1785,7 +1785,7 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"fconn25".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "Anything in a 'data port' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(25) => [
 					"fconn26".assertEquals(name)
@@ -1796,13 +1796,13 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"fconn27".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "Anything in a 'data port' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(27) => [
 					"fconn28".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "Anything in a 'data port' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(28) => [
 					"fconn29".assertEquals(name)
@@ -1813,7 +1813,7 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"fconn30".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "Anything in an 'event data port' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(30) => [
 					"fconn31".assertEquals(name)
@@ -1824,13 +1824,13 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"fconn32".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "Anything in an 'event data port' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
 				]
 				ownedFeatureConnections.get(32) => [
 					"fconn33".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "Anything in an 'event data port' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
 				]
 				ownedFeatureConnections.get(33) => [
 					"fconn34".assertEquals(name)
@@ -1861,7 +1861,7 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"fconn39".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "Anything in an 'event data port' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(39) => [
 					"fconn40".assertEquals(name)
@@ -1872,33 +1872,33 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"fconn41".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "Anything in an 'event data port' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(41) => [
 					"fconn42".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "Anything in an 'event data port' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(44) => [
 					"fconn45".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(46) => [
 					"fconn47".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(48) => [
 					"fconn49".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(49) => [
 					"fconn50".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(50) => [
 					"fconn51".assertEquals(name)
@@ -1909,7 +1909,7 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"fconn52".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "A 'data subcomponent' in an 'abstract subcomponent' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(52) => [
 					"fconn53".assertEquals(name)
@@ -1920,13 +1920,13 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"fconn54".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "A 'subprogram subcomponent' in an 'abstract subcomponent' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
 				]
 				ownedFeatureConnections.get(54) => [
 					"fconn55".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "A 'subprogram proxy' in an 'abstract subcomponent' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
 				]
 				ownedFeatureConnections.get(55) => [
 					"fconn56".assertEquals(name)
@@ -1943,40 +1943,40 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"fconn60".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "A 'parameter' in a 'subprogram subcomponent' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::a1.i'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::a1.i'")
 				]
 				ownedFeatureConnections.get(61) => [
 					"fconn62".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(63) => [
 					"fconn64".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(64) => [
 					"fconn65".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(65) => [
 					"fconn66".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "A 'data subcomponent' in a 'subprogram call' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(66) => [
 					"fconn67".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "A 'subprogram subcomponent' in a 'subprogram call' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
 				]
 				ownedFeatureConnections.get(67) => [
 					"fconn68".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "A 'subprogram proxy' in a 'subprogram call' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
 				]
 				ownedFeatureConnections.get(68) => [
 					"fconn69".assertEquals(name)
@@ -1991,17 +1991,17 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 				ownedFeatureConnections.get(72) => [
 					"fconn73".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::a1.i'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::a1.i'")
 				]
 				ownedFeatureConnections.get(73) => [
 					"fconn74".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
 				]
 				ownedFeatureConnections.get(74) => [
 					"fconn75".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureGroupConnections.get(0) => [
 					"fgconn1".assertEquals(name)
@@ -2726,12 +2726,12 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 				ownedPortConnections.get(5) => [
 					"portconn6".assertEquals(name)
 					//Tests typeCheckPortConnectionEnd
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'pp1' to have classifier 'legalTypeTest::d1'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'pp1' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedPortConnections.get(6) => [
 					"portconn7".assertEquals(name)
 					//Tests typeCheckPortConnectionEnd
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'eds1' to have classifier 'legalTypeTest::d1'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'eds1' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedPortConnections.get(7) => [
 					"portconn8".assertEquals(name)
@@ -2776,13 +2776,13 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"portconn20".assertEquals(name)
 					//Tests typeCheckPortConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "A 'port proxy' in a 'data port' is not a valid port connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'pp3' to have classifier 'legalTypeTest::d1'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'pp3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedPortConnections.get(20) => [
 					"portconn21".assertEquals(name)
 					//Tests typeCheckPortConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "An 'event data source' in a 'data port' is not a valid port connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'eds3' to have classifier 'legalTypeTest::d1'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'eds3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedPortConnections.get(21) => [
 					"portconn22".assertEquals(name)
@@ -2847,13 +2847,13 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"portconn34".assertEquals(name)
 					//Tests typeCheckPortConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "A 'port proxy' in an 'event data port' is not a valid port connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'pp3' to have classifier 'legalTypeTest::d1'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'pp3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedPortConnections.get(34) => [
 					"portconn35".assertEquals(name)
 					//Tests typeCheckPortConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "An 'event data source' in an 'event data port' is not a valid port connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'eds3' to have classifier 'legalTypeTest::d1'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'eds3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedPortConnections.get(35) => [
 					"portconn36".assertEquals(name)
@@ -2939,13 +2939,13 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"portconn56".assertEquals(name)
 					//Tests typeCheckPortConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "A 'port proxy' in an 'abstract subcomponent' is not a valid port connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'pp3' to have classifier 'legalTypeTest::d1'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'pp3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedPortConnections.get(56) => [
 					"portconn57".assertEquals(name)
 					//Tests typeCheckPortConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "An 'event data source' in an 'abstract subcomponent' is not a valid port connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'eds3' to have classifier 'legalTypeTest::d1'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'eds3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedPortConnections.get(57) => [
 					"portconn58".assertEquals(name)
@@ -2991,13 +2991,13 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"portconn71".assertEquals(name)
 					//Tests typeCheckPortConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "A 'port proxy' in a 'data subcomponent' is not a valid port connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'pp3' to have classifier 'legalTypeTest::d1'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'pp3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedPortConnections.get(71) => [
 					"portconn72".assertEquals(name)
 					//Tests typeCheckPortConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "An 'event data source' in a 'data subcomponent' is not a valid port connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'eds3' to have classifier 'legalTypeTest::d1'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'eds3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedPortConnections.get(72) => [
 					"portconn73".assertEquals(name)
@@ -3028,13 +3028,13 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"portconn83".assertEquals(name)
 					//Tests typeCheckPortConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "A 'port proxy' in a 'subprogram call' is not a valid port connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'pp2' to have classifier 'legalTypeTest::d1'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'pp2' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedPortConnections.get(83) => [
 					"portconn84".assertEquals(name)
 					//Tests typeCheckPortConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "An 'event data source' in a 'subprogram call' is not a valid port connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'eds2' to have classifier 'legalTypeTest::d1'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'eds2' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedPortConnections.get(84) => [
 					"portconn85".assertEquals(name)
@@ -3160,7 +3160,7 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 				ownedFeatureConnections.get(0) => [
 					"fconn78".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::a1.i'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::a1.i'")
 				]
 				ownedFeatureConnections.get(1) => [
 					"fconn79".assertEquals(name)
@@ -3171,7 +3171,7 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"fconn80".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "Anything in a 'parameter' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(3) => [
 					"fconn81".assertEquals(name)
@@ -3182,13 +3182,13 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"fconn82".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "Anything in a 'parameter' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
 				]
 				ownedFeatureConnections.get(5) => [
 					"fconn83".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "Anything in a 'parameter' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
 				]
 				ownedFeatureConnections.get(6) => [
 					"fconn84".assertEquals(name)
@@ -3219,7 +3219,7 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"fconn89".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "Anything in a 'parameter' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(12) => [
 					"fconn90".assertEquals(name)
@@ -3230,13 +3230,13 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"fconn91".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "Anything in a 'parameter' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureConnections.get(14) => [
 					"fconn92".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "Anything in a 'parameter' is not a valid feature connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedFeatureGroupConnections.get(0) => [
 					"fgconn78".assertEquals(name)
@@ -3413,13 +3413,13 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					"portconn98".assertEquals(name)
 					//Tests typeCheckPortConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "Anything in a 'parameter' is not a valid port connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'pp3' to have classifier 'legalTypeTest::d1'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'pp3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedPortConnections.get(7) => [
 					"portconn99".assertEquals(name)
 					//Tests typeCheckPortConnectionEnd
 					source.assertError(testFileResult.issues, issueCollection, "Anything in a 'parameter' is not a valid port connection end.")
-					assertWarning(testFileResult.issues, issueCollection, "Expected feature 'eds3' to have classifier 'legalTypeTest::d1'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'eds3' to have classifier 'legalTypeTest::d1'")
 				]
 				ownedPortConnections.get(8) => [
 					"portconn100".assertEquals(name)

--- a/core/org.osate.core.tests/src/org/osate/core/tests/aadl2javavalidator/FeatureGroupChainingTest.xtend
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/aadl2javavalidator/FeatureGroupChainingTest.xtend
@@ -306,8 +306,9 @@ class FeatureGroupChainingTest extends XtextTest {
 				ownedFeatureGroupConnections.get(4) => [
 					"conn5".assertEquals(name)
 					assertError(testFileResult.issues, issueCollection,
-							"The feature groups 'fg18' and 'fg20' are not inverses of each other.",
-							"Feature sub2.fg19.fg20.p5 must not be out due to the direction of the connection")
+						"The feature groups 'fg18' and 'fg20' are not inverses of each other.")
+					destination.assertError(testFileResult.issues, issueCollection,
+						"Feature sub2.fg19.fg20.p5 must not be out due to the direction of the connection")
 				]
 				ownedFeatureGroupConnections.get(9) => [
 					"conn10".assertEquals(name)

--- a/core/org.osate.core.tests/src/org/osate/core/tests/aadl2javavalidator/OtherAadl2JavaValidatorTest.xtend
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/aadl2javavalidator/OtherAadl2JavaValidatorTest.xtend
@@ -1199,9 +1199,10 @@ class OtherAadl2JavaValidatorTest extends XtextTest {
 				"sys2.i".assertEquals(name)
 				ownedConnections.get(1) => [
 					"c2".assertEquals(name)
-						assertError(testFileResult.issues, issueCollection, 
-										"Feature inner.fg1.o1 must not be in due to the direction of the connection"
-										, "Feature i.fg1.o1 must not be in due to the direction of the connection")
+					source.assertError(testFileResult.issues, issueCollection,
+						"Feature inner.fg1.o1 must not be in due to the direction of the connection")
+					destination.assertError(testFileResult.issues, issueCollection,
+						"Feature i.fg1.o1 must not be in due to the direction of the connection")
 				]
 			]
 		]

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue1988Test.xtend
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue1988Test.xtend
@@ -53,7 +53,7 @@ class Issue1988Test extends XtextTest {
 		val pkg = testFileResult.resource.contents.head as AadlPackage;
 		val p_i = pkg.ownedPublicSection.ownedClassifiers.findFirst[name == "p.i"] as ProcessImplementation
 			
-		p_i.ownedConnections.get(0) => [
+		p_i.ownedConnections.get(0).source => [
 			assertWarning(testFileResult.issues, issueCollection, "Expected feature 'p1' to have classifier 'PortSrc::D'")
 		]	
 		issueCollection.sizeIs(testFileResult.issues.size)
@@ -67,7 +67,7 @@ class Issue1988Test extends XtextTest {
 		val pkg = testFileResult.resource.contents.head as AadlPackage;
 		val p_i = pkg.ownedPublicSection.ownedClassifiers.findFirst[name == "p.i"] as ProcessImplementation
 			
-		p_i.ownedConnections.get(0) => [
+		p_i.ownedConnections.get(0).destination => [
 			assertWarning(testFileResult.issues, issueCollection, "Expected feature 'ip2' to have classifier 'PortDst::D'")
 		]	
 		issueCollection.sizeIs(testFileResult.issues.size)
@@ -161,10 +161,10 @@ class Issue1988Test extends XtextTest {
 		val pkg = testFileResult.resource.contents.head as AadlPackage;
 		val th2_bad = pkg.ownedPublicSection.ownedClassifiers.findFirst[name == "th2.bad"] as ThreadImplementation
 			
-		th2_bad.ownedConnections.get(0) => [
+		th2_bad.ownedConnections.get(0).source => [
 			assertWarning(testFileResult.issues, issueCollection, "Expected feature 'ip2' to have classifier 'ParameterSrc::D'")
 		]	
-		th2_bad.ownedConnections.get(1) => [
+		th2_bad.ownedConnections.get(1).source => [
 			assertWarning(testFileResult.issues, issueCollection, "Expected feature 'p2' to have classifier 'ParameterSrc::D'")
 		]	
 		issueCollection.sizeIs(testFileResult.issues.size)
@@ -178,10 +178,10 @@ class Issue1988Test extends XtextTest {
 		val pkg = testFileResult.resource.contents.head as AadlPackage;
 		val th2_bad = pkg.ownedPublicSection.ownedClassifiers.findFirst[name == "th2.bad"] as ThreadImplementation
 			
-		th2_bad.ownedConnections.get(0) => [
+		th2_bad.ownedConnections.get(0).destination => [
 			assertWarning(testFileResult.issues, issueCollection, "Expected feature 'p1' to have classifier 'ParameterDst::D'")
 		]	
-		th2_bad.ownedConnections.get(1) => [
+		th2_bad.ownedConnections.get(1).destination => [
 			assertWarning(testFileResult.issues, issueCollection, "Expected subcomponent 'myData' to have classifier 'ParameterDst::D'")
 		]	
 		issueCollection.sizeIs(testFileResult.issues.size)
@@ -208,4 +208,3 @@ class Issue1988Test extends XtextTest {
 		assertConstraints(issueCollection)
 	}
 }
-

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2344Test.xtend
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2344Test.xtend
@@ -56,13 +56,13 @@ class Issue2344Test extends XtextTest {
 			"Test".assertEquals(name)
 			publicSection.ownedClassifiers.findFirst[name == "top.i"] as SystemImplementation => [
 				ownedPortConnections.findFirst[name == "none_to_d"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'f_none' to have classifier 'Test::D'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'f_none' to have classifier 'Test::D'")
 				]
 				ownedPortConnections.findFirst[name == "none_to_di"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'f_none' to have classifier 'Test::D.i'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'f_none' to have classifier 'Test::D.i'")
 				]
 				ownedPortConnections.findFirst[name == "d_to_none"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'f_none' to have classifier 'Test::D'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'f_none' to have classifier 'Test::D'")
 				]
 				ownedPortConnections.findFirst[name == "d_to_di"] => [
 					it.assertError(testFileResult.issues, issueCollection, "'f_d' and 'f_di' have incompatible classifiers.")
@@ -71,7 +71,7 @@ class Issue2344Test extends XtextTest {
 					it.assertError(testFileResult.issues, issueCollection, "'f_d' and 'f_x' have incompatible classifiers.")
 				]
 				ownedPortConnections.findFirst[name == "di_to_none"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'f_none' to have classifier 'Test::D.i'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'f_none' to have classifier 'Test::D.i'")
 				]
 				ownedPortConnections.findFirst[name == "di_to_x"] => [
 					it.assertError(testFileResult.issues, issueCollection, "The types of 'f_di' and 'f_x' do not match.")
@@ -97,16 +97,16 @@ class Issue2344Test extends XtextTest {
 			"TestBidirectional".assertEquals(name)
 			publicSection.ownedClassifiers.findFirst[name == "top.i"] as SystemImplementation => [
 				ownedPortConnections.findFirst[name == "none_to_d"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'f_none' to have classifier 'TestBidirectional::D'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'f_none' to have classifier 'TestBidirectional::D'")
 				]
 				ownedPortConnections.findFirst[name == "none_to_di"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'f_none' to have classifier 'TestBidirectional::D.i'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'f_none' to have classifier 'TestBidirectional::D.i'")
 				]
 				ownedPortConnections.findFirst[name == "d_to_none"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'f_none' to have classifier 'TestBidirectional::D'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'f_none' to have classifier 'TestBidirectional::D'")
 				]
 				ownedPortConnections.findFirst[name == "di_to_none"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'f_none' to have classifier 'TestBidirectional::D.i'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'f_none' to have classifier 'TestBidirectional::D.i'")
 				]
 				
 				ownedPortConnections.findFirst[name == "d_to_di"] => [

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2355Test.xtend
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2355Test.xtend
@@ -63,7 +63,8 @@ class Issue2355Test extends XtextTest {
 					assertError(testFileResult.issues, issueCollection, "'ap' and 'br' have incompatible classifiers.")
 				]
 				ownedFeatureConnections.get(5) => [
-					assertError(testFileResult.issues, issueCollection, "'ap' must be a requires access feature for a connection to an accessed subcomponent.")
+					source.assertError(testFileResult.issues, issueCollection,
+						"'ap' must be a requires access feature for a connection to an accessed subcomponent.")
 				]
 				ownedFeatureConnections.get(6) => [
 					assertError(testFileResult.issues, issueCollection, "'d1' and 'br' have incompatible classifiers.")

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue582NestedAbstractAccessTest.xtend
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue582NestedAbstractAccessTest.xtend
@@ -58,19 +58,19 @@ class Issue582NestedAbstractAccessTest extends XtextTest {
 		testFileResult.resource.contents.head as AadlPackage => [
 			publicSection.ownedClassifiers.findFirst[name == "SrcSys.allExplicit"] as SystemImplementation => [
 				ownedFeatureConnections.findFirst[name == "blank_to_provides"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
 				]
 				ownedFeatureConnections.findFirst[name == "blank_to_requires"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
 				]
 				ownedFeatureConnections.findFirst[name == "provides_to_blank"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'provides_to_blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'provides_to_blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
 				]
 				ownedAccessConnections.findFirst[name == "provides_to_requires"] => [
 					it.assertError(testFileResult.issues, issueCollection, "Source and destination must both be provides or requires for a connection mapping features up or down the containment hierarchy.")
 				]
 				ownedFeatureConnections.findFirst[name == "requires_to_blank"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'requires_to_blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'requires_to_blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
 				]
 				ownedAccessConnections.findFirst[name == "requires_to_provides"] => [
 					it.assertError(testFileResult.issues, issueCollection, "Source and destination must both be provides or requires for a connection mapping features up or down the containment hierarchy.")
@@ -79,55 +79,55 @@ class Issue582NestedAbstractAccessTest extends XtextTest {
 
 			publicSection.ownedClassifiers.findFirst[name == "Top.allExplicit"] as SystemImplementation => [
 				ownedFeatureConnections.findFirst[name == "blank_to_blank_to_provides"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'blank_to_blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'blank_to_blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
 				]
 				ownedFeatureConnections.findFirst[name == "blank_to_blank_to_requires"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'blank_to_blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'blank_to_blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
 				]
 				ownedFeatureConnections.findFirst[name == "blank_to_provides_to_blank"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
 				]
 				ownedAccessConnections.findFirst[name == "blank_to_provides_to_provides"] => [
 					it.assertError(testFileResult.issues, issueCollection, "Source and destination of access connections between sibling components cannot both be 'provides'.")
 				]
 				ownedFeatureConnections.findFirst[name == "blank_to_requires_to_blank"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
 				]
 				ownedAccessConnections.findFirst[name == "blank_to_requires_to_requires"] => [
 					it.assertError(testFileResult.issues, issueCollection, "Source and destination of access connections between sibling components cannot both be 'requires'.")
 				]
 				ownedFeatureConnections.findFirst[name == "provides_to_blank_to_provides"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'provides_to_blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'provides_to_blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
 				]
 				ownedFeatureConnections.findFirst[name == "provides_to_blank_to_requires"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'provides_to_blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'provides_to_blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
 				]
 				ownedFeatureConnections.findFirst[name == "provides_to_provides_to_blank"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
 				]
 				ownedAccessConnections.findFirst[name == "provides_to_provides_to_provides"] => [
 					it.assertError(testFileResult.issues, issueCollection, "Source and destination of access connections between sibling components cannot both be 'provides'.")
 				]
 				ownedFeatureConnections.findFirst[name == "provides_to_requires_to_blank"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
 				]
 				ownedAccessConnections.findFirst[name == "provides_to_requires_to_requires"] => [
 					it.assertError(testFileResult.issues, issueCollection, "Source and destination of access connections between sibling components cannot both be 'requires'.")
 				]
 				ownedFeatureConnections.findFirst[name == "requires_to_blank_to_provides"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'requires_to_blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'requires_to_blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
 				]
 				ownedFeatureConnections.findFirst[name == "requires_to_blank_to_requires"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'requires_to_blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
+					source.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'requires_to_blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
 				]
 				ownedFeatureConnections.findFirst[name == "requires_to_provides_to_blank"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
 				]
 				ownedAccessConnections.findFirst[name == "requires_to_provides_to_provides"] => [
 					it.assertError(testFileResult.issues, issueCollection, "Source and destination of access connections between sibling components cannot both be 'provides'.")
 				]
 				ownedFeatureConnections.findFirst[name == "requires_to_requires_to_blank"] => [
-					it.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
+					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'blank_feature' to have classifier 'TestNestedAbstractAccess::D'")
 				]
 				ownedAccessConnections.findFirst[name == "requires_to_requires_to_requires"] => [
 					it.assertError(testFileResult.issues, issueCollection, "Source and destination of access connections between sibling components cannot both be 'requires'.")

--- a/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/validation/Aadl2Validator.java
+++ b/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/validation/Aadl2Validator.java
@@ -47,7 +47,6 @@ import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.util.BasicInternalEList;
 import org.eclipse.emf.ecore.util.EcoreUtil;
@@ -5579,13 +5578,13 @@ public class Aadl2Validator extends AbstractAadl2Validator {
 				destinationClassifier = getClassifier(destination);
 			}
 			if (sourceClassifier == null && destinationClassifier != null) {
-				warning("Expected " + (sourceIsSubcomponent ? "subcomponent" : "feature") + " \'" + source.getName()
-						+ "' to have classifier '" + destinationClassifier.getQualifiedName() + '\'', connection,
-						Aadl2Package.eINSTANCE.getConnection_Source());
+				warning(connection.getSource(),
+						"Expected " + (sourceIsSubcomponent ? "subcomponent" : "feature") + " \'" + source.getName()
+								+ "' to have classifier '" + destinationClassifier.getQualifiedName() + '\'');
 			} else if (sourceClassifier != null && destinationClassifier == null) {
-				warning("Expected " + (destIsSubcomponent ? "subcomponent" : "feature") + " \'" + destination.getName()
-						+ "' to have classifier '" + sourceClassifier.getQualifiedName() + '\'', connection,
-						Aadl2Package.eINSTANCE.getConnection_Destination());
+				warning(connection.getDestination(),
+						"Expected " + (destIsSubcomponent ? "subcomponent" : "feature") + " \'"
+								+ destination.getName() + "' to have classifier '" + sourceClassifier.getQualifiedName() + '\'');
 			} else if (sourceClassifier != null && destinationClassifier != null) {
 				try {
 					final ClassifierMatchingRule classifierMatchingRuleValue = org.osate.aadl2.contrib.modeling.ModelingProperties
@@ -5668,13 +5667,13 @@ public class Aadl2Validator extends AbstractAadl2Validator {
 			destinationClassifier = getClassifier(destination);
 		}
 		if (sourceClassifier == null && destinationClassifier != null) {
-			warning("Expected " + (sourceIsSubcomponent ? "subcomponent" : "feature") + " \'" + source.getName()
-					+ "' to have classifier '" + destinationClassifier.getQualifiedName() + '\'', connection,
-					Aadl2Package.eINSTANCE.getConnection_Source());
+			warning(connection.getSource(),
+					"Expected " + (sourceIsSubcomponent ? "subcomponent" : "feature") + " \'" + source.getName()
+							+ "' to have classifier '" + destinationClassifier.getQualifiedName() + '\'');
 		} else if (sourceClassifier != null && destinationClassifier == null) {
-			warning("Expected " + (destIsSubcomponent ? "subcomponent" : "feature") + " \'" + destination.getName()
-					+ "' to have classifier '" + sourceClassifier.getQualifiedName() + '\'', connection,
-					Aadl2Package.eINSTANCE.getConnection_Destination());
+			warning(connection.getDestination(),
+					"Expected " + (destIsSubcomponent ? "subcomponent" : "feature") + " \'" + destination.getName()
+							+ "' to have classifier '" + sourceClassifier.getQualifiedName() + '\'');
 		} else if (sourceClassifier != null && destinationClassifier != null) {
 			try {
 				final ClassifierMatchingRule classifierMatchingRuleValue = org.osate.aadl2.contrib.modeling.ModelingProperties
@@ -6005,23 +6004,22 @@ public class Aadl2Validator extends AbstractAadl2Validator {
 			}
 			if ((srcContext instanceof Subcomponent) || (srcContext instanceof SubprogramCall)) {
 				if (!(srcDirection.outgoing())) {
-					error("Outgoing connection requires outgoing feature '" + srcContext.getName() + "."
-							+ source.getName() + "'.", connection, Aadl2Package.eINSTANCE.getConnection_Source());
+					error(connection.getSource(), "Outgoing connection requires outgoing feature '" + srcContext.getName()
+							+ "." + source.getName() + "'.");
 				}
 				if (!(dstDirection.outgoing())) {
-					error("Outgoing connection requires outgoing feature '" + destination.getName() + "'.", connection,
-							Aadl2Package.eINSTANCE.getConnection_Destination());
+					error(connection.getDestination(),
+							"Outgoing connection requires outgoing feature '" + destination.getName() + "'.");
 				}
 			}
 			if ((dstContext instanceof Subcomponent) || (dstContext instanceof SubprogramCall)) {
 				if (!(dstDirection.incoming())) {
-					error("Incoming connection requires incoming feature '" + dstContext.getName() + "."
-							+ destination.getName() + "'.", connection,
-							Aadl2Package.eINSTANCE.getConnection_Destination());
+					error(connection.getDestination(), "Incoming connection requires incoming feature '" + dstContext.getName()
+							+ "." + destination.getName() + "'.");
 				}
 				if (!(srcDirection.incoming())) {
-					error("Incoming connection requires incoming feature '" + source.getName() + "'.", connection,
-							Aadl2Package.eINSTANCE.getConnection_Source());
+					error(connection.getSource(),
+							"Incoming connection requires incoming feature '" + source.getName() + "'.");
 				}
 			}
 		} else if (source instanceof InternalFeature || destination instanceof InternalFeature) {
@@ -6272,13 +6270,13 @@ public class Aadl2Validator extends AbstractAadl2Validator {
 				destinationClassifier = ((Feature) destination).getAllClassifier();
 			}
 			if (sourceClassifier == null && destinationClassifier != null) {
-				warning("Expected " + (sourceIsSubcomponent ? "subcomponent" : "feature") + " \'" + source.getName()
-						+ "' to have classifier '" + destinationClassifier.getQualifiedName() + '\'', connection,
-						Aadl2Package.eINSTANCE.getConnection_Source());
+				warning(connection.getSource(),
+						"Expected " + (sourceIsSubcomponent ? "subcomponent" : "feature") + " \'" + source.getName()
+								+ "' to have classifier '" + destinationClassifier.getQualifiedName() + '\'');
 			} else if (sourceClassifier != null && destinationClassifier == null) {
-				warning("Expected " + (destIsSubcomponent ? "subcomponent" : "feature") + " \'" + destination.getName()
-						+ "' to have classifier '" + sourceClassifier.getQualifiedName() + '\'', connection,
-						Aadl2Package.eINSTANCE.getConnection_Destination());
+				warning(connection.getDestination(),
+						"Expected " + (destIsSubcomponent ? "subcomponent" : "feature") + " \'"
+								+ destination.getName() + "' to have classifier '" + sourceClassifier.getQualifiedName() + '\'');
 			} else if (sourceClassifier != null && destinationClassifier != null) {
 				final ClassifierMatchingRule classifierMatchingRuleValue = org.osate.aadl2.contrib.modeling.ModelingProperties
 						.getClassifierMatchingRule(connection)
@@ -6594,15 +6592,15 @@ public class Aadl2Validator extends AbstractAadl2Validator {
 		}
 
 		if (sourceCategory != null && !connectionCategory.equals(sourceCategory)) {
-			error("The source of a " + connectionCategory.getName() + " access connection must be a "
+			error(connection.getSource(), "The source of a " + connectionCategory.getName() + " access connection must be a "
 					+ connectionCategory.getName() + " access feature or a " + connectionCategory.getName()
-					+ " subcomponent.", connection, Aadl2Package.eINSTANCE.getConnection_Source());
+					+ " subcomponent.");
 		}
 
 		if (destinationCategory != null && !connectionCategory.equals(destinationCategory)) {
-			error("The destination of a " + connectionCategory.getName() + " access connection must be a "
-					+ connectionCategory.getName() + " access feature or a " + connectionCategory.getName()
-					+ " subcomponent.", connection, Aadl2Package.eINSTANCE.getConnection_Destination());
+			error(connection.getDestination(), "The destination of a " + connectionCategory.getName()
+					+ " access connection must be a " + connectionCategory.getName() + " access feature or a "
+					+ connectionCategory.getName() + " subcomponent.");
 		}
 	}
 
@@ -6678,18 +6676,16 @@ public class Aadl2Validator extends AbstractAadl2Validator {
 		else if (source instanceof Subcomponent && destination instanceof Access
 				&& (dstContext == null || dstContext instanceof FeatureGroup)) {
 			if (destinationType != AccessType.PROVIDES) {
-				error('\'' + destination.getName()
-						+ "' must be a provides access feature for a connection from an accessed subcomponent.",
-						connection, Aadl2Package.eINSTANCE.getConnection_Destination());
+				error(connection.getDestination(), '\'' + destination.getName()
+						+ "' must be a provides access feature for a connection from an accessed subcomponent.");
 			}
 		}
 		// Test for L6: connection between access feature and subcomponent
 		else if (destination instanceof Subcomponent && source instanceof Access
 				&& (srcContext == null || srcContext instanceof FeatureGroup)) {
 			if (!sourceType.equals(AccessType.PROVIDES)) {
-				error('\'' + source.getName()
-						+ "' must be a provides access feature for a connection to a accessed subcomponent.",
-						connection, Aadl2Package.eINSTANCE.getConnection_Source());
+				error(connection.getSource(), '\'' + source.getName()
+						+ "' must be a provides access feature for a connection to a accessed subcomponent.");
 			}
 		}
 		// Test for L7: connection between subcomponent and access feature of
@@ -6697,9 +6693,8 @@ public class Aadl2Validator extends AbstractAadl2Validator {
 		else if (source instanceof Subcomponent && destination instanceof Access
 				&& dstContext instanceof Subcomponent) {
 			if (destinationType != AccessType.REQUIRES) {
-				error('\'' + destination.getName()
-						+ "' must be a requires access feature for a connection from an accessed subcomponent.",
-						connection, Aadl2Package.eINSTANCE.getConnection_Destination());
+				error(connection.getDestination(), '\'' + destination.getName()
+						+ "' must be a requires access feature for a connection from an accessed subcomponent.");
 			}
 		}
 		// Test for L7: connection between access feature of subcomponent and
@@ -6707,9 +6702,8 @@ public class Aadl2Validator extends AbstractAadl2Validator {
 		else if (destination instanceof Subcomponent && source instanceof Access
 				&& srcContext instanceof Subcomponent) {
 			if (!sourceType.equals(AccessType.REQUIRES)) {
-				error('\'' + source.getName()
-						+ "' must be a requires access feature for a connection to an accessed subcomponent.",
-						connection, Aadl2Package.eINSTANCE.getConnection_Source());
+				error(connection.getSource(), '\'' + source.getName()
+						+ "' must be a requires access feature for a connection to an accessed subcomponent.");
 			}
 		}
 	}
@@ -8129,56 +8123,53 @@ public class Aadl2Validator extends AbstractAadl2Validator {
 				// sibling to sibling
 				if (sourceDirection.equals(DirectionType.IN)) {
 					error("The direction of the source " + source.getName()
-							+ " of a directional feature group connection must not be in", connection,
-							Aadl2Package.eINSTANCE.getConnection_Source(), MAKE_CONNECTION_BIDIRECTIONAL);
+							+ " of a directional feature group connection must not be in", connection.getSource(), null,
+							MAKE_CONNECTION_BIDIRECTIONAL);
 				} else if (sourceDirection.equals(DirectionType.IN_OUT)) {
-					checkDirectionOfFeatureGroupMembers(sourceChain, DirectionType.IN, connection,
-							Aadl2Package.eINSTANCE.getConnection_Source());
+					checkDirectionOfFeatureGroupMembers(sourceChain, DirectionType.IN, connection.getSource());
 				}
 				if (destinationDirection.equals(DirectionType.OUT)) {
 					error("The direction of the destination " + destination.getName()
-							+ " of a directional feature group connection must not be out", connection,
-							Aadl2Package.eINSTANCE.getConnection_Destination(), MAKE_CONNECTION_BIDIRECTIONAL);
+							+ " of a directional feature group connection must not be out", connection.getDestination(),
+							null, MAKE_CONNECTION_BIDIRECTIONAL);
 				} else if (destinationDirection.equals(DirectionType.IN_OUT)) {
-					checkDirectionOfFeatureGroupMembers(destinationChain, DirectionType.OUT, connection,
-							Aadl2Package.eINSTANCE.getConnection_Destination());
+					checkDirectionOfFeatureGroupMembers(destinationChain, DirectionType.OUT,
+							connection.getDestination());
 				}
 			} else if (!(srccxt instanceof Subcomponent)) {
 				// going down
 				if (sourceDirection.equals(DirectionType.OUT)) {
 					error("The direction of the source " + source.getName()
-							+ " of this incoming directional feature group connection must not be out", connection,
-							Aadl2Package.eINSTANCE.getConnection_Source(), MAKE_CONNECTION_BIDIRECTIONAL);
+							+ " of this incoming directional feature group connection must not be out",
+							connection.getSource(), null, MAKE_CONNECTION_BIDIRECTIONAL);
 				} else if (sourceDirection.equals(DirectionType.IN_OUT)) {
-					checkDirectionOfFeatureGroupMembers(sourceChain, DirectionType.OUT, connection,
-							Aadl2Package.eINSTANCE.getConnection_Source());
+					checkDirectionOfFeatureGroupMembers(sourceChain, DirectionType.OUT, connection.getSource());
 				}
 
 				if (destinationDirection.equals(DirectionType.OUT)) {
 					error("The direction of the destination " + destination.getName()
-							+ " of this incoming directional feature group connection must not be out", connection,
-							Aadl2Package.eINSTANCE.getConnection_Destination(), MAKE_CONNECTION_BIDIRECTIONAL);
+							+ " of this incoming directional feature group connection must not be out",
+							connection.getDestination(), null, MAKE_CONNECTION_BIDIRECTIONAL);
 				} else if (destinationDirection.equals(DirectionType.IN_OUT)) {
-					checkDirectionOfFeatureGroupMembers(destinationChain, DirectionType.OUT, connection,
-							Aadl2Package.eINSTANCE.getConnection_Destination());
+					checkDirectionOfFeatureGroupMembers(destinationChain, DirectionType.OUT,
+							connection.getDestination());
 				}
 			} else if (!(dstcxt instanceof Subcomponent)) {
 				// going up
 				if (sourceDirection.equals(DirectionType.IN)) {
 					error("The direction of the source " + source.getName()
-							+ " of this outgoing directional feature group connection must not be in", connection,
-							Aadl2Package.eINSTANCE.getConnection_Destination(), MAKE_CONNECTION_BIDIRECTIONAL);
+							+ " of this outgoing directional feature group connection must not be in",
+							connection.getSource(), null, MAKE_CONNECTION_BIDIRECTIONAL);
 				} else if (sourceDirection.equals(DirectionType.IN_OUT)) {
-					checkDirectionOfFeatureGroupMembers(sourceChain, DirectionType.IN, connection,
-							Aadl2Package.eINSTANCE.getConnection_Source());
+					checkDirectionOfFeatureGroupMembers(sourceChain, DirectionType.IN, connection.getSource());
 				}
 				if (destinationDirection.equals(DirectionType.IN)) {
 					error("The direction of the destination " + destination.getName()
-							+ " of this outgoing directional feature group connection must not be in", connection,
-							Aadl2Package.eINSTANCE.getConnection_Destination(), MAKE_CONNECTION_BIDIRECTIONAL);
+							+ " of this outgoing directional feature group connection must not be in",
+							connection.getDestination(), null, MAKE_CONNECTION_BIDIRECTIONAL);
 				} else if (destinationDirection.equals(DirectionType.IN_OUT)) {
-					checkDirectionOfFeatureGroupMembers(destinationChain, DirectionType.IN, connection,
-							Aadl2Package.eINSTANCE.getConnection_Destination());
+					checkDirectionOfFeatureGroupMembers(destinationChain, DirectionType.IN,
+							connection.getDestination());
 				}
 			}
 		}
@@ -8203,8 +8194,8 @@ public class Aadl2Validator extends AbstractAadl2Validator {
 	 * Checks legality rule 8 in section 9.5 the endpoints of a directional
 	 * feature group must be consistent with the direction.
 	 */
-	private void checkDirectionOfFeatureGroupMembers(List<NamedElement> chain, DirectionType notDir, Connection conn,
-			EStructuralFeature structuralFeature) {
+	private void checkDirectionOfFeatureGroupMembers(List<NamedElement> chain, DirectionType notDir,
+			ConnectedElement connectedElement) {
 		NamedElement lastElement = chain.get(chain.size() - 1);
 		if (!(lastElement instanceof FeatureGroup)) {
 			return;
@@ -8230,7 +8221,7 @@ public class Aadl2Validator extends AbstractAadl2Validator {
 								.map(chainElement -> chainElement.getName())
 								.collect(Collectors.joining("."));
 						error("Feature " + chainName + " must not be " + notDir.getName()
-								+ " due to the direction of the connection", conn, structuralFeature,
+								+ " due to the direction of the connection", connectedElement, null,
 								MAKE_CONNECTION_BIDIRECTIONAL);
 					}
 				});


### PR DESCRIPTION
## Summary

- associate end-specific validation errors and warnings with the source or destination ConnectedElement
- preserve connection-wide diagnostics on the Connection and retain feature-group direction quick fixes
- rewrite affected validator assertions to verify the precise connection end for classifier, direction, category, and access diagnostics

## Testing

- focused regression suite: 82 tests passed
- full org.osate.core.tests suite: 540 tests passed
- Maven used the focused local/offline reactor described in aadl-language-server/build.md

Fixes #2625