### PR TITLE
Stop narrowing connection ends past their feature group nesting 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateConnectionsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateConnectionsSwitch.java
@@ -1064,6 +1064,10 @@ public class CreateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 						dstEnd = (FeatureInstance) AadlUtil.findNamedElementInList(flist, name);
 					}
 				}
+				if (dstEnd == null) {
+					// this level does not exist below dstEnd, see the comment in the down case
+					return;
+				}
 			}
 		} else if (!downFeature.isEmpty()) {
 			// dstEnd is further down in the hierarchy than srcEnd: find feature corresponding to dstEnd
@@ -1088,6 +1092,21 @@ public class CreateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 						String name = downFi.getName();
 						srcEnd = (FeatureInstance) AadlUtil.findNamedElementInList(flist, name);
 					}
+				}
+				if (srcEnd == null) {
+					/*
+					 * Issue 3038: The stack describes the feature group levels the traversal
+					 * descended through, counted from the outermost boundary feature group. This
+					 * traversal was seeded at a feature contained in that boundary feature group,
+					 * because instantiateExternalConnections() seeds both a boundary feature group
+					 * and its members, so the first stack entries describe levels at or above the
+					 * seed and narrowing runs off the end of the seed's own nesting.
+					 *
+					 * There is nothing to create and nothing to report: the seed at the enclosing
+					 * feature group enumerates the same semantic connection and reaches the same
+					 * leaf. Continuing would dereference null.
+					 */
+					return;
 				}
 			}
 			connInfo.src = srcEnd;

--- a/core/org.osate.core.tests/models/issue3038/.gitignore
+++ b/core/org.osate.core.tests/models/issue3038/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3038/.project
+++ b/core/org.osate.core.tests/models/issue3038/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3038</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3038/Issue3038.aadl
+++ b/core/org.osate.core.tests/models/issue3038/Issue3038.aadl
@@ -1,0 +1,48 @@
+-- The boundary feature group of Producer nests one feature group, and the
+-- subcomponent's feature group is connected to that nested member rather than to
+-- the boundary feature group itself. Instantiating Producer.i as the top-level
+-- system crashes in balanceFeatureGroupEnds because the source end of the
+-- boundary segment is null.
+package Issue3038
+public
+
+	feature group LeafGroup
+		features
+			alpha: in out event port;
+	end LeafGroup;
+
+	feature group OuterGroup
+		features
+			inner: feature group LeafGroup;
+	end OuterGroup;
+
+	thread Leaf
+		features
+			io: in out event port;
+	end Leaf;
+
+	process LeafSide
+		features
+			boundary: feature group LeafGroup;
+	end LeafSide;
+
+	process implementation LeafSide.i
+		subcomponents
+			leaf: thread Leaf;
+		connections
+			up: port leaf.io <-> boundary.alpha;
+	end LeafSide.i;
+
+	system Producer
+		features
+			boundary: feature group OuterGroup;
+	end Producer;
+
+	system implementation Producer.i
+		subcomponents
+			leaf_side: process LeafSide.i;
+		connections
+			nested_up: feature group leaf_side.boundary <-> boundary.inner;
+	end Producer.i;
+
+end Issue3038;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3038Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3038Test.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instance.ConnectionInstance;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * Regression test for issue #3038.
+ *
+ * <p>
+ * {@code Producer.i} declares a boundary feature group whose single member is
+ * itself a feature group, and connects a subcomponent's feature group to that
+ * nested member rather than to the boundary feature group. Instantiating it as the
+ * top-level system used to throw {@code NullPointerException} from
+ * {@code CreateConnectionsSwitch.balanceFeatureGroupEnds}, because the boundary
+ * segment's source end is null and was dereferenced without a check.
+ * </p>
+ *
+ * <p>
+ * The assertion is deliberately independent of which repair is chosen. Either the
+ * boundary connection is instantiated with both endpoints resolved, or a
+ * diagnostic explains why it was not. What may never happen is an unhandled
+ * exception, a connection instance with a null endpoint, or the connection being
+ * dropped silently.
+ * </p>
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3038Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3038/Issue3038.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void nestedBoundaryFeatureGroupMemberDoesNotCrashInstantiation() throws Exception {
+		var pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+		var producer = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals("Producer.i"))
+				.findFirst()
+				.orElseThrow();
+		var errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+
+		SystemInstance instance = InstantiateModel.instantiate(producer, errorManager);
+
+		var connections = instance.getAllConnectionInstances();
+		for (ConnectionInstance connection : connections) {
+			assertNotNull("connection '" + connection.getName() + "' has no source", connection.getSource());
+			assertNotNull("connection '" + connection.getName() + "' has no destination", connection.getDestination());
+		}
+
+		var messages = ((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource())).getErrors();
+		assertTrue("the boundary connection must either be instantiated or be explained by a diagnostic",
+				!connections.isEmpty() || !messages.isEmpty());
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3038Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3038Test.java
@@ -23,8 +23,12 @@
  */
 package org.osate.core.tests.issues;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
+import java.util.List;
 
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.XtextRunner;
@@ -98,5 +102,21 @@ public class Issue3038Test extends XtextTest {
 		var messages = ((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource())).getErrors();
 		assertTrue("the boundary connection must either be instantiated or be explained by a diagnostic",
 				!connections.isEmpty() || !messages.isEmpty());
+
+		/*
+		 * The semantic connection leaves the system, so it is incomplete and traverses
+		 * both declarations: up inside LeafSide.i and nested_up inside Producer.i. It is
+		 * enumerated once, from the boundary feature group; the seed at the contained
+		 * member boundary.inner reaches the same leaf and must not add a second instance.
+		 */
+		assertEquals(List.of("Producer_i_Instance.leaf_side.leaf.io -> Producer_i_Instance.boundary.inner.alpha|2"),
+				connections.stream()
+						.map(connection -> connection.getSource().getInstanceObjectPath() + " -> "
+								+ connection.getDestination().getInstanceObjectPath() + "|"
+								+ connection.getConnectionReferences().size())
+						.toList());
+		assertFalse("the connection leaves the system, so it is not complete",
+				connections.get(0).isComplete());
+		assertEquals(List.of(), messages);
 	}
 }


### PR DESCRIPTION
Fixes #3038

## Summary

Instantiating a system whose boundary feature group nests a feature group that is connected to a subcomponent's feature group crashed with `NullPointerException` instead of producing a connection instance.

## Root cause

`balanceFeatureGroupEnds()` narrows one end of a semantic connection down through feature group levels, one level per entry on the `upFeature` or `downFeature` stack. Each iteration reads the children of the end the previous iteration produced, and the loop ran for every stack entry unconditionally.

The stack counts levels from the *outermost* boundary feature group, but `instantiateExternalConnections()` seeds a traversal from each boundary feature group **and, separately, from each feature contained in it**. For a seed that is already a contained member, the leading stack entries describe levels at or above that seed, so narrowing runs off the end of the seed's own nesting, `AadlUtil.findNamedElementInList()` finds no matching child, and the next iteration dereferences `null`.

Concretely, for the fixture seeded at `boundary.inner`: the stack entry `inner` is looked up among `inner`'s own children `[alpha]`, which yields `null`, and the following iteration crashes.

## Fix

Stop as soon as narrowing finds no matching feature.

No diagnostic is emitted, deliberately. The seed at the enclosing feature group enumerates the same semantic connection and reaches the same leaf, so a warning here would claim a connection was lost when it was not. This is confirmed by the fixture: the expected connection is present after the fix.

The same guard is applied to the `upFeature` loop, which narrows the destination end by the same mechanism and can produce `null` the same way. **No fixture reaches that branch**, so it is symmetry rather than a demonstrated fix — say the word and I will drop it if unexercised defensive code is unwanted here.

The production change is 19 lines and touches no signature.

## Verification

- `Issue3038Test` fails on `master` with the reported `NullPointerException` and passes with the fix. It asserts the exact resulting connection, its incompleteness, its reference count, that no connection instance has a null endpoint, and that no diagnostics are reported.

  ```text
  Producer_i_Instance.leaf_side.leaf.io -> Producer_i_Instance.boundary.inner.alpha   complete=false, refs=2
  ```

  The connection leaves the system, so it is incomplete, and it traverses both declarations (`up` inside `LeafSide.i`, `nested_up` inside `Producer.i`). It is enumerated once, from the boundary feature group; the redundant seed at the contained member `boundary.inner` no longer crashes and adds nothing.

- `ProducerSide.i` in the existing `issue3019` fixture is the shape that exposed this crash. It now instantiates the same way. `Top.i` and `SubsetTop.i` in that fixture are unchanged, matching `Issue3019Test`'s existing assertions (2 and 1 connection instances).

- All 570 tests in `org.osate.core.tests` pass.

- By construction the guard can only affect paths that previously threw, so no model that instantiates today can change behavior. Checked against an independent baseline capture: connection descriptors and traversal counters for a separate feature-group characterization fixture are byte-identical before and after.

## How this was found

By sweeping every `ComponentImplementation` in every parseable model under `core/org.osate.core.tests/models/` through instantiation: 1246 implementations instantiated, two crashed. This is one of them. The other, `Issue2835.aadl :: S.i1`, is not a defect — that fixture is intentionally invalid and `Issue2835Test` asserts four validation errors on it.

## Not run

A clean root-reactor build and the sibling `aadl-language-server` compile were not run. The change is a local guard inside one method with no API change, so the module build plus the full core test suite was the proportionate check. Say if you want either before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
