### PR TITLE
Correct feature-group endpoint mapping 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateConnectionsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateConnectionsSwitch.java
@@ -1066,7 +1066,7 @@ public class CreateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 						dstEnd = flist.get(Aadl2InstanceUtil.getFeatureIndex(upFi));
 					} else {
 						String name = upFi.getName();
-						srcEnd = (FeatureInstance) AadlUtil.findNamedElementInList(flist, name);
+						dstEnd = (FeatureInstance) AadlUtil.findNamedElementInList(flist, name);
 					}
 				}
 			}
@@ -1312,7 +1312,7 @@ public class CreateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 					if (targetFI == null) {
 						// name does not match. We may have an inverse of feature group type with its own set of feature names
 						// In this case it is an index based match
-						int idx = dst.eContents().indexOf(target);
+						int idx = ((FeatureInstance) dst).getFeatureInstances().indexOf(target);
 						if (idx >= 0) {
 							targetFI = fgi.getFeatureInstances().get(idx);
 						}
@@ -1351,7 +1351,7 @@ public class CreateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 					if (targetFI == null) {
 						// name does not match. We may have an inverse of feature group type with its own set of feature names
 						// In this case it is an index based match
-						int idx = dst.eContents().indexOf(target);
+						int idx = ((FeatureInstance) src).getFeatureInstances().indexOf(target);
 						if (idx >= 0) {
 							targetFI = fgi.getFeatureInstances().get(idx);
 						}

--- a/core/org.osate.core.tests/models/issue3019/.gitignore
+++ b/core/org.osate.core.tests/models/issue3019/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3019/.project
+++ b/core/org.osate.core.tests/models/issue3019/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3019</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3019/Issue3019.aadl
+++ b/core/org.osate.core.tests/models/issue3019/Issue3019.aadl
@@ -1,0 +1,104 @@
+package Issue3019
+public
+	feature group SourceLeafGroup
+	features
+		alpha: in out event port;
+		beta: in out event port;
+	end SourceLeafGroup;
+
+	feature group SourceGroup
+	features
+		source_inner: feature group SourceLeafGroup;
+	end SourceGroup;
+
+	feature group DestinationLeafGroup
+	features
+		alpha: in out event port;
+		beta: in out event port;
+	end DestinationLeafGroup;
+
+	feature group DestinationGroup
+	features
+		destination_inner: feature group DestinationLeafGroup;
+	inverse of SourceGroup
+	end DestinationGroup;
+
+	feature group SubsetSourceGroup
+	features
+		common: out event port;
+		extra: out event port;
+	end SubsetSourceGroup;
+
+	feature group SubsetDestinationGroup
+	features
+		common: in event port;
+	end SubsetDestinationGroup;
+
+	thread Leaf
+	features
+		io: in out event port;
+	end Leaf;
+
+	process ProducerLeafSide
+	features
+		boundary: feature group SourceLeafGroup;
+	end ProducerLeafSide;
+
+	process implementation ProducerLeafSide.i
+	subcomponents
+		leaf: thread Leaf;
+	connections
+		up: port leaf.io <-> boundary.alpha;
+	end ProducerLeafSide.i;
+
+	system ProducerSide
+	features
+		boundary: feature group SourceGroup;
+	end ProducerSide;
+
+	system implementation ProducerSide.i
+	subcomponents
+		leaf_side: process ProducerLeafSide.i;
+	connections
+		nested_up: feature group leaf_side.boundary <-> boundary.source_inner;
+	end ProducerSide.i;
+
+	system ConsumerSide
+	features
+		boundary: feature group DestinationGroup;
+	end ConsumerSide;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+	subcomponents
+		producer_side: system ProducerSide.i;
+		consumer_side: system ConsumerSide;
+	connections
+		across: feature group producer_side.boundary <-> consumer_side.boundary;
+	end Top.i;
+
+	system SubsetProducer
+	features
+		boundary: feature group SubsetSourceGroup;
+	end SubsetProducer;
+
+	system SubsetConsumer
+	features
+		boundary: feature group SubsetDestinationGroup;
+	end SubsetConsumer;
+
+	system SubsetTop
+	end SubsetTop;
+
+	system implementation SubsetTop.i
+	subcomponents
+		producer: system SubsetProducer;
+		consumer: system SubsetConsumer;
+	connections
+		across_subset: feature group producer.boundary -> consumer.boundary {
+			Classifier_Matching_Rule => Subset;
+		};
+	end SubsetTop.i;
+end Issue3019;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3019Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3019Test.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instance.ConnectionInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3019Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3019/Issue3019.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void nestedInverseFeatureGroupsInBothDirections() throws Exception {
+		var pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+		var impl = findImplementation(pkg, "Top.i");
+		var connections = InstantiateModel.instantiate(impl).getAllConnectionInstances();
+
+		assertEquals(2, connections.size());
+		assertEquals(List.of(
+				"up|Top_i_Instance.producer_side.leaf_side.leaf.io|Top_i_Instance.producer_side.leaf_side.boundary.alpha|Top_i_Instance.producer_side.leaf_side|false",
+				"nested_up|Top_i_Instance.producer_side.leaf_side.boundary.alpha|Top_i_Instance.producer_side.boundary.source_inner.alpha|Top_i_Instance.producer_side|false",
+				"across|Top_i_Instance.producer_side.boundary.source_inner.alpha|Top_i_Instance.consumer_side.boundary.destination_inner.alpha|Top_i_Instance|false"),
+				describe(connections.get(0)));
+		assertEquals(List.of(
+				"across|Top_i_Instance.consumer_side.boundary.destination_inner.alpha|Top_i_Instance.producer_side.boundary.source_inner.alpha|Top_i_Instance|true",
+				"nested_up|Top_i_Instance.producer_side.boundary.source_inner.alpha|Top_i_Instance.producer_side.leaf_side.boundary.alpha|Top_i_Instance.producer_side|true",
+				"up|Top_i_Instance.producer_side.leaf_side.boundary.alpha|Top_i_Instance.producer_side.leaf_side.leaf.io|Top_i_Instance.producer_side.leaf_side|true"),
+				describe(connections.get(1)));
+	}
+
+	@Test
+	public void subsetFeatureGroups() throws Exception {
+		var pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+		var connections = InstantiateModel.instantiate(findImplementation(pkg, "SubsetTop.i"))
+				.getAllConnectionInstances();
+
+		assertEquals(1, connections.size());
+		assertEquals(List.of(
+				"across_subset|SubsetTop_i_Instance.producer.boundary.common|SubsetTop_i_Instance.consumer.boundary.common|SubsetTop_i_Instance|false"),
+				describe(connections.get(0)));
+	}
+
+	private static ComponentImplementation findImplementation(AadlPackage pkg, String name) {
+		return (ComponentImplementation) pkg.getOwnedPublicSection().getOwnedClassifiers().stream()
+				.filter(classifier -> classifier.getName().equals(name))
+				.findFirst()
+				.orElseThrow();
+	}
+
+	private static List<String> describe(ConnectionInstance connection) {
+		return connection.getConnectionReferences().stream()
+				.map(reference -> reference.getConnection().getName() + "|"
+						+ reference.getSource().getInstanceObjectPath() + "|"
+						+ reference.getDestination().getInstanceObjectPath() + "|"
+						+ reference.getContext().getInstanceObjectPath() + "|" + reference.isReverse())
+				.toList();
+	}
+}


### PR DESCRIPTION
Fixes #3019

## Summary

- keep upward name-based feature-group matches on the destination endpoint
- compute inverse feature-group ordinals from the established feature-instance container instead of generic EMF contents
- add a valid AADL regression project covering nested inverse groups in both traversal directions and subset matching
- assert every connection-reference source, destination, context, and reverse flag

The regression fixture contains no annex.

## Testing

- Focused and related Tycho tests: 16 tests, 0 failures
- Clean root-reactor Tycho build with local artifacts ignored: all 137 modules succeeded

This branch is based on the merged fix from #3018.