### PR TITLE
Guard missing connection subcomponent instances 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/ConnectionInfo.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/ConnectionInfo.java
@@ -277,6 +277,7 @@ class ConnectionInfo {
 	/**
 	 * If the destination is a feature group we must find the contained feature that matches
 	 * the contained feature on the source side.
+	 * 
 	 * @param origCIE
 	 * @param rootCIE
 	 * @return

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/ConnectionInfo.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/ConnectionInfo.java
@@ -277,14 +277,15 @@ class ConnectionInfo {
 	/**
 	 * If the destination is a feature group we must find the contained feature that matches
 	 * the contained feature on the source side.
-	 * 
+	 *
 	 * @param origCIE
 	 * @param rootCIE
 	 * @return
 	 */
 	protected ConnectionInstanceEnd resolveFeatureInstance(ConnectionInstanceEnd origCIE,
 			ConnectionInstanceEnd rootCIE) {
-		if (origCIE instanceof ComponentInstance || rootCIE instanceof ComponentInstance) {
+		if (rootCIE == null || origCIE instanceof ComponentInstance || rootCIE instanceof ComponentInstance) {
+			// an unresolved end resolves to itself
 			return rootCIE;
 		}
 		FeatureInstance rootFI = (FeatureInstance) rootCIE;

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateConnectionsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateConnectionsSwitch.java
@@ -361,7 +361,6 @@ public class CreateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 				? ci.findSubcomponentInstance((Subcomponent) toCtx)
 				: null;
 		final boolean finalComponent = isConnectionEndingComponent(toCtx);
-		final boolean dstEmpty = toCtx instanceof Subcomponent && toCi.getComponentInstances().isEmpty();
 		ConnectionInstanceEnd fromFi = null;
 		ConnectionInstanceEnd toFi = null;
 		FeatureInstance pushedFeature = null;
@@ -394,6 +393,9 @@ public class CreateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 			}
 			return;
 		}
+
+		// 'toCi' is known to exist if the destination context is a subcomponent
+		final boolean dstEmpty = toCtx instanceof Subcomponent && toCi.getComponentInstances().isEmpty();
 
 		if (!(fromEnd instanceof Subcomponent)) {
 			// fromEnd is a feature

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateConnectionsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateConnectionsSwitch.java
@@ -469,7 +469,7 @@ public class CreateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 		 * have to check that the end feature is a port because AADL semantics guarantee that it will be.
 		 */
 		if (fromFi instanceof FeatureInstance && ((FeatureInstance) fromFi).getFeature() instanceof Port
-				&& toFi.eContainer().equals(ci) && isConnectionEndingCategory(ci.getCategory())) {
+				&& toFi != null && toFi.eContainer().equals(ci) && isConnectionEndingCategory(ci.getCategory())) {
 			return;
 		}
 

--- a/core/org.osate.core.tests/models/issue3027/.gitignore
+++ b/core/org.osate.core.tests/models/issue3027/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3027/.project
+++ b/core/org.osate.core.tests/models/issue3027/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3027</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3027/Issue3027.aadl
+++ b/core/org.osate.core.tests/models/issue3027/Issue3027.aadl
@@ -1,0 +1,26 @@
+package Issue3027
+public
+	device Sensor
+		features
+			alarm: out event port;
+	end Sensor;
+
+	device Monitor
+		features
+			incoming: in event port;
+	end Monitor;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			sensor: device Sensor;
+			monitor: device Monitor;
+		internal features
+			raised_event: event;
+		connections
+			to_internal: port sensor.alarm -> self.raised_event;
+			to_monitor: port sensor.alarm -> monitor.incoming;
+	end Top.i;
+end Issue3027;

--- a/core/org.osate.core.tests/models/issue3030/.gitignore
+++ b/core/org.osate.core.tests/models/issue3030/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3030/.project
+++ b/core/org.osate.core.tests/models/issue3030/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3030</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3030/Issue3030.aadl
+++ b/core/org.osate.core.tests/models/issue3030/Issue3030.aadl
@@ -1,0 +1,23 @@
+package Issue3030
+public
+	device Sensor
+		features
+			alarm: out event port;
+	end Sensor;
+
+	device Monitor
+		features
+			incoming: in event port;
+	end Monitor;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			sensor: device Sensor;
+			monitors: device Monitor [0];
+		connections
+			to_monitors: port sensor.alarm -> monitors.incoming;
+	end Top.i;
+end Issue3030;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3027Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3027Test.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, MERCHANTABILITY, EXCLUSIVITY,
+ * RESULTS OBTAINED FROM USE OF THE MATERIAL, OR FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3027Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3027/Issue3027.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void connectionToInternalFeatureIsReportedNotDereferenced() throws Exception {
+		var pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+		var top = (ComponentImplementation) pkg.getOwnedPublicSection().getOwnedClassifiers().stream()
+				.filter(classifier -> classifier.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		var errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+
+		var instance = InstantiateModel.instantiate(top, errorManager);
+
+		assertNotNull(instance);
+		assertEquals(List.of("Top_i_Instance.sensor.alarm|Top_i_Instance.monitor.incoming"),
+				instance.getAllConnectionInstances()
+						.stream()
+						.map(connection -> connection.getSource().getInstanceObjectPath() + "|"
+								+ connection.getDestination().getInstanceObjectPath())
+						.toList());
+
+		var messages = ((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource())).getErrors();
+		assertEquals(1, messages.size());
+		assertEquals(QueuingAnalysisErrorReporter.WARNING, messages.get(0).kind);
+		assertEquals("Connection to Issue3027::Top.i.raised_event could not be instantiated.",
+				messages.get(0).message);
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3030Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3030Test.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, MERCHANTABILITY, EXCLUSIVITY,
+ * RESULTS OBTAINED FROM USE OF THE MATERIAL, OR FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3030Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3030/Issue3030.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	/**
+	 * The destination subcomponent of the connection is an array with no elements, so it has no component
+	 * instance. Instantiation must report the missing subcomponent instance instead of dereferencing it.
+	 */
+	@Test
+	public void missingSubcomponentInstanceIsReportedNotDereferenced() throws Exception {
+		var pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+		var top = (ComponentImplementation) pkg.getOwnedPublicSection().getOwnedClassifiers().stream()
+				.filter(classifier -> classifier.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		var errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+
+		var instance = InstantiateModel.instantiate(top, errorManager);
+
+		assertNotNull(instance);
+		assertEquals(1, instance.getComponentInstances().size());
+		assertEquals("sensor", instance.getComponentInstances().get(0).getName());
+		assertTrue(instance.getAllConnectionInstances().isEmpty());
+
+		var messages = ((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource())).getErrors();
+		assertEquals(1, messages.size());
+		assertEquals(QueuingAnalysisErrorReporter.ERROR, messages.get(0).kind);
+		assertEquals("Instantiation error: no component instance for subcomponent monitors",
+				messages.get(0).message);
+	}
+}


### PR DESCRIPTION
Fixes #3030

## Cause and correction

`CreateConnectionsSwitch.appendSegment()` resolved the destination subcomponent instance and then immediately dereferenced it to compute `dstEmpty`:

```java
final boolean dstEmpty = toCtx instanceof Subcomponent && toCi.getComponentInstances().isEmpty();
```

The method already guards a missing destination subcomponent instance, but that guard sits 27 lines further down, so it was unreachable and instantiation threw a `NullPointerException` instead of reporting the diagnostic. `dstEmpty` is now computed after that guard, where `toCi` is known to exist whenever the destination context is a subcomponent. The guard itself, the two special-case early returns that precede it, and every diagnostic are unchanged, so only the point of evaluation moves.

A subcomponent array with zero elements reaches this path: `AadlUtil.getElementCount()` returns `0` both for an omitted array size (`[]`) and for an explicit `[0]`, `InstantiateModel.instantiateSubcomponents()` then creates no component instance, and `ComponentInstance.findSubcomponentInstance()` returns `null` while the destination context is still a `Subcomponent`.

## Regression model and assertion

`core/org.osate.core.tests/models/issue3030/Issue3030.aadl` declares a device with an out event port connected to `monitors.incoming`, where `monitors: device Monitor [0]` has no elements. The package validates with no AADL issues.

`Issue3030Test.missingSubcomponentInstanceIsReportedNotDereferenced()` instantiates `Top.i` with a `QueuingAnalysisErrorReporter` and asserts that

- instantiation returns a system instance instead of throwing,
- only `sensor` is instantiated,
- no connection instance is created, and
- exactly one diagnostic is queued: the error `Instantiation error: no component instance for subcomponent monitors`.

Before the fix the test fails with `NullPointerException: Cannot invoke "org.osate.aadl2.instance.ComponentInstance.getComponentInstances()" because "toCi" is null` at `CreateConnectionsSwitch.appendSegment()`.

## Additional commit: the lost half of the #3027 fix

This PR contains one commit that is not part of issue #3030. Commit `12b9fc9a11` on `master`, the fix for #3027, described two guards but landed only its `CreateConnectionsSwitch` change; its `ConnectionInfo` change was reduced to a whitespace-only comment edit. As a result `Issue3027Test` fails on `master` today with `NullPointerException ... because "rootFI" is null` in `ConnectionInfo.resolveFeatureInstance()`. I reproduced that failure on `master` itself before starting this work.

`Resolve unresolved connection segment ends to themselves` restores the intended guard: both callers in `addSegment()` may pass an unresolved end, and `addSegment()` otherwise treats a null end as expected, so an unresolved end resolves to itself. This was included here at the maintainer's explicit request so that the pre-PR root-reactor gate is green. It is a deliberate exception to the one-fix-per-PR rule and can be split out if you prefer a separate PR.

## Commands and results

All commands were run outside the sandbox from the repository root.

Focused core regression, red before the fix and green after:

```bash
mvn -o -s releng/osate.releng/settings.xml -Plocal \
  -pl :org.osate.aadl2.instantiation,:org.osate.core.tests,:org.osate.core.feature \
  -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false \
  -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
  -Dtest=Issue3030Test -DfailIfNoTests=false clean install
```

- Before the production commit: `Tests run: 1, Failures: 0, Errors: 1` with the NPE above.
- After: `Tests run: 1, Failures: 0, Errors: 0`; `core/org.osate.core.tests/target/surefire-reports/org.osate.core.tests.issues.Issue3030Test.txt` reports a run count of 1.

Full core test bundle, same selection without `-Dtest`: `Tests run: 557, Failures: 0, Errors: 0`, including `Issue3027Test`.

Clean root reactor:

```bash
mvn -s releng/osate.releng/settings.xml -Plocal \
  -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false \
  -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
  -DfailIfNoTests=false clean install
```

`BUILD SUCCESS` across 137 modules, with `org.osate.analysis.modes.tests` green, including `ModeDomainTest` and `SOMTest`.

## Dependencies

The branch is based on the local `master` merge of #3029 (issue #3027), which is still open upstream. Until #3029 merges, this PR's commit list and diff also show #3029's regression assets and `CreateConnectionsSwitch` guard; they disappear once #3029 lands. **Merge #3029 first.**

It further depends on the already merged local-correctness PRs for issues #3019, #3021, #3023, and #3025, and it repairs the incomplete half of the #3027 fix as described above.

## Residual risk

- Behavior change is limited to models where a connection's destination context has no component instance. Those models previously produced no instance model at all; they now produce one, minus the affected connection, plus the existing error. Consumers that relied on instantiation aborting will now see a partially connected model with a queued error.
- The `SubprogramSubcomponent` case still returns silently without a diagnostic, unchanged from before.
- Whether a subcomponent array with zero or unspecified size should be rejected by declarative validation is out of scope; the instantiator must report the condition either way.
- The duplicate `toCi == null` guard further down in `appendSegment()` was left in place to avoid unrelated cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
