### PR TITLE
Reject internal features at connection destinations 🤖

### DIFF
--- a/core/org.osate.core.tests/models/issue3028/.gitignore
+++ b/core/org.osate.core.tests/models/issue3028/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3028/.project
+++ b/core/org.osate.core.tests/models/issue3028/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3028</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3028/Issue3028.aadl
+++ b/core/org.osate.core.tests/models/issue3028/Issue3028.aadl
@@ -1,0 +1,33 @@
+package Issue3028
+public
+	device Sensor
+		features
+			alarm: out event port;
+	end Sensor;
+
+	device Monitor
+		features
+			incoming: in event port;
+			also_incoming: in event port;
+	end Monitor;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			sensor: device Sensor;
+			monitor: device Monitor;
+		internal features
+			raised_event: event;
+			logged_event: event;
+			shared_event: event;
+		connections
+			--  Illegal: an internal feature is allowed only at the source end.
+			to_internal: port sensor.alarm -> self.raised_event;
+			--  Legal: an internal feature at the source end.
+			from_internal: port self.logged_event -> monitor.incoming;
+			--  Questionable: bidirectional, so the internal feature also acts as a destination.
+			bidirectional_internal: port self.shared_event <-> monitor.also_incoming;
+	end Top.i;
+end Issue3028;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/aadl2javavalidator/ConnectionAndFlowTypesTest.xtend
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/aadl2javavalidator/ConnectionAndFlowTypesTest.xtend
@@ -1708,6 +1708,11 @@ class ConnectionAndFlowTypesTest extends XtextTest {
 					source.assertError(testFileResult.issues, issueCollection, "A 'subprogram proxy' is not a valid feature connection end.")
 					destination.assertWarning(testFileResult.issues, issueCollection, "Expected feature 'af3' to have classifier 'legalTypeTest::subpcontainer'")
 				]
+				ownedFeatureConnections.get(6) => [
+					"fconn7".assertEquals(name)
+					//Tests checkInternalFeatureConnectionEnd
+					source.assertWarning(testFileResult.issues, issueCollection, "Bidirectional connection makes internal feature 'eds1' a connection destination.")
+				]
 				ownedFeatureConnections.get(8) => [
 					"fconn9".assertEquals(name)
 					//Tests typeCheckFeatureConnectionEnd

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3027Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3027Test.java
@@ -47,7 +47,14 @@ public class Issue3027Test extends XtextTest {
 	@Test
 	public void connectionToInternalFeatureIsReportedNotDereferenced() throws Exception {
 		var pkg = testHelper.parseFile(MODEL);
-		validationHelper.assertNoIssues(pkg);
+		/*
+		 * The connection into the internal feature is rejected by the declarative validator since issue #3028. The
+		 * instantiator must still handle it without dereferencing the missing destination feature instance.
+		 */
+		var validationIssues = validationHelper.validate(pkg);
+		assertEquals(1, validationIssues.size());
+		assertEquals("Internal feature 'raised_event' is allowed only at the source end of a connection.",
+				validationIssues.get(0).getMessage());
 		var top = (ComponentImplementation) pkg.getOwnedPublicSection().getOwnedClassifiers().stream()
 				.filter(classifier -> classifier.getName().equals("Top.i"))
 				.findFirst()

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3028Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3028Test.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, MERCHANTABILITY, EXCLUSIVITY,
+ * RESULTS OBTAINED FROM USE OF THE MATERIAL, OR FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.Connection;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.AssertHelper;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.FluentIssueCollection;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * An internal feature is allowed only at the source end of a connection. The model declares one connection into an
+ * internal feature, one legal connection out of an internal feature, and one bidirectional connection whose source is
+ * an internal feature.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3028Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3028/Issue3028.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Test
+	public void internalFeatureIsAllowedOnlyAtConnectionSource() throws Exception {
+		FluentIssueCollection result = issues = testHelper.testFile(MODEL);
+		FluentIssueCollection expectedIssues = new FluentIssueCollection(result.getResource(), new ArrayList<>(),
+				new ArrayList<>());
+
+		AadlPackage pkg = (AadlPackage) result.getResource().getContents().get(0);
+		ComponentImplementation top = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+
+		Connection toInternal = findConnection(top, "to_internal");
+		Connection fromInternal = findConnection(top, "from_internal");
+		Connection bidirectionalInternal = findConnection(top, "bidirectional_internal");
+
+		// A connection into an internal feature is illegal.
+		AssertHelper.assertError(toInternal.getDestination(), result.getIssues(), expectedIssues,
+				"Internal feature 'raised_event' is allowed only at the source end of a connection.");
+
+		// A connection out of an internal feature is legal.
+		AssertHelper.assertError(fromInternal.getSource(), result.getIssues(), expectedIssues);
+		AssertHelper.assertWarning(fromInternal.getSource(), result.getIssues(), expectedIssues);
+
+		// A bidirectional connection also uses its source end as a destination.
+		AssertHelper.assertWarning(bidirectionalInternal.getSource(), result.getIssues(), expectedIssues,
+				"Bidirectional connection makes internal feature 'shared_event' a connection destination.");
+
+		expectedIssues.sizeIs(result.getIssues().size());
+		assertConstraints(expectedIssues);
+	}
+
+	private static Connection findConnection(ComponentImplementation implementation, String name) {
+		Connection connection = implementation.getOwnedConnections()
+				.stream()
+				.filter(candidate -> name.equals(candidate.getName()))
+				.findFirst()
+				.orElseThrow();
+		assertEquals(name, connection.getName());
+		return connection;
+	}
+}

--- a/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/validation/Aadl2Validator.java
+++ b/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/validation/Aadl2Validator.java
@@ -389,6 +389,7 @@ public class Aadl2Validator extends AbstractAadl2Validator {
 		if (connection.getRefined() == null) {
 			typeCheckPortConnectionEnd(connection.getSource());
 			typeCheckPortConnectionEnd(connection.getDestination());
+			checkInternalFeatureConnectionEnd(connection);
 			checkConnectionDirection(connection);
 			checkPortConnectionEnds(connection);
 			checkAggregateDataPort(connection);
@@ -420,6 +421,9 @@ public class Aadl2Validator extends AbstractAadl2Validator {
 
 	@Check(CheckType.FAST)
 	public void caseFeatureConnection(FeatureConnection connection) {
+		if (connection.getRefined() == null) {
+			checkInternalFeatureConnectionEnd(connection);
+		}
 		checkFeatureGroupChaining(connection);
 		ConnectionEnd src = connection.getAllLastSource();
 		ConnectionEnd dst = connection.getAllLastDestination();
@@ -8173,6 +8177,37 @@ public class Aadl2Validator extends AbstractAadl2Validator {
 				}
 			}
 		}
+	}
+
+	/**
+	 * An internal feature is a source of events or event data inside the containing component. It is therefore allowed
+	 * only at the source end of a connection. A bidirectional connection uses its source end as a destination as well,
+	 * so an internal feature there is reported too.
+	 *
+	 * An internal feature belongs to the containing component implementation, so it is only ever referenced without a
+	 * context. A contextual reference to an internal feature is already reported by the connection end type checks.
+	 */
+	private void checkInternalFeatureConnectionEnd(Connection connection) {
+		ConnectedElement destination = connection.getDestination();
+		if (isInternalFeatureOfContainingComponent(destination)) {
+			error("Internal feature '" + destination.getLastConnectionEnd().getName()
+					+ "' is allowed only at the source end of a connection.", destination,
+					Aadl2Package.eINSTANCE.getConnectedElement_ConnectionEnd());
+		}
+		ConnectedElement source = connection.getSource();
+		if (connection.isAllBidirectional() && isInternalFeatureOfContainingComponent(source)) {
+			warning("Bidirectional connection makes internal feature '" + source.getLastConnectionEnd().getName()
+					+ "' a connection destination.", source,
+					Aadl2Package.eINSTANCE.getConnectedElement_ConnectionEnd());
+		}
+	}
+
+	private static boolean isInternalFeatureOfContainingComponent(ConnectedElement connectedElement) {
+		if (connectedElement == null || connectedElement.getContext() != null) {
+			return false;
+		}
+		ConnectionEnd connectionEnd = connectedElement.getLastConnectionEnd();
+		return connectionEnd instanceof InternalFeature && !connectionEnd.eIsProxy();
 	}
 
 	private void checkThroughConnection(Connection connection) {


### PR DESCRIPTION
Fixes #3028

## Cause and correction

An internal feature is an event or event data source inside the containing component implementation, so it is allowed only at the source end of a connection. The declarative validator accepted it at either end: `checkConnectionDirection()` only rejected the case where *both* ends are internal features, and `checkPortConnectionEnds()` explicitly listed `EventSource`/`EventDataSource` among the acceptable destinations. A connection into an internal feature therefore validated cleanly and only surfaced later as the instantiator warning `Connection to <feature> could not be instantiated.` (`CreateConnectionsSwitch.appendSegment()`).

The fix adds `checkInternalFeatureConnectionEnd()` to `Aadl2Validator`, called for port connections and feature connections (the two connection kinds where an internal feature is a legal connection end at all):

- **Error** when the destination end resolves to an internal feature of the containing component.
- **Warning** when such a feature is the source end of a *bidirectional* connection, because that end also acts as a destination.

Ends reached through a context (`dp1.eds3`, `call1.eds2`, `param1.eds3`, …) are skipped: a contextual reference to an internal feature is already rejected by `typeCheckPortConnectionEnd()` / `typeCheckFeatureConnectionEnd()`, so this avoids a second diagnostic on an already-invalid end.

`checkPortConnectionEnds()` is deliberately left unchanged, so an illegal destination yields exactly one message instead of two overlapping ones. The pre-existing `Cannot connect two internal features of the containing component.` error is also untouched, so a connection with internal features at both ends now reports both messages.

## Regression model and assertion

`core/org.osate.core.tests/models/issue3028/Issue3028.aadl` declares three port connections in one system implementation:

```aadl
to_internal: port sensor.alarm -> self.raised_event;
from_internal: port self.logged_event -> monitor.incoming;
bidirectional_internal: port self.shared_event <-> monitor.also_incoming;
```

`Issue3028Test` asserts the error on `to_internal`'s destination, that `from_internal` stays free of errors and warnings, the warning on `bidirectional_internal`'s source, and — via `sizeIs`/`assertConstraints` — that the model produces no other issues. Before the fix it failed with `expected:<[Internal feature 'raised_event' is allowed only at the source end of a connection.]> but was:<[]>`.

Two existing tests observe the new diagnostics and are updated in the fix commit:

- `Issue3027Test` — its fixture models a connection into an internal feature on purpose, so `assertNoIssues` becomes an assertion of exactly the one new error. The instantiation assertions are unchanged, preserving the issue 3027 coverage that the instantiator does not dereference the missing destination feature instance.
- `ConnectionAndFlowTypesTest` — records the new warning for the bidirectional feature connection `fconn7: feature eds1 <-> asub1.af3`.

## Commands and results

Focused core tests:

```bash
mvn -o -s releng/osate.releng/settings.xml -Plocal \
  -pl :org.osate.xtext.aadl2,:org.osate.core.tests,:org.osate.core.feature \
  -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false \
  -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
  -Dtest='Issue3028Test,Issue3027Test,ConnectionAndFlowTypesTest,OtherAadl2JavaValidatorTest,ConnectedElementsAndFlowEndsTest,ModeTransitionsTest,OtherAadl2ScopeProviderTest' \
  -DfailIfNoTests=false clean install
```

Result: 25 tests, 0 failures, 0 errors. `TEST-org.osate.core.tests.issues.Issue3028Test.xml` reports `tests="1" failures="0" errors="0"`.

Clean root reactor:

```bash
mvn -s releng/osate.releng/settings.xml -Plocal \
  -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false \
  -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
  -DfailIfNoTests=false clean install
```

Result: BUILD SUCCESS, 2310 tests, 0 failures, 0 errors.

## Dependencies

None. The branch is based on current `master` (`cd326a40b6`) and does not depend on an unmerged PR. It touches the issue 3027 regression test only because that fixture intentionally contains the newly rejected model shape.

## Residual risk

- Models that connect into an internal feature, or that use a bidirectional connection out of one, now show a marker where they previously validated cleanly. Those models could not be instantiated correctly before either; the instantiator dropped the segment with a warning.
- The bidirectional case is reported as a warning rather than an error, so existing models keep instantiating.
- The SpotBugs/JaCoCo gate and the `with-ge-tests` profile were not run for this change; no GE, EMV2, ALISA, or BA test model connects to an internal feature (only EMV2 annex constructs reference internal features, which are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)