### PR TITLE
Reject unresolved connection instance endpoints 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateConnectionsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateConnectionsSwitch.java
@@ -929,6 +929,20 @@ public class CreateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 
 	protected ConnectionInstance addConnectionInstance(final SystemInstance systemInstance,
 			final ConnectionInfo connInfo, final ConnectionInstanceEnd dstI) {
+		Element diagnosticTarget = connInfo.container != null ? connInfo.container : systemInstance;
+		boolean unresolvedEndpoint = false;
+		if (connInfo.src == null) {
+			error(diagnosticTarget, "Connection source not found");
+			unresolvedEndpoint = true;
+		}
+		if (dstI == null) {
+			error(diagnosticTarget, "Connection destination not found");
+			unresolvedEndpoint = true;
+		}
+		if (unresolvedEndpoint) {
+			return null;
+		}
+
 		// with aggregate data ports will be sources/destinations missing
 		int numConns = connInfo.connections.size();
 		if (connInfo.sources.size() != numConns || connInfo.destinations.size() != numConns) {

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
@@ -1778,41 +1778,48 @@ public class InstantiateModel {
 	 * @param dstIndices
 	 */
 	private void createNewConnection(ConnectionInstance conni, List<Long> srcIndices, List<Long> dstIndices) {
+		ComponentInstance container = conni.getContainingComponentInstance();
 		LinkedList<String> names = new LinkedList<String>();
 		LinkedList<Integer> dims = new LinkedList<Integer>();
 		LinkedList<Integer> sizes = new LinkedList<Integer>();
 		ConnectionInstance newConn = EcoreUtil.copy(conni);
-		conni.getContainingComponentInstance().getConnectionInstances().add(newConn);
+		newConn.setSource(null);
+		newConn.setDestination(null);
 		ConnectionReference topConnRef = Aadl2InstanceUtil.getTopConnectionReference(newConn);
-		analyzePath(conni.getContainingComponentInstance(), conni.getSource(), names, dims, sizes);
+		analyzePath(container, conni.getSource(), names, dims, sizes);
 		if (srcIndices.size() != sizes.size() &&
 		// filter out one side being an element without index (array of 1) (many to one mapping)
 				!(sizes.size() == 0 && dstIndices.size() == 1)) {
-			errManager.error(newConn,
+			errManager.error(container,
 					"Source indices " + srcIndices + " do not match source dimension " + sizes.size());
 		}
-		InstanceObject src = resolveConnectionInstancePath(newConn, topConnRef, names, dims, sizes, srcIndices, true);
+		InstanceObject src = resolveConnectionInstancePath(newConn, topConnRef, container, container, names, dims, sizes,
+				srcIndices, true);
 		names.clear();
 		dims.clear();
 		sizes.clear();
-		analyzePath(conni.getContainingComponentInstance(), conni.getDestination(), names, dims, sizes);
+		analyzePath(container, conni.getDestination(), names, dims, sizes);
 		if (dstIndices.size() != sizes.size() &&
 		// filter out one side being an element without index (array of 1) (many to one mapping)
 				!(sizes.size() == 0 && dstIndices.size() == 1)) {
-			errManager.error(newConn,
+			errManager.error(container,
 					"For " + newConn.getConnectionReferences().get(0).getFullName() + " : " + newConn.getFullName()
 							+ ", destination indices " + dstIndices + " do not match destination dimension "
 							+ sizes.size());
 		}
-		InstanceObject dst = resolveConnectionInstancePath(newConn, topConnRef, names, dims, sizes, dstIndices, false);
+		InstanceObject dst = resolveConnectionInstancePath(newConn, topConnRef, container, container, names, dims, sizes,
+				dstIndices, false);
 		if (src == null) {
-			errManager.error(newConn, "Connection source not found");
+			errManager.error(container, "Connection source not found");
 		}
 		if (dst == null) {
-			errManager.error(newConn, "Connection destination not found");
+			errManager.error(container, "Connection destination not found");
+		}
+		if (src == null || dst == null) {
+			return;
 		}
 
-		String containerPath = conni.getContainingComponentInstance().getInstanceObjectPath();
+		String containerPath = container.getInstanceObjectPath();
 		int len = containerPath.length() + 1;
 		String srcPath = (src != null) ? src.getInstanceObjectPath() : "Source end not found";
 		StringBuffer sb = new StringBuffer();
@@ -1824,13 +1831,14 @@ public class InstantiateModel {
 		sb.append(dstPath.substring(i));
 
 		ConnectionInstance duplicate = (ConnectionInstance) AadlUtil
-				.findNamedElementInList(conni.getContainingComponentInstance().getConnectionInstances(), sb.toString());
+				.findNamedElementInList(container.getConnectionInstances(), sb.toString());
 		if (duplicate != null && duplicate != conni) { // conni will be removed later
-			errManager.warning(newConn, "There is already another connection between the same endpoints");
+			errManager.warning(container, "There is already another connection between the same endpoints");
 		}
 		newConn.setSource((ConnectionInstanceEnd) src);
 		newConn.setDestination((ConnectionInstanceEnd) dst);
 		newConn.setName(sb.toString());
+		container.getConnectionInstances().add(newConn);
 
 	}
 
@@ -1847,21 +1855,27 @@ public class InstantiateModel {
 		LinkedList<Integer> dims = new LinkedList<Integer>();
 		LinkedList<Integer> sizes = new LinkedList<Integer>();
 		ConnectionInstance newConn = EcoreUtil.copy(conni);
-		targetComponent.getConnectionInstances().add(newConn);
+		newConn.setSource(null);
+		newConn.setDestination(null);
 		ConnectionReference topConnRef = Aadl2InstanceUtil.getTopConnectionReference(newConn);
 		analyzePath(conni.getContainingComponentInstance(), conni.getSource(), names, dims, sizes, indices);
-		InstanceObject src = resolveConnectionInstancePath(newConn, topConnRef, names, dims, sizes, indices, true);
+		InstanceObject src = resolveConnectionInstancePath(newConn, topConnRef, targetComponent, targetComponent, names,
+				dims, sizes, indices, true);
 		names.clear();
 		dims.clear();
 		sizes.clear();
 		indices.clear();
 		analyzePath(conni.getContainingComponentInstance(), conni.getDestination(), names, dims, sizes, indices);
-		InstanceObject dst = resolveConnectionInstancePath(newConn, topConnRef, names, dims, sizes, indices, false);
+		InstanceObject dst = resolveConnectionInstancePath(newConn, topConnRef, targetComponent, targetComponent, names,
+				dims, sizes, indices, false);
 		if (src == null) {
-			errManager.error(newConn, "Connection source not found");
+			errManager.error(targetComponent, "Connection source not found");
 		}
 		if (dst == null) {
-			errManager.error(newConn, "Connection destination not found");
+			errManager.error(targetComponent, "Connection destination not found");
+		}
+		if (src == null || dst == null) {
+			return;
 		}
 
 		String containerPath = targetComponent.getInstanceObjectPath();
@@ -1878,6 +1892,7 @@ public class InstantiateModel {
 		newConn.setSource((ConnectionInstanceEnd) src);
 		newConn.setDestination((ConnectionInstanceEnd) dst);
 		newConn.setName(sb.toString());
+		targetComponent.getConnectionInstances().add(newConn);
 
 	}
 
@@ -1992,6 +2007,8 @@ public class InstantiateModel {
 	 * this method resolves the connection instance from the top connection reference down the source or the destination
 	 * @param newconn Connection Instance whose paths need to be resolved
 	 * @param topref Connection Reference going across components
+	 * @param resolutionRoot component instance from which the path is resolved
+	 * @param diagnosticTarget resource-backed object used for diagnostics
 	 * @param names sequence of names of the path bottom up
 	 * @param dims Dimensions (bottom up) along the path
 	 * @param sizes Sizes of each dimension bottom up
@@ -2000,11 +2017,12 @@ public class InstantiateModel {
 	 * @return ConnectionInstanceEnd the ultimate source/destination object (feature instance or component instance)
 	 */
 	private ConnectionInstanceEnd resolveConnectionInstancePath(ConnectionInstance newconn, ConnectionReference topref,
-			List<String> names, List<Integer> dims, List<Integer> sizes, List<Long> indices, boolean doSource) {
+			ComponentInstance resolutionRoot, Element diagnosticTarget, List<String> names, List<Integer> dims,
+			List<Integer> sizes, List<Long> indices, boolean doSource) {
 		// the connection reference to be resolved
 		ConnectionReference targetConnRef = topref;
 		ConnectionReference outerConnRef = topref;
-		ConnectionInstanceEnd resolutionContext = newconn.getContainingComponentInstance();
+		ConnectionInstanceEnd resolutionContext = resolutionRoot;
 		// we have to process the indices backwards since we go top down
 		// offset starts with the last element of the indices array
 		int offset = indices.size() - 1;
@@ -2052,7 +2070,8 @@ public class InstantiateModel {
 								}
 							}
 						} catch (IndexOutOfBoundsException e) {
-							errManager.warning(newconn, "Too few indices for connection end, using fist array element");
+							errManager.warning(diagnosticTarget,
+									"Too few indices for connection end, using fist array element");
 						}
 						resolutionContext = (ConnectionInstanceEnd) io;
 						break;

--- a/core/org.osate.core.tests/models/issue3017/.gitignore
+++ b/core/org.osate.core.tests/models/issue3017/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3017/.project
+++ b/core/org.osate.core.tests/models/issue3017/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3017</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3017/Issue3017.aadl
+++ b/core/org.osate.core.tests/models/issue3017/Issue3017.aadl
@@ -1,0 +1,38 @@
+package Issue3017
+public
+	thread SrcThread
+	features
+		outp: out event port;
+	end SrcThread;
+
+	thread DstThread
+	features
+		inp: in event port;
+	end DstThread;
+
+	process Container
+	end Container;
+
+	process implementation Container.i
+	subcomponents
+		destination_srcs: thread SrcThread[2];
+		destination_dsts: thread DstThread[2];
+		source_srcs: thread SrcThread[2];
+		source_dsts: thread DstThread[2];
+	connections
+		missing_destination: port destination_srcs.outp -> destination_dsts.inp {
+			Communication_Properties::Connection_Set => ([src => (1); dst => (3);]);
+		};
+		missing_source: port source_srcs.outp -> source_dsts.inp {
+			Communication_Properties::Connection_Set => ([src => (3); dst => (1);]);
+		};
+	end Container.i;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+	subcomponents
+		container: process Container.i;
+	end Top.i;
+end Issue3017;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3017Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3017Test.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instance.ConnectionInstance;
+import org.osate.aadl2.instance.ConnectionInstanceEnd;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3017Test extends XtextTest {
+	private static final String PATH = "org.osate.core.tests/models/issue3017/";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void unresolvedExpansionEndpointsAreRejected() throws Exception {
+		var pkg = testHelper.parseFile(PATH + "Issue3017.aadl");
+		validationHelper.assertNoIssues(pkg);
+		var impl = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(c -> c.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		var errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+
+		SystemInstance instance = InstantiateModel.instantiate(impl, errorManager);
+
+		assertNotNull(instance);
+		var messages = ((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource())).getErrors();
+		assertTrue(messages.stream().anyMatch(m -> m.message.equals("Connection source not found")));
+		assertTrue(messages.stream().anyMatch(m -> m.message.equals("Connection destination not found")));
+
+		Set<ConnectionInstance> containedConnections = Collections.newSetFromMap(new IdentityHashMap<>());
+		containedConnections.addAll(instance.getAllConnectionInstances());
+		assertTrue(containedConnections.stream().allMatch(c -> c.getSource() != null && c.getDestination() != null));
+
+		assertInverseConnectionsAreContained(instance, containedConnections);
+		instance.eAllContents().forEachRemaining(object -> {
+			if (object instanceof ConnectionInstanceEnd end) {
+				assertInverseConnectionsAreContained(end, containedConnections);
+			}
+		});
+	}
+
+	private static void assertInverseConnectionsAreContained(ConnectionInstanceEnd end,
+			Set<ConnectionInstance> containedConnections) {
+		assertTrue(containedConnections.containsAll(end.getSrcConnectionInstances()));
+		assertTrue(containedConnections.containsAll(end.getDstConnectionInstances()));
+	}
+}


### PR DESCRIPTION
Fixes #3017

## Cause and correction

Array, pattern, and set expansion copied and attached provisional connection instances before resolving their indexed source and destination. Failed resolution therefore left contained connections with null required endpoints and stale endpoint inverse references. The normal connection-creation path also had no final null-endpoint guard.

Keep expansion candidates detached, clear copied endpoint references, and resolve paths using an explicit containing-component context. Report failures against that resource-backed component and attach the candidate only after both endpoints resolve. Reject null endpoints defensively before normal connection attachment.

## Regression

The `issue3017` model uses out-of-range source and destination indices in separate `Connection_Set` associations. `Issue3017Test` asserts that instantiation returns, both expected diagnostics are queued, every contained connection has both endpoints, and every connection reachable through endpoint inverse lists remains contained. The fixture project ignores both `/.aadlbin-gen/` and `/instances/`.

## Validation

- Pre-fix focused test: 1 test run, 1 failure at the null-endpoint invariant.
- `mvn -o -s releng/osate.releng/settings.xml -Plocal -pl :org.osate.aadl2.instantiation,:org.osate.core.tests,:org.osate.core.feature -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -Dtest=Issue3017Test -DfailIfNoTests=false clean install`: 1 test run, 0 failures, 0 errors.
- Same focused reactor without `-Dtest`: 550 tests run, 0 failures, 0 errors.
- `mvn -s releng/osate.releng/settings.xml -Plocal -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -DfailIfNoTests=false clean install`: all 137 reactor projects succeeded.
- `git diff --check` and `git diff master...HEAD --check`: clean.

## Dependencies

This is the first Plan 1 pull request and has no earlier Plan 1 dependency.

## Residual risk

The expansion failure has an end-to-end declarative model. No supported model was found that directly reaches `addConnectionInstance()` with a null final destination, so that lower-boundary check remains a defensive guard covered by compilation and the full core suite rather than a dedicated natural-path fixture.
