### PR TITLE
Clear rejected short access connections 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/ValidateConnectionsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/ValidateConnectionsSwitch.java
@@ -159,7 +159,11 @@ class ValidateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 				toRemove.add(conni);
 			}
 		});
-		connis.removeAll(toRemove);
+		for (ConnectionInstance conni : toRemove) {
+			conni.setSource(null);
+			conni.setDestination(null);
+			connis.remove(conni);
+		}
 	}
 
 	private boolean shouldCompare(ConnectionInstance test, ConnectionInstance conni) {

--- a/core/org.osate.core.tests/models/issue3023/.gitignore
+++ b/core/org.osate.core.tests/models/issue3023/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3023/.project
+++ b/core/org.osate.core.tests/models/issue3023/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3023</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3023/Issue3023.aadl
+++ b/core/org.osate.core.tests/models/issue3023/Issue3023.aadl
@@ -1,0 +1,48 @@
+package Issue3023
+public
+	feature group ServiceGroup
+	features
+		shared_call: provides subprogram access;
+		signal_line: out data port;
+	end ServiceGroup;
+
+	thread ProviderSide
+	features
+		service_bundle: feature group ServiceGroup;
+	end ProviderSide;
+
+	thread implementation ProviderSide.impl
+	subcomponents
+		worker_unit: subprogram;
+	connections
+		internal_supply: subprogram access worker_unit -> service_bundle.shared_call;
+	end ProviderSide.impl;
+
+	subprogram ServiceClient
+	features
+		requested_call: requires subprogram access;
+	end ServiceClient;
+
+	thread RequesterSide
+	features
+		service_bundle: feature group inverse of ServiceGroup;
+	end RequesterSide;
+
+	thread implementation RequesterSide.impl
+	subcomponents
+		worker_unit: subprogram ServiceClient;
+	connections
+		internal_demand: subprogram access worker_unit.requested_call <-> service_bundle.shared_call;
+	end RequesterSide.impl;
+
+	process DemoTop
+	end DemoTop;
+
+	process implementation DemoTop.impl
+	subcomponents
+		provider_side: thread ProviderSide.impl;
+		requester_side: thread RequesterSide.impl;
+	connections
+		across_link: feature group provider_side.service_bundle <-> requester_side.service_bundle;
+	end DemoTop.impl;
+end Issue3023;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3023Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3023Test.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instance.ConnectionInstance;
+import org.osate.aadl2.instance.ConnectionInstanceEnd;
+import org.osate.aadl2.instance.ConnectionKind;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3023Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3023/Issue3023.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void removedShortConnectionsAreAbsentFromEndpointInverses() throws Exception {
+		var pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+		var instance = InstantiateModel.instantiate(findImplementation(pkg, "DemoTop.impl"));
+		var accessPaths = instance.getAllConnectionInstances()
+				.stream()
+				.filter(connection -> connection.getKind() == ConnectionKind.ACCESS_CONNECTION)
+				.map(Issue3023Test::describe)
+				.toList();
+
+		assertEquals(List.of(List.of("internal_supply|false", "across_link|false", "internal_demand|true")),
+				accessPaths);
+
+		Set<ConnectionInstance> containedConnections = Collections.newSetFromMap(new IdentityHashMap<>());
+		containedConnections.addAll(instance.getAllConnectionInstances());
+		assertInverseConnectionsAreContained(instance, containedConnections);
+		instance.eAllContents().forEachRemaining(object -> {
+			if (object instanceof ConnectionInstanceEnd end) {
+				assertInverseConnectionsAreContained(end, containedConnections);
+			}
+		});
+	}
+
+	private static ComponentImplementation findImplementation(AadlPackage pkg, String name) {
+		return (ComponentImplementation) pkg.getOwnedPublicSection().getOwnedClassifiers().stream()
+				.filter(classifier -> classifier.getName().equals(name))
+				.findFirst()
+				.orElseThrow();
+	}
+
+	private static List<String> describe(ConnectionInstance connection) {
+		return connection.getConnectionReferences().stream()
+				.map(reference -> reference.getConnection().getName() + "|" + reference.isReverse())
+				.toList();
+	}
+
+	private static void assertInverseConnectionsAreContained(ConnectionInstanceEnd end,
+			Set<ConnectionInstance> containedConnections) {
+		assertTrue(end.getInstanceObjectPath() + " has a detached source connection",
+				containedConnections.containsAll(end.getSrcConnectionInstances()));
+		assertTrue(end.getInstanceObjectPath() + " has a detached destination connection",
+				containedConnections.containsAll(end.getDstConnectionInstances()));
+	}
+}


### PR DESCRIPTION
Fixes #3023.

## Cause

`ValidateConnectionsSwitch.removeShortAccessConnections()` removes rejected short access connections only from component containment with `connis.removeAll(toRemove)`. A connection source and destination are bidirectional EMF references, so containment removal alone leaves the detached object in endpoint `srcConnectionInstance` or `dstConnectionInstance` inverse lists.

## Correction

For each rejected connection, clear its source, clear its destination, and then remove it from component containment. Clearing the endpoint references updates both EMF opposites directly without a resource-set-wide cross-reference scan.

## Regression

`Issue3023Test` instantiates forward and reverse short access paths through inverse feature groups. It first confirms cleanup retains the expected complete three-reference path, then builds an identity set from all contained connection instances and verifies that every connection reachable from every endpoint inverse list belongs to that set. Before the fix, the provider feature-group access endpoint retained a detached source connection.

## Validation

- Unfixed `Issue3023Test`: 1 test executed and failed at the inverse-containment assertion.
- Fixed `Issue3023Test`: 1 test passed.
- Related `Issue2984Test`, `Issue3017Test`, `Issue3019Test`, `Issue3021Test`, and `Issue3023Test`: 6 tests passed.
- Clean root-reactor `mvn ... clean install -DskipTests -Dtycho.localArtifacts=ignore`: all 137 modules passed in 5:16.
- `git diff --check`: passed.

## Dependencies

This is Plan 1 work item 4 and follows the destination-index correction from PR #3022. The earlier endpoint-invariant and feature-group endpoint-mapping fixes are also merged.

## Residual risk

The change is limited to short-access cleanup before downstream connection consumers run. It does not alter later SOM-inactive connection deletion or other uses of `EcoreUtil.delete()`.