### PR TITLE
Set connection reference contexts on replicated connections 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
@@ -2005,11 +2005,65 @@ public class InstantiateModel {
 		i = (dstPath.startsWith(containerPath)) ? len : 0;
 		sb.append(dstPath.substring(i));
 
+		relocateConnectionReferenceContexts(newConn, conni.getContainingComponentInstance(), targetComponent);
 		newConn.setSource((ConnectionInstanceEnd) src);
 		newConn.setDestination((ConnectionInstanceEnd) dst);
 		newConn.setName(sb.toString());
 		targetComponent.getConnectionInstances().add(newConn);
 
+	}
+
+	/**
+	 * Point the connection references of a replicated connection instance at the array element that now
+	 * contains them. The copy keeps the contexts of the element it was copied from. Resolving the
+	 * endpoints gives every enclosed connection reference a context in the target element, but nothing
+	 * updates the context of the reference that goes across in the copied element.
+	 *
+	 * @param newConn the copy of the connection instance
+	 * @param origComponent the component instance that contains the original connection instance
+	 * @param targetComponent the component instance that will contain the copy
+	 */
+	private void relocateConnectionReferenceContexts(ConnectionInstance newConn, ComponentInstance origComponent,
+			ComponentInstance targetComponent) {
+		for (ConnectionReference connRef : newConn.getConnectionReferences()) {
+			ComponentInstance relocated = relocateComponentInstance(connRef.getContext(), origComponent,
+					targetComponent);
+			if (relocated != null) {
+				connRef.setContext(relocated);
+			}
+		}
+	}
+
+	/**
+	 * Find the component instance in the target element that corresponds to a component instance in the
+	 * element the connection instance was copied from.
+	 *
+	 * @param original the component instance to relocate
+	 * @param origComponent the root of the subtree the original belongs to
+	 * @param targetComponent the root of the subtree to relocate into
+	 * @return the corresponding component instance, or null if the original is neither
+	 *         <code>origComponent</code> nor contained in it, or if it has no counterpart
+	 */
+	private ComponentInstance relocateComponentInstance(ComponentInstance original, ComponentInstance origComponent,
+			ComponentInstance targetComponent) {
+		if (original == null) {
+			return null;
+		}
+		if (original == origComponent) {
+			return targetComponent;
+		}
+		ComponentInstance parent = relocateComponentInstance(original.getContainingComponentInstance(), origComponent,
+				targetComponent);
+		if (parent == null) {
+			return null;
+		}
+		for (ComponentInstance candidate : parent.getComponentInstances()) {
+			if (candidate.getName().equalsIgnoreCase(original.getName())
+					&& candidate.getIndices().equals(original.getIndices())) {
+				return candidate;
+			}
+		}
+		return null;
 	}
 
 	/**

--- a/core/org.osate.core.tests/models/issue3034/.gitignore
+++ b/core/org.osate.core.tests/models/issue3034/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3034/.project
+++ b/core/org.osate.core.tests/models/issue3034/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3034</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3034/Issue3034.aadl
+++ b/core/org.osate.core.tests/models/issue3034/Issue3034.aadl
@@ -1,0 +1,63 @@
+package Issue3034
+public
+	thread Producer
+	features
+		outp: out data port;
+	end Producer;
+
+	thread Consumer
+	features
+		inp: in data port;
+	end Consumer;
+
+	process Inner
+	end Inner;
+
+	-- The connection expands into one connection instance per array element.
+	process implementation Inner.i
+	subcomponents
+		producers: thread Producer[2];
+		consumers: thread Consumer[2];
+	connections
+		c: port producers.outp -> consumers.inp;
+	end Inner.i;
+
+	system Top
+	end Top;
+
+	-- The containment path names the first element of the array that owns the connection. Only the
+	-- connection instances of that element may carry the value.
+	system implementation Top.first
+	subcomponents
+		nested: process Inner.i[2];
+	properties
+		Communication_Properties::Timing => delayed applies to nested[1].c;
+	end Top.first;
+
+	-- The containment path names the second element of the array that owns the connection. Only the
+	-- connection instances of that element may carry the value. The connection instances of that
+	-- element are replicated copies of the ones created for the first element.
+	system implementation Top.second
+	subcomponents
+		nested: process Inner.i[2];
+	properties
+		Communication_Properties::Timing => delayed applies to nested[2].c;
+	end Top.second;
+
+	-- Control: without an index the containment path names every element, so every connection
+	-- instance carries the value.
+	system implementation Top.noIndex
+	subcomponents
+		nested: process Inner.i[2];
+	properties
+		Communication_Properties::Timing => delayed applies to nested.c;
+	end Top.noIndex;
+
+	-- Control: an indexed containment path whose last element is a component, not a connection.
+	system implementation Top.componentTarget
+	subcomponents
+		nested: process Inner.i[2];
+	properties
+		Timing_Properties::Period => 10 ms applies to nested[2].producers[1];
+	end Top.componentTarget;
+end Issue3034;

--- a/core/org.osate.core.tests/models/issue3034/Issue3034Nested.aadl
+++ b/core/org.osate.core.tests/models/issue3034/Issue3034Nested.aadl
@@ -1,0 +1,63 @@
+package Issue3034Nested
+public
+	thread Producer
+	features
+		outp: out data port;
+	end Producer;
+
+	thread Consumer
+	features
+		inp: in data port;
+	end Consumer;
+
+	process Upstream
+	features
+		outp: out data port;
+	end Upstream;
+
+	process implementation Upstream.i
+	subcomponents
+		p: thread Producer;
+	connections
+		up: port p.outp -> outp;
+	end Upstream.i;
+
+	process Downstream
+	features
+		inp: in data port;
+	end Downstream;
+
+	process implementation Downstream.i
+	subcomponents
+		cs: thread Consumer;
+	connections
+		down: port inp -> cs.inp;
+	end Downstream.i;
+
+	system Middle
+	end Middle;
+
+	-- A connection instance in an element of the array below is a chain of three connection
+	-- references: up, across, down. Each reference has to name the component instance in which its
+	-- connection is declared as its context.
+	system implementation Middle.i
+	subcomponents
+		producer_side: process Upstream.i;
+		consumer_side: process Downstream.i;
+	connections
+		across: port producer_side.outp -> consumer_side.inp;
+	end Middle.i;
+
+	system Top
+	end Top;
+
+	-- The containment path names the second element of the array. Only the connection instance of
+	-- that element, which is a replicated copy of the one created for the first element, may carry
+	-- the value.
+	system implementation Top.i
+	subcomponents
+		nested: system Middle.i[2];
+	properties
+		Communication_Properties::Timing => delayed applies to nested[2].across;
+	end Top.i;
+end Issue3034Nested;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3032Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3032Test.java
@@ -189,9 +189,10 @@ public class Issue3032Test extends XtextTest {
 	 * Property caching runs on the final connection instances now instead of on the provisional ones, so
 	 * what the expanded connections carry must not change.
 	 * <p>
-	 * {@code Top.perElement} records that a containment path which indexes the component that owns the
-	 * connection reaches no connection instance at all. That is pre-existing behavior, it is the same
-	 * before and after the reordering.
+	 * {@code Top.perElement} indexes the component that owns the connection. The value reaches the
+	 * connection instances of that element, which the replication produced as copies. Issue #3034
+	 * corrected the connection reference contexts of those copies; before that fix the value reached no
+	 * connection instance at all.
 	 */
 	@Test
 	public void containedPropertiesOnExpandedConnectionsAreUnchanged() throws Exception {
@@ -207,8 +208,8 @@ public class Issue3032Test extends XtextTest {
 		assertEquals(
 				List.of("Top_perElement_Instance.nested[1].producers[1].outp --> consumers[1].inp = <none>",
 						"Top_perElement_Instance.nested[1].producers[2].outp --> consumers[2].inp = <none>",
-						"Top_perElement_Instance.nested[2].producers[1].outp --> consumers[1].inp = <none>",
-						"Top_perElement_Instance.nested[2].producers[2].outp --> consumers[2].inp = <none>"),
+						"Top_perElement_Instance.nested[2].producers[1].outp --> consumers[1].inp = delayed",
+						"Top_perElement_Instance.nested[2].producers[2].outp --> consumers[2].inp = delayed"),
 				cachedTimings(perElement));
 		assertEquals(List.of(), diagnostics(perElement));
 	}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3034Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3034Test.java
@@ -1,0 +1,254 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.EnumerationLiteral;
+import org.osate.aadl2.NamedValue;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.aadl2.instance.ConnectionInstance;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * A connection declared in a subcomponent array is instantiated for the first array element only and
+ * then replicated into the other elements. The replication re-resolved the endpoints of the copy
+ * against the target element but kept the connection reference contexts of the element it copied from,
+ * so every replicated connection named the first element as the context of the connection reference
+ * that goes across. A contained property association that indexes one array element resolves through
+ * {@code ComponentInstance.findConnectionInstance()}, which matches on that context, so the value was
+ * applied to the connections of every element or to no connection at all.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3034Test extends XtextTest {
+	private static final String MODEL_DIR = "org.osate.core.tests/models/issue3034/";
+	private static final String MODEL = MODEL_DIR + "Issue3034.aadl";
+	private static final String NESTED_MODEL = MODEL_DIR + "Issue3034Nested.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	private AnalysisErrorReporterManager errorManager;
+
+	/**
+	 * Every connection reference of a replicated connection instance names the array element that
+	 * contains it.
+	 */
+	@Test
+	public void replicatedConnectionReferencesNameTheirElement() throws Exception {
+		SystemInstance instance = instantiate(MODEL, "Top.noIndex");
+
+		assertEquals(List.of(
+				"Top_noIndex_Instance.nested[1].producers[1].outp --> consumers[1].inp"
+						+ " = [c in Top_noIndex_Instance.nested[1]]",
+				"Top_noIndex_Instance.nested[1].producers[2].outp --> consumers[2].inp"
+						+ " = [c in Top_noIndex_Instance.nested[1]]",
+				"Top_noIndex_Instance.nested[2].producers[1].outp --> consumers[1].inp"
+						+ " = [c in Top_noIndex_Instance.nested[2]]",
+				"Top_noIndex_Instance.nested[2].producers[2].outp --> consumers[2].inp"
+						+ " = [c in Top_noIndex_Instance.nested[2]]"),
+				referenceContexts(instance));
+		assertEquals(List.of(), diagnostics(instance));
+	}
+
+	/**
+	 * A containment path that indexes the first element of the array that owns the connection applies
+	 * the value to the connection instances of that element and to no other.
+	 */
+	@Test
+	public void containedPropertyOnIndexedElementAppliesToThatElement() throws Exception {
+		SystemInstance instance = instantiate(MODEL, "Top.first");
+
+		assertEquals(List.of("Top_first_Instance.nested[1].producers[1].outp --> consumers[1].inp = delayed",
+				"Top_first_Instance.nested[1].producers[2].outp --> consumers[2].inp = delayed",
+				"Top_first_Instance.nested[2].producers[1].outp --> consumers[1].inp = <none>",
+				"Top_first_Instance.nested[2].producers[2].outp --> consumers[2].inp = <none>"),
+				cachedTimings(instance));
+		assertEquals(List.of(), diagnostics(instance));
+	}
+
+	/**
+	 * A containment path that indexes an element whose connection instances are replicated copies
+	 * applies the value to the connection instances of that element.
+	 */
+	@Test
+	public void containedPropertyOnSecondElementIsNotLost() throws Exception {
+		SystemInstance instance = instantiate(MODEL, "Top.second");
+
+		assertEquals(List.of("Top_second_Instance.nested[1].producers[1].outp --> consumers[1].inp = <none>",
+				"Top_second_Instance.nested[1].producers[2].outp --> consumers[2].inp = <none>",
+				"Top_second_Instance.nested[2].producers[1].outp --> consumers[1].inp = delayed",
+				"Top_second_Instance.nested[2].producers[2].outp --> consumers[2].inp = delayed"),
+				cachedTimings(instance));
+		assertEquals(List.of(), diagnostics(instance));
+	}
+
+	/**
+	 * Control: a containment path without an index names every element of the array, and an indexed
+	 * containment path whose last element is a component resolves to that component instance only.
+	 * Both are unaffected by the connection reference context.
+	 */
+	@Test
+	public void containedPropertyWithoutIndexAppliesToAllElements() throws Exception {
+		SystemInstance allElements = instantiate(MODEL, "Top.noIndex");
+
+		assertEquals(List.of("Top_noIndex_Instance.nested[1].producers[1].outp --> consumers[1].inp = delayed",
+				"Top_noIndex_Instance.nested[1].producers[2].outp --> consumers[2].inp = delayed",
+				"Top_noIndex_Instance.nested[2].producers[1].outp --> consumers[1].inp = delayed",
+				"Top_noIndex_Instance.nested[2].producers[2].outp --> consumers[2].inp = delayed"),
+				cachedTimings(allElements));
+		assertEquals(List.of(), diagnostics(allElements));
+
+		SystemInstance componentTarget = instantiate(MODEL, "Top.componentTarget");
+
+		assertEquals(List.of("Top_componentTarget_Instance.nested[2].producers[1]"),
+				pathsWithProperty(componentTarget, "Period"));
+		assertEquals(List.of(), diagnostics(componentTarget));
+	}
+
+	/**
+	 * The complete connection reference chain of a replicated connection instance names the component
+	 * instances of the element that contains it. The contexts of the enclosed references are already
+	 * corrected by the endpoint resolution; the context of the reference that goes across is the one
+	 * the replication left behind.
+	 */
+	@Test
+	public void replicatedConnectionReferenceChainNamesItsElement() throws Exception {
+		SystemInstance instance = instantiate(NESTED_MODEL, "Top.i");
+
+		assertEquals(List.of(
+				"Top_i_Instance.nested[1].producer_side.p.outp -> consumer_side.cs.inp"
+						+ " = [up in Top_i_Instance.nested[1].producer_side,"
+						+ " across in Top_i_Instance.nested[1],"
+						+ " down in Top_i_Instance.nested[1].consumer_side]",
+				"Top_i_Instance.nested[2].producer_side.p.outp --> consumer_side.cs.inp"
+						+ " = [up in Top_i_Instance.nested[2].producer_side,"
+						+ " across in Top_i_Instance.nested[2],"
+						+ " down in Top_i_Instance.nested[2].consumer_side]"),
+				referenceContexts(instance));
+		assertEquals(List.of("Top_i_Instance.nested[1].producer_side.p.outp -> consumer_side.cs.inp = <none>",
+				"Top_i_Instance.nested[2].producer_side.p.outp --> consumer_side.cs.inp = delayed"),
+				cachedTimings(instance));
+		assertEquals(List.of(), diagnostics(instance));
+	}
+
+	/**
+	 * The connection and the context of every connection reference, keyed by the path of the connection
+	 * instance.
+	 */
+	private List<String> referenceContexts(SystemInstance instance) {
+		return instance.getAllConnectionInstances()
+				.stream()
+				.map(conni -> conni.getInstanceObjectPath() + " = " + conni.getConnectionReferences()
+						.stream()
+						.map(connRef -> connRef.getConnection().getName() + " in "
+								+ connRef.getContext().getInstanceObjectPath())
+						.toList())
+				.sorted()
+				.toList();
+	}
+
+	/**
+	 * The Timing value cached on each connection instance, keyed by the path of the connection instance.
+	 */
+	private List<String> cachedTimings(SystemInstance instance) {
+		return instance.getAllConnectionInstances()
+				.stream()
+				.map(conni -> conni.getInstanceObjectPath() + " = " + cachedTiming(conni))
+				.sorted()
+				.toList();
+	}
+
+	private String cachedTiming(ConnectionInstance conni) {
+		return conni.getOwnedPropertyAssociations()
+				.stream()
+				.filter(pa -> pa.getProperty().getName().equalsIgnoreCase("Timing"))
+				.map(pa -> (NamedValue) pa.getOwnedValues().get(0).getOwnedValue())
+				.map(value -> ((EnumerationLiteral) value.getNamedValue()).getName())
+				.findFirst()
+				.orElse("<none>");
+	}
+
+	/**
+	 * The paths of all component instances that cache the named property.
+	 */
+	private List<String> pathsWithProperty(ComponentInstance ci, String propertyName) {
+		List<String> result = new ArrayList<>();
+
+		if (ci.getOwnedPropertyAssociations()
+				.stream()
+				.anyMatch(pa -> pa.getProperty().getName().equalsIgnoreCase(propertyName))) {
+			result.add(ci.getInstanceObjectPath());
+		}
+		ci.getComponentInstances().forEach(child -> result.addAll(pathsWithProperty(child, propertyName)));
+		return result;
+	}
+
+	private SystemInstance instantiate(String model, String implementationName) throws Exception {
+		AadlPackage pkg = testHelper.parseFile(model);
+		validationHelper.assertNoIssues(pkg);
+		ComponentImplementation implementation = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals(implementationName))
+				.findFirst()
+				.orElseThrow();
+		errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+
+		SystemInstance instance = InstantiateModel.instantiate(implementation, errorManager);
+
+		assertNotNull(instance);
+		return instance;
+	}
+
+	private List<String> diagnostics(SystemInstance instance) {
+		return ((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource())).getErrors()
+				.stream()
+				.map(message -> message.kind + ": " + message.message)
+				.toList();
+	}
+}


### PR DESCRIPTION
Fixes #3034

## Cause

A connection declared in a subcomponent array is instantiated for the first array element only
(`CreateConnectionsSwitch.isFirstArrayElement()`) and then replicated into the remaining elements by
`InstantiateModel.createNewConnection(ConnectionInstance, ComponentInstance)`. The copy re-resolves
its source and its destination against the target element, and `resolveConnectionReference()` gives
every *enclosed* connection reference a context in that element, but nothing updates the context of
the reference that goes across in the copied element. Every replicated connection therefore kept the
first array element as that context.

`ComponentInstance.findConnectionInstance(Connection)` selects connection instances by connection
plus `this == connRef.getContext()`, and it is how `findInstanceObjectsHelper()` resolves a
containment path whose last element is a connection. So a contained property association that indexes
one array element was applied to the connections of *every* element (`applies to nested[1].c`) or to
no connection at all (`applies to nested[2].c`), in both cases without a diagnostic.

## Correction

`relocateConnectionReferenceContexts()` maps the context of every connection reference of the copy
from the subtree of the original element into the subtree of the target element, using
`relocateComponentInstance()` to find the counterpart by name and array indices. A context that is
neither the original element nor contained in it has no counterpart and is left untouched, which
preserves the contexts that the endpoint resolution already corrected. The
`Connection_Pattern` / `Connection_Set` variant of `createNewConnection()` copies within the same
container and is unchanged.

## Regression

`Issue3034Test` with an external model project `models/issue3034`:

- `Issue3034.aadl` — the reported topology: `process Inner.i[2]` whose implementation connects
  `thread Producer[2]` to `thread Consumer[2]`, with `Top.first` (`applies to nested[1].c`),
  `Top.second` (`applies to nested[2].c`), `Top.noIndex` (`applies to nested.c`) and
  `Top.componentTarget` (`Period ... applies to nested[2].producers[1]`).
- `Issue3034Nested.aadl` — a chain of three connection references (`up`, `across`, `down`) inside the
  array element, so the enclosed references are covered as well as the one that goes across.

Assertions: every connection reference of a replicated connection instance names the element that
contains it; `applies to nested[1].c` reaches the two connection instances of `nested[1]` and no
other; `applies to nested[2].c` reaches the two connection instances of `nested[2]`; an unindexed
containment path and an indexed path ending at a component are unchanged controls; no diagnostics are
reported.

Before the fix, 4 of the 5 tests failed. The nested chain showed precisely which context was stale:
`up` and `down` already named `nested[2].producer_side` and `nested[2].consumer_side`, while `across`
still named `nested[1]`.

`Issue3032Test.containedPropertiesOnExpandedConnectionsAreUnchanged` characterized the defect for
`Top.perElement`, where the containment path indexes the element that owns the connection and reached
no connection instance. Its expectation and comment are updated in the fix commit; that is the only
existing test whose expected values change.

## Commands and results

Focused core regression, `clean install` so Tycho executes the tests:

```
mvn -o -s releng/osate.releng/settings.xml -Plocal \
  -pl :org.osate.aadl2.instantiation,:org.osate.core.tests,:org.osate.core.feature \
  -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false \
  -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
  -Dtest=Issue3034Test -DfailIfNoTests=false clean install
```

- Before the fix: `Tests run: 5, Failures: 4`.
- After the fix: `Tests run: 5, Failures: 0`.

Related connection regressions, same selection with
`-Dtest='Issue3034Test,Issue3032Test,Issue3030Test,Issue3027Test,Issue3025Test,Issue3023Test,Issue3021Test,Issue3019Test,Issue3017Test,Issue2988Test'`:
`Tests run: 20, Failures: 0, Errors: 0`, with `Issue3032Test` reporting 6 of 6 and `Issue3034Test`
5 of 5.

Clean root reactor:

```
mvn -s releng/osate.releng/settings.xml -Plocal -Dtycho.localArtifacts=ignore \
  -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
  -DfailIfNoTests=false clean install
```

`BUILD SUCCESS`, 1154 tests across the core, textual instance model, analyses, EMV2, ALISA, GE and BA
bundles, 0 failures and 0 errors.

## Dependencies

Based on `master` at `30b0fe3456` (issue #3032, final expansion pipeline). No other open branch is
required.

## Residual risk

- Connection reference contexts of replicated connections are now different objects than before, which
  changes what context-sensitive consumers observe: `Aadl2InstanceUtil.getIncomingConnectionReferences()`
  and `getOutgoingConnectionReferences()`, `CachePropertyAssociationsSwitch` mode lookup through the
  reference context, `EMV2Util`, and the `context` reference serialized by
  `org.osate.aadl2.instance.textual`. Each now names the element that contains the reference, which is
  the intended value; the reactor run covers those bundles.
- Existing `.aaxl2` files still parse and load, and their stored contexts are unchanged;
  reinstantiation is required to obtain the corrected contexts.
- Connection instance names are untouched, including the pre-existing ` -> ` versus ` --> ` difference
  between originally created and copied connection instances.
- The relocation matches counterparts by name and array indices within the copied subtree. It returns
  no counterpart, and therefore leaves the context alone, if the two elements are not structurally
  identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)