### PR TITLE
Stop instantiating mode-transition connections 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/ConnectionInfo.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/ConnectionInfo.java
@@ -26,7 +26,6 @@ package org.osate.aadl2.instantiation;
 import static org.osate.aadl2.instance.ConnectionKind.ACCESS_CONNECTION;
 import static org.osate.aadl2.instance.ConnectionKind.FEATURE_CONNECTION;
 import static org.osate.aadl2.instance.ConnectionKind.FEATURE_GROUP_CONNECTION;
-import static org.osate.aadl2.instance.ConnectionKind.MODE_TRANSITION_CONNECTION;
 import static org.osate.aadl2.instance.ConnectionKind.PARAMETER_CONNECTION;
 import static org.osate.aadl2.instance.ConnectionKind.PORT_CONNECTION;
 import static org.osate.aadl2.instance.FeatureCategory.ABSTRACT_FEATURE;
@@ -68,7 +67,6 @@ import org.osate.aadl2.util.Aadl2InstanceUtil;
  * connection instance.
  */
 class ConnectionInfo {
-	private ConnectionKind kind;
 	final List<Connection> connections;
 	final List<Boolean> opposites;
 	final List<ComponentInstance> contexts;
@@ -84,7 +82,6 @@ class ConnectionInfo {
 	ComponentInstance container;
 
 	private ConnectionInfo(final ConnectionInfo info) {
-		kind = info.kind;
 		src = info.src;
 		connections = new ArrayList<Connection>(info.connections);
 		opposites = new ArrayList<Boolean>(info.opposites);
@@ -100,11 +97,6 @@ class ConnectionInfo {
 		container = info.container;
 	}
 
-	private ConnectionInfo(final ConnectionKind k, final ConnectionInstanceEnd s) {
-		this(s);
-		kind = k;
-	}
-
 	private ConnectionInfo(final ConnectionInstanceEnd s) {
 		src = s;
 		connections = new ArrayList<Connection>();
@@ -116,10 +108,6 @@ class ConnectionInfo {
 
 	public static ConnectionInfo newConnectionInfo(final ConnectionInstanceEnd s) {
 		return new ConnectionInfo(s);
-	}
-
-	public static ConnectionInfo newModeTransition(final ConnectionInstanceEnd s) {
-		return new ConnectionInfo(MODE_TRANSITION_CONNECTION, s);
 	}
 
 	/**
@@ -252,15 +240,6 @@ class ConnectionInfo {
 		return false;
 	}
 
-	/*
-	 * Specialized clone operation that changes the prototype connection
-	 * instance to be a mode transition connection instance.
-	 */
-	public ConnectionInfo convertToModeTransition() {
-		kind = MODE_TRANSITION_CONNECTION;
-		return this;
-	}
-
 	public ConnectionInfo cloneInfo() {
 		return new ConnectionInfo(this);
 	}
@@ -291,8 +270,7 @@ class ConnectionInfo {
 		conni.setSource(src);
 		conni.setDestination(dst);
 		conni.setComplete(across);
-		kind = getKind(dst);
-		conni.setKind(kind);
+		conni.setKind(getKind(dst));
 		return conni;
 	}
 

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateConnectionsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateConnectionsSwitch.java
@@ -67,17 +67,13 @@ import org.osate.aadl2.FeatureGroupType;
 import org.osate.aadl2.InternalFeature;
 import org.osate.aadl2.Mode;
 import org.osate.aadl2.ModeTransition;
-import org.osate.aadl2.ModeTransitionTrigger;
-import org.osate.aadl2.NamedElement;
 import org.osate.aadl2.Parameter;
 import org.osate.aadl2.ParameterConnection;
 import org.osate.aadl2.Port;
-import org.osate.aadl2.PortConnection;
 import org.osate.aadl2.ProcessorFeature;
 import org.osate.aadl2.Subcomponent;
 import org.osate.aadl2.SubprogramCall;
 import org.osate.aadl2.SubprogramSubcomponent;
-import org.osate.aadl2.TriggerPort;
 import org.osate.aadl2.contrib.modeling.ClassifierMatchingRule;
 import org.osate.aadl2.contrib.modeling.ModelingProperties;
 import org.osate.aadl2.impl.ParameterImpl;
@@ -276,9 +272,6 @@ public class CreateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 					final boolean connectedInside = lookInside && isConnectionEnd(insideSubConns, feature);
 					final boolean destinationFromInside = lookInside && isDestination(insideSubConns, feature);
 
-					// first see if mode transitions are triggered by a
-					// doModeTransitionConnections(ci, featurei);
-
 					for (final Connection conn : outgoingConns) {
 						// conn is first segment if it can't continue inside
 						// the subcomponent
@@ -360,7 +353,6 @@ public class CreateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 	// TODO-LW: set 'complete' in conn info
 	private void appendSegment(ConnectionInfo connInfo, final Connection newSegment, final ComponentInstance ci,
 			final boolean goOpposite) {
-		final boolean didModeTransitionConnection = doModeTransitionConnections(ci, connInfo, newSegment);
 		final ConnectionEnd fromEnd = goOpposite ? newSegment.getAllDestination() : newSegment.getAllSource();
 		final Context fromCtx = goOpposite ? newSegment.getAllDestinationContext() : newSegment.getAllSourceContext();
 		ConnectionEnd toEnd = goOpposite ? newSegment.getAllSource() : newSegment.getAllDestination();
@@ -570,15 +562,16 @@ public class CreateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 								ci.getSubcomponent());
 
 						if (conns.isEmpty()) {
-							if (!didModeTransitionConnection) {
-								if (ci instanceof SystemInstance) {
-									finalizeConnectionInstance(ci, connInfo, ci.findFeatureInstance(toFeature));
-								} else {
-									warning(toFi,
-											"Could not continue connection from " + connInfo.src.getInstanceObjectPath()
-													+ "  through " + toFi.getInstanceObjectPath()
-													+ ". No connection instance created.");
-								}
+							if (isModeTransitionTrigger(nextCi, toFi)) {
+								connInfo.complete = true;
+								finalizeConnectionInstance(ci, connInfo, toFi);
+							} else if (ci instanceof SystemInstance) {
+								finalizeConnectionInstance(ci, connInfo, ci.findFeatureInstance(toFeature));
+							} else {
+								warning(toFi,
+										"Could not continue connection from " + connInfo.src.getInstanceObjectPath()
+												+ "  through " + toFi.getInstanceObjectPath()
+												+ ". No connection instance created.");
 							}
 						} else {
 							for (Connection nextConn : conns) {
@@ -1368,114 +1361,11 @@ public class CreateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 
 	}
 
-	// ------------------------------------------------------------------------
-	// Methods related to mode transition connections
-	// ------------------------------------------------------------------------
-
-	/**
-	 * handles the situation that a mode transition may name an event port in a
-	 * thread (or other leaf component instance) and that port is not the
-	 * destination of a connection instance - it is the start of a connection
-	 * instance
-	 *
-	 * @param ci
-	 *            ComponentInstance
-	 * @param fi
-	 *            FeatureInstance
-	 * @return true if we created a ModetransitionInstance
-	 */
-	private boolean doModeTransitionConnections(ComponentInstance ci, FeatureInstance fi) {
-		boolean didTransition = false;
-		if (fi.getCategory() == FeatureCategory.EVENT_PORT) {
-			Subcomponent sub = ci.getSubcomponent();
-			Feature f = fi.getFeature();
-
-			for (ModeTransitionInstance mti : ci.getContainingComponentInstance().getModeTransitionInstances()) {
-				for (ModeTransitionTrigger trigger : mti.getModeTransition().getOwnedTriggers()) {
-					TriggerPort tp = trigger.getTriggerPort();
-					if (tp instanceof Port) {
-						Port p = (Port) tp;
-						Context c = trigger.getContext();
-
-						if (f == p && c == sub) {
-							addConnectionInstance(ci.getSystemInstance(), ConnectionInfo.newModeTransition(fi), mti);
-							didTransition = true;
-						}
-					} else {
-						// TODO-LW: what if it's a processor port or internal
-						// event?
-					}
-				}
-			}
-		}
-		return didTransition;
-	}
-
-	/**
-	 * As we are following connection declarations we need to check whether the
-	 * destination of the connection is named in one of the mode transitions of
-	 * the component instance that is the destination of the connection being
-	 * added
-	 *
-	 * @param parentci
-	 *            The component that is the context in which the connections are
-	 *            declared
-	 * @param pci
-	 *            PortConnectionInstance that is being created
-	 * @param conn
-	 *            connection being added to the ConnectionInstance
-	 * @return true if we created a ModetransitionInstance
-	 */
-	private boolean doModeTransitionConnections(final ComponentInstance parentci, ConnectionInfo connInfo,
-			Connection conn) {
-		boolean didTransition = false;
-		if (!(conn instanceof PortConnection || conn instanceof FeatureGroupConnection)) {
-			return false;
-		}
-		ComponentInstance parent = null;
-		Context fc = conn.getAllDestinationContext();
-		Element connContext = null;
-		if (fc instanceof ComponentImplementation || fc instanceof FeatureGroup) { // we
-			// have
-			// an
-			// outgoing
-			// connection
-			parent = (ComponentInstance) parentci.eContainer();
-			connContext = parentci.getSubcomponent();
-		} else if (fc instanceof Subcomponent) {
-			parent = parentci.findSubcomponentInstance((Subcomponent) fc);
-			connContext = ((Subcomponent) fc).getAllClassifier();
-		}
-		if (parent == null) {
-			return false;
-		}
-		EList<ModeTransitionInstance> mtl = parent.getModeTransitionInstances();
-		Feature f = (Feature) conn.getAllDestination();
-		for (ModeTransitionInstance mti : mtl) {
-			ModeTransition mt = mti.getModeTransition();
-			Context co = null;
-			for (ModeTransitionTrigger trigger : mt.getOwnedTriggers()) {
-				TriggerPort tp = trigger.getTriggerPort();
-				if (tp instanceof Port) {
-					Port o = (Port) tp;
-					co = trigger.getContext();
-					NamedElement context = co;
-					if (context instanceof FeatureGroup) {
-						context = parent.getSubcomponent().getAllClassifier();
-					}
-					if (f == o && context == connContext) {
-						final ConnectionInstance mtci = addConnectionInstance(parentci.getSystemInstance(),
-								connInfo.convertToModeTransition(), mti);
-						fillInModes(mtci);
-						fillInModeTransitions(mtci);
-						didTransition = true;
-					}
-				} else {
-					// TODO-LW: what if it's a processor port or internal event?
-				}
-			}
-		}
-		return didTransition;
+	private static boolean isModeTransitionTrigger(ComponentInstance component, ConnectionInstanceEnd end) {
+		return end instanceof FeatureInstance feature && feature.getCategory() == FeatureCategory.EVENT_PORT
+				&& component.getModeTransitionInstances()
+						.stream()
+						.anyMatch(transition -> transition.getTriggers().contains(feature));
 	}
 
 	// ------------------------------------------------------------------------

--- a/core/org.osate.core.tests/models/issue3025/.gitignore
+++ b/core/org.osate.core.tests/models/issue3025/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3025/.project
+++ b/core/org.osate.core.tests/models/issue3025/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3025</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3025/Issue3025.aadl
+++ b/core/org.osate.core.tests/models/issue3025/Issue3025.aadl
@@ -1,0 +1,45 @@
+package Issue3025
+public
+	device Generator
+		features
+			to_trigger: out event port;
+			to_unresolved: out event port;
+			to_ordinary: out event port;
+	end Generator;
+
+	device Receiver
+		features
+			incoming: in event port;
+	end Receiver;
+
+	system Bridge
+		features
+			trigger_terminal: in out event port;
+			unresolved_terminal: in out event port;
+			ordinary_terminal: in out event port;
+	end Bridge;
+
+	system implementation Bridge.i
+		subcomponents
+			producer: device Generator;
+		connections
+			trigger_path: port producer.to_trigger -> trigger_terminal;
+			unresolved_path: port producer.to_unresolved -> unresolved_terminal;
+			ordinary_path: port producer.to_ordinary -> ordinary_terminal;
+	end Bridge.i;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			bridge: system Bridge.i;
+			consumer: device Receiver;
+		connections
+			ordinary_continuation: port bridge.ordinary_terminal -> consumer.incoming;
+		modes
+			idle: initial mode;
+			active: mode;
+			activate: idle -[bridge.trigger_terminal]-> active;
+	end Top.i;
+end Issue3025;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3025Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3025Test.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, MERCHANTABILITY, EXCLUSIVITY,
+ * RESULTS OBTAINED FROM USE OF THE MATERIAL, OR FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.osate.aadl2.instance.ConnectionKind.MODE_TRANSITION_CONNECTION;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.aadl2.instance.ModeTransitionInstance;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3025Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3025/Issue3025.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void modeTransitionTriggerIsAnOrdinaryTerminal() throws Exception {
+		var pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+		var top = (ComponentImplementation) pkg.getOwnedPublicSection().getOwnedClassifiers().stream()
+				.filter(classifier -> classifier.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		var errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+
+		SystemInstance instance = InstantiateModel.instantiate(top, errorManager);
+		var connections = instance.getAllConnectionInstances();
+		assertEquals(List.of(
+				"Top_i_Instance.bridge.producer.to_trigger|Top_i_Instance.bridge.trigger_terminal|1",
+				"Top_i_Instance.bridge.producer.to_ordinary|Top_i_Instance.consumer.incoming|2"),
+				connections.stream()
+						.map(connection -> connection.getSource().getInstanceObjectPath() + "|"
+								+ connection.getDestination().getInstanceObjectPath() + "|"
+								+ connection.getConnectionReferences().size())
+						.toList());
+		assertFalse(connections.stream().anyMatch(connection -> connection.getKind() == MODE_TRANSITION_CONNECTION
+				|| connection.getSource() instanceof ModeTransitionInstance
+				|| connection.getDestination() instanceof ModeTransitionInstance));
+
+		ComponentInstance bridge = instance.getComponentInstances().stream()
+				.filter(component -> component.getName().equals("bridge"))
+				.findFirst()
+				.orElseThrow();
+		var transition = instance.getModeTransitionInstances().get(0);
+		assertEquals(1, transition.getTriggers().size());
+		var trigger = bridge.getFeatureInstances().stream()
+				.filter(feature -> feature.getName().equals("trigger_terminal"))
+				.findFirst()
+				.orElseThrow();
+		assertSame(trigger, transition.getTriggers().get(0));
+
+		var messages = ((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource())).getErrors();
+		assertEquals(1, messages.size());
+		assertEquals(QueuingAnalysisErrorReporter.WARNING, messages.get(0).kind);
+		assertEquals("Could not continue connection from Top_i_Instance.bridge.producer.to_unresolved  through "
+				+ "Top_i_Instance.bridge.unresolved_terminal. No connection instance created.", messages.get(0).message);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #3025.

Normal connection instantiation used a legacy `doModeTransitionConnections()` path to attempt a synthetic connection to a `ModeTransitionInstance`. Its `didModeTransitionConnection` result also suppressed ordinary terminal handling, so a valid event-port path ending at a mode-transition trigger could disappear silently.

Remove both legacy creators, their commented invocation, and the associated `ConnectionInfo` mode-transition state. When an upward event-port path has no declarative continuation, inspect the parent component's instantiated mode-transition triggers directly: a matching trigger feature now finalizes one ordinary port connection; a non-trigger still produces the existing continuation warning and no connection. `ConnectionKind.MODE_TRANSITION_CONNECTION` remains available for analyses and other consumers.

## Regression

`Issue3025.aadl` models three parallel paths:

- a terminal event port used as a parent mode-transition trigger;
- a genuinely unresolved non-trigger terminal;
- an ordinary path with a top-level continuation.

`Issue3025Test` validates the model and asserts the exact two ordinary connection paths, absence of synthetic mode-transition endpoints/kinds, preservation of the trigger feature reference, and the exact single warning for the unresolved control path. The test failed before the fix because the trigger-terminal connection was absent.

## Validation

- Focused Issue3025 Tycho test: 1 test, 0 failures, 0 errors.
- Existing modal instantiation tests (`Issue109Test`, `Issue1096Test`): 2 tests, 0 failures, 0 errors.
- Complete `org.osate.analysis.modes.tests` bundle: 34 tests, 0 failures, 0 errors.
- Clean root reactor with `-DskipTests -Dtycho.localArtifacts=ignore`: 137 modules, build success.
- `git diff --check`: clean.
- Surefire report confirms `tests="1" errors="0" failures="0"` for `Issue3025Test`.

## Dependencies

This is Plan 1 work item 5 and is based on updated `master` after the endpoint invariant, feature-group mapping, short-access destination indexing, and short-access inverse cleanup work (issues #3017, #3019, #3021, and #3023). It contains exactly the regression commit followed by the production-fix commit.

## Residual risk

The replacement terminal rule is intentionally limited to resolved event-port feature instances listed as triggers on the immediate parent component's instantiated mode transitions. Other unresolved nonterminal paths keep their existing warning behavior. Mode-domain analyses that create and consume `MODE_TRANSITION_CONNECTION` themselves are unchanged and pass their full test bundle.