### PR TITLE
Guard missing destination connection features 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/ConnectionInfo.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/ConnectionInfo.java
@@ -277,6 +277,7 @@ class ConnectionInfo {
 	/**
 	 * If the destination is a feature group we must find the contained feature that matches
 	 * the contained feature on the source side.
+	 * 
 	 * @param origCIE
 	 * @param rootCIE
 	 * @return

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateConnectionsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateConnectionsSwitch.java
@@ -469,7 +469,7 @@ public class CreateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 		 * have to check that the end feature is a port because AADL semantics guarantee that it will be.
 		 */
 		if (fromFi instanceof FeatureInstance && ((FeatureInstance) fromFi).getFeature() instanceof Port
-				&& toFi.eContainer().equals(ci) && isConnectionEndingCategory(ci.getCategory())) {
+				&& toFi != null && toFi.eContainer().equals(ci) && isConnectionEndingCategory(ci.getCategory())) {
 			return;
 		}
 

--- a/core/org.osate.core.tests/models/issue3027/.gitignore
+++ b/core/org.osate.core.tests/models/issue3027/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3027/.project
+++ b/core/org.osate.core.tests/models/issue3027/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3027</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3027/Issue3027.aadl
+++ b/core/org.osate.core.tests/models/issue3027/Issue3027.aadl
@@ -1,0 +1,26 @@
+package Issue3027
+public
+	device Sensor
+		features
+			alarm: out event port;
+	end Sensor;
+
+	device Monitor
+		features
+			incoming: in event port;
+	end Monitor;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			sensor: device Sensor;
+			monitor: device Monitor;
+		internal features
+			raised_event: event;
+		connections
+			to_internal: port sensor.alarm -> self.raised_event;
+			to_monitor: port sensor.alarm -> monitor.incoming;
+	end Top.i;
+end Issue3027;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3027Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3027Test.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, MERCHANTABILITY, EXCLUSIVITY,
+ * RESULTS OBTAINED FROM USE OF THE MATERIAL, OR FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3027Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3027/Issue3027.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void connectionToInternalFeatureIsReportedNotDereferenced() throws Exception {
+		var pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+		var top = (ComponentImplementation) pkg.getOwnedPublicSection().getOwnedClassifiers().stream()
+				.filter(classifier -> classifier.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		var errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+
+		var instance = InstantiateModel.instantiate(top, errorManager);
+
+		assertNotNull(instance);
+		assertEquals(List.of("Top_i_Instance.sensor.alarm|Top_i_Instance.monitor.incoming"),
+				instance.getAllConnectionInstances()
+						.stream()
+						.map(connection -> connection.getSource().getInstanceObjectPath() + "|"
+								+ connection.getDestination().getInstanceObjectPath())
+						.toList());
+
+		var messages = ((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource())).getErrors();
+		assertEquals(1, messages.size());
+		assertEquals(QueuingAnalysisErrorReporter.WARNING, messages.get(0).kind);
+		assertEquals("Connection to Issue3027::Top.i.raised_event could not be instantiated.",
+				messages.get(0).message);
+	}
+}


### PR DESCRIPTION
Fixes #3027

## Cause and correction

`CreateConnectionsSwitch.appendSegment()` resolves the destination end of a new
segment with a name-based lookup in the feature instances of the destination
component instance. That lookup returns `null` for a destination that has no
feature instance, such as an internal feature (`self.<internal feature>`). The
method expects that: it reports a dedicated message for a null destination when
the direction is invalid, and it has a branch that reports an `InternalFeature`
or `ProcessorFeature` destination as not instantiable.

The Issue 2032 filter runs before those branches and dereferenced the
destination unconditionally, so instantiation aborted with a
`NullPointerException` instead of reporting the warning. The filter now tests
the destination before dereferencing it.

Letting execution continue exposed a second unguarded dereference of the same
unresolved end, one call deeper on the same path:

```text
java.lang.NullPointerException: Cannot invoke
"org.osate.aadl2.instance.FeatureInstance.getFeatureInstances()" because "rootFI" is null
	at org.osate.aadl2.instantiation.ConnectionInfo.resolveFeatureInstance(ConnectionInfo.java:290)
	at org.osate.aadl2.instantiation.ConnectionInfo.addSegment(ConnectionInfo.java:177)
	at org.osate.aadl2.instantiation.CreateConnectionsSwitch.appendSegment(CreateConnectionsSwitch.java:483)
```

`addSegment()` otherwise treats a null end as expected: it guards `srcFi` and
`dstFi` before using them. Only the two `resolveFeatureInstance()` calls added
for issue 582 pass the end through unguarded.
`ConnectionInfo.resolveFeatureInstance()` now resolves an unresolved end to
itself. Both dereferences are part of this defect, so they are fixed together.

With both guards, a connection that ends at an internal feature reaches the
existing `InternalFeature` branch, which reports that the connection could not
be instantiated and creates no connection instance.

## Regression model and assertion

`core/org.osate.core.tests/models/issue3027/Issue3027.aadl` declares a system
implementation with an internal event feature, a device subcomponent whose out
event port is connected to that internal feature, and a second connection from
the same port to an ordinary in event port. The model has no validation issues:
an event port source connected to an internal event destination is legal
(section 9.2 legality rule L5, implemented in
`Aadl2Validator.checkPortConnectionEnds()`).

`Issue3027Test` instantiates `Top.i` through `InstantiateModel.instantiate()`
with a `QueuingAnalysisErrorReporter` and asserts that

- instantiation returns a system instance,
- the only connection instance is
  `Top_i_Instance.sensor.alarm|Top_i_Instance.monitor.incoming`, so the ordinary
  connection is neither suppressed nor duplicated, and
- exactly one diagnostic is reported, the warning
  `Connection to Issue3027::Top.i.raised_event could not be instantiated.`

## Commands and results

Focused core regression, before the fix:

```bash
mvn -o -s releng/osate.releng/settings.xml -Plocal \
  -pl :org.osate.aadl2.instantiation,:org.osate.core.tests,:org.osate.core.feature \
  -Dtycho.localArtifacts=default \
  -Dpr.build=true -Dsign=false \
  -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
  -Dtest=Issue3027Test -DfailIfNoTests=false \
  clean install
```

`Tests run: 1, Failures: 0, Errors: 1` with
`NullPointerException: Cannot invoke "...ConnectionInstanceEnd.eContainer()" because "toFi" is null`
at `CreateConnectionsSwitch.appendSegment(CreateConnectionsSwitch.java:472)`,
reached from `InstantiateModel.instantiate(InstantiateModel.java:260)`.

An intermediate run with only the `CreateConnectionsSwitch` guard was still red,
with the `ConnectionInfo.resolveFeatureInstance()` dereference above.

Same command after both guards: `Tests run: 1, Failures: 0, Errors: 0`, with a
non-zero run count for the selected class in
`core/org.osate.core.tests/target/surefire-reports`.

Clean root reactor with tests:

```bash
mvn -s releng/osate.releng/settings.xml -Plocal \
  -Dtycho.localArtifacts=ignore \
  -Dpr.build=true -Dsign=false \
  -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
  -DfailIfNoTests=false \
  clean install
```

`BUILD SUCCESS`, no failures or errors in any test bundle, `Issue3027Test`
executed as part of `org.osate.core.tests`.

## Dependencies

None outstanding. This branch starts from `master` at
`Stop instantiating mode-transition connections`, so it already contains the
merged endpoint-invariant, feature-group mapping, short-access destination
index, short-access inverse cleanup, and mode-transition PRs. It does not depend
on any unmerged branch.

## Residual risk

- The guards only add null tests; no resolved-endpoint behavior changes, and the
  full reactor test suite is unchanged and green.
- The confirmed model uses an internal feature destination. A processor feature
  destination reaches the same code, but the port connection legality rules
  reject an event or data port connected to a port proxy in this direction, so
  that variant is not covered by a model here.
- Other producers of an unresolved destination, for example a feature-group
  element lookup that fails, are not investigated in this PR. The guards make
  them report the existing diagnostics instead of throwing, but no model
  reaching them was confirmed.
