### PR TITLE
Index short access connections by destination 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/ValidateConnectionsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/ValidateConnectionsSwitch.java
@@ -115,11 +115,26 @@ class ValidateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 	 */
 	private void removeShortAccessConnections(ComponentInstance ci) {
 		List<ConnectionInstance> connis = ci.getConnectionInstances();
+		boolean hasUnresolvedEndpoint = false;
+		for (ConnectionInstance conni : connis) {
+			if (conni.getSource() == null) {
+				error(conni, "Connection instance has no source endpoint");
+				hasUnresolvedEndpoint = true;
+			}
+			if (conni.getDestination() == null) {
+				error(conni, "Connection instance has no destination endpoint");
+				hasUnresolvedEndpoint = true;
+			}
+		}
+		if (hasUnresolvedEndpoint) {
+			return;
+		}
+
 		List<ConnectionInstance> toRemove = new ArrayList<>();
 		Map<ConnectionInstanceEnd, List<ConnectionInstance>> bySrc = connis.stream()
 				.collect(Collectors.groupingBy(ConnectionInstance::getSource));
 		Map<ConnectionInstanceEnd, List<ConnectionInstance>> byDst = connis.stream()
-				.collect(Collectors.groupingBy(ConnectionInstance::getSource));
+				.collect(Collectors.groupingBy(ConnectionInstance::getDestination));
 
 		connis.stream().forEach(conni -> {
 			if (conni.getKind() != ConnectionKind.ACCESS_CONNECTION) {

--- a/core/org.osate.core.tests/models/issue3021/.gitignore
+++ b/core/org.osate.core.tests/models/issue3021/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3021/.project
+++ b/core/org.osate.core.tests/models/issue3021/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3021</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3021/Issue3021.aadl
+++ b/core/org.osate.core.tests/models/issue3021/Issue3021.aadl
@@ -1,0 +1,48 @@
+package Issue3021
+public
+	feature group ServiceGroup
+	features
+		shared_call: provides subprogram access;
+		signal_line: out data port;
+	end ServiceGroup;
+
+	thread ProviderSide
+	features
+		service_bundle: feature group ServiceGroup;
+	end ProviderSide;
+
+	thread implementation ProviderSide.impl
+	subcomponents
+		worker_unit: subprogram;
+	connections
+		internal_supply: subprogram access worker_unit -> service_bundle.shared_call;
+	end ProviderSide.impl;
+
+	subprogram ServiceClient
+	features
+		requested_call: requires subprogram access;
+	end ServiceClient;
+
+	thread RequesterSide
+	features
+		service_bundle: feature group inverse of ServiceGroup;
+	end RequesterSide;
+
+	thread implementation RequesterSide.impl
+	subcomponents
+		worker_unit: subprogram ServiceClient;
+	connections
+		internal_demand: subprogram access worker_unit.requested_call <-> service_bundle.shared_call;
+	end RequesterSide.impl;
+
+	process DemoTop
+	end DemoTop;
+
+	process implementation DemoTop.impl
+	subcomponents
+		provider_side: thread ProviderSide.impl;
+		requester_side: thread RequesterSide.impl;
+	connections
+		across_link: feature group provider_side.service_bundle <-> requester_side.service_bundle;
+	end DemoTop.impl;
+end Issue3021;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3021Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3021Test.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instance.ConnectionInstance;
+import org.osate.aadl2.instance.ConnectionKind;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3021Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3021/Issue3021.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void removesForwardAndReverseDestinationSuffixes() throws Exception {
+		var pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+		var instance = InstantiateModel.instantiate(findImplementation(pkg, "DemoTop.impl"));
+		var accessPaths = instance.getAllConnectionInstances()
+				.stream()
+				.filter(connection -> connection.getKind() == ConnectionKind.ACCESS_CONNECTION)
+				.map(Issue3021Test::describe)
+				.toList();
+
+		assertEquals(List.of(List.of("internal_supply|false", "across_link|false", "internal_demand|true")),
+				accessPaths);
+	}
+
+	private static ComponentImplementation findImplementation(AadlPackage pkg, String name) {
+		return (ComponentImplementation) pkg.getOwnedPublicSection().getOwnedClassifiers().stream()
+				.filter(classifier -> classifier.getName().equals(name))
+				.findFirst()
+				.orElseThrow();
+	}
+
+	private static List<String> describe(ConnectionInstance connection) {
+		return connection.getConnectionReferences().stream()
+				.map(reference -> reference.getConnection().getName() + "|" + reference.isReverse())
+				.toList();
+	}
+}


### PR DESCRIPTION
Fixes #3021.

## Cause

`ValidateConnectionsSwitch.removeShortAccessConnections()` builds its `byDst` lookup from `ConnectionInstance::getSource`. As a result, the `endsWith` and `endsWithReverse` checks cannot find longer access paths that share the short connection destination, leaving incomplete connection instances in the model.

## Correction

Build `byDst` from `ConnectionInstance::getDestination`. Before constructing either index, report any missing required source or destination endpoint and stop short-access cleanup, avoiding an exception from `Collectors.groupingBy` if the endpoint invariant is violated.

## Regression

`Issue3021Test` instantiates a mixed feature-group topology containing forward and reverse short access paths. It asserts that destination-suffix cleanup removes both incomplete paths and retains only the complete ordered connection-reference chain. Existing source-prefix behavior remains covered by the same topology and the related access-connection regression.

## Validation

- Focused `Issue3021Test`: 1 test passed.
- Related `Issue2984Test`, `Issue3017Test`, `Issue3019Test`, and `Issue3021Test`: 5 tests passed.
- Clean root-reactor `mvn ... clean install -DskipTests -Dtycho.localArtifacts=ignore`: all 137 modules passed in 5:23.
- `git diff --check`: passed.

## Dependencies

This is Plan 1 work item 3. It follows the endpoint-invariant fix from PR #3018 and the feature-group endpoint-mapping fix from PR #3020; both are merged.

## Residual risk

Normal instantiation enforces non-null endpoints before attachment. If an external producer nevertheless creates an invalid contained connection instance, validation now reports the invariant violation and leaves short-access cleanup unchanged for that component instead of throwing.