### PR TITLE
Narrow only the feature group levels below a connection end 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateConnectionsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateConnectionsSwitch.java
@@ -1046,6 +1046,10 @@ public class CreateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 			// we need to match from latest to the oldest in stack going down into the FG nesting hierarchy
 			for (int count = upFeature.size() - 1; count >= 0; count--) {
 				FeatureInstance upFi = upFeature.get(count);
+				if (upFi == dstEnd) {
+					// this entry names the level dstEnd already stands at, see the down case
+					continue;
+				}
 				EList<FeatureInstance> flist = ((FeatureInstance) dstEnd).getFeatureInstances();
 				if (connInfo.dstToMatch != null) {
 					String name = connInfo.dstToMatch.getConnectionEnd().getName();
@@ -1075,6 +1079,20 @@ public class CreateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 			// This is a down stack, i.e., the highest element got pushed first and is the oldest.
 			for (int count = 0; count < downFeature.size(); count++) {
 				FeatureInstance downFi = downFeature.get(count);
+				if (downFi == srcEnd) {
+					/*
+					 * Issue 3040: This entry names the level the end already stands at, so there is
+					 * nothing to narrow for it.
+					 *
+					 * The stack counts feature group levels from the outermost boundary feature, but
+					 * instantiateExternalConnections() seeds a traversal from a boundary feature and
+					 * from each feature contained in one. A traversal seeded at a contained member
+					 * therefore starts one or more levels below where the stack starts counting.
+					 * Narrowing such an entry would look for a feature among its own children and
+					 * find nothing, abandoning a path that should produce a connection instance.
+					 */
+					continue;
+				}
 				EList<FeatureInstance> flist = ((FeatureInstance) srcEnd).getFeatureInstances();
 				if (connInfo.srcToMatch != null) {
 					String name = connInfo.srcToMatch.getConnectionEnd().getName();
@@ -1095,16 +1113,13 @@ public class CreateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 				}
 				if (srcEnd == null) {
 					/*
-					 * Issue 3038: The stack describes the feature group levels the traversal
-					 * descended through, counted from the outermost boundary feature group. This
-					 * traversal was seeded at a feature contained in that boundary feature group,
-					 * because instantiateExternalConnections() seeds both a boundary feature group
-					 * and its members, so the first stack entries describe levels at or above the
-					 * seed and narrowing runs off the end of the seed's own nesting.
+					 * Issue 3038: narrowing found no matching feature, so the path cannot be
+					 * continued and must not be dereferenced.
 					 *
-					 * There is nothing to create and nothing to report: the seed at the enclosing
-					 * feature group enumerates the same semantic connection and reaches the same
-					 * leaf. Continuing would dereference null.
+					 * The common cause, a stack entry naming the level the end already stands at, is
+					 * handled by the skip above since issue 3040; do not assume that some other seed
+					 * covers whatever reaches here, because for the nested boundary shape that
+					 * assumption was wrong and a connection instance went missing.
 					 */
 					return;
 				}

--- a/core/org.osate.core.tests/models/issue3040/.gitignore
+++ b/core/org.osate.core.tests/models/issue3040/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3040/.project
+++ b/core/org.osate.core.tests/models/issue3040/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3040</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3040/Issue3040.aadl
+++ b/core/org.osate.core.tests/models/issue3040/Issue3040.aadl
@@ -1,0 +1,59 @@
+-- Flat.i and Nested.i differ only in whether the boundary feature group nests the
+-- feature group the subcomponent connects to. Nesting a feature group must not
+-- change which semantic connections exist, only how deep their endpoints sit, so
+-- both implementations must produce the same two connections one level apart.
+package Issue3040
+public
+
+	feature group LeafGroup
+		features
+			alpha: in out event port;
+	end LeafGroup;
+
+	feature group OuterGroup
+		features
+			inner: feature group LeafGroup;
+	end OuterGroup;
+
+	thread Leaf
+		features
+			io: in out event port;
+	end Leaf;
+
+	process LeafSide
+		features
+			boundary: feature group LeafGroup;
+	end LeafSide;
+
+	process implementation LeafSide.i
+		subcomponents
+			leaf: thread Leaf;
+		connections
+			up: port leaf.io <-> boundary.alpha;
+	end LeafSide.i;
+
+	system Flat
+		features
+			boundary: feature group LeafGroup;
+	end Flat;
+
+	system implementation Flat.i
+		subcomponents
+			leaf_side: process LeafSide.i;
+		connections
+			flat_up: feature group leaf_side.boundary <-> boundary;
+	end Flat.i;
+
+	system Nested
+		features
+			boundary: feature group OuterGroup;
+	end Nested;
+
+	system implementation Nested.i
+		subcomponents
+			leaf_side: process LeafSide.i;
+		connections
+			nested_up: feature group leaf_side.boundary <-> boundary.inner;
+	end Nested.i;
+
+end Issue3040;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3038Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3038Test.java
@@ -104,19 +104,26 @@ public class Issue3038Test extends XtextTest {
 				!connections.isEmpty() || !messages.isEmpty());
 
 		/*
-		 * The semantic connection leaves the system, so it is incomplete and traverses
-		 * both declarations: up inside LeafSide.i and nested_up inside Producer.i. It is
-		 * enumerated once, from the boundary feature group; the seed at the contained
-		 * member boundary.inner reaches the same leaf and must not add a second instance.
+		 * The path crosses the system boundary in both directions, so both connections are
+		 * incomplete and each traverses both declarations: up inside LeafSide.i and
+		 * nested_up inside Producer.i.
+		 *
+		 * Only the outward connection was created when this test was first written. That
+		 * was the defect reported as issue #3040: the traversal seeded at the contained
+		 * boundary member was abandoned during feature group narrowing, so nesting a
+		 * feature group silently changed which semantic connections existed. The guard
+		 * added here for issue #3038 stopped the crash but kept the connection missing.
 		 */
-		assertEquals(List.of("Producer_i_Instance.leaf_side.leaf.io -> Producer_i_Instance.boundary.inner.alpha|2"),
+		assertEquals(List.of("Producer_i_Instance.boundary.inner.alpha -> Producer_i_Instance.leaf_side.leaf.io|2",
+				"Producer_i_Instance.leaf_side.leaf.io -> Producer_i_Instance.boundary.inner.alpha|2"),
 				connections.stream()
 						.map(connection -> connection.getSource().getInstanceObjectPath() + " -> "
 								+ connection.getDestination().getInstanceObjectPath() + "|"
 								+ connection.getConnectionReferences().size())
+						.sorted()
 						.toList());
-		assertFalse("the connection leaves the system, so it is not complete",
-				connections.get(0).isComplete());
+		assertFalse("both connections leave the system, so neither is complete",
+				connections.stream().anyMatch(ConnectionInstance::isComplete));
 		assertEquals(List.of(), messages);
 	}
 }

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3040Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3040Test.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * Regression test for issue #3040.
+ *
+ * <p>
+ * Nesting a feature group must not change which semantic connections exist, only how
+ * deep their endpoints sit. {@code Flat.i} and {@code Nested.i} differ only in that
+ * respect, so both must produce the same two connections, one level apart.
+ * </p>
+ *
+ * <p>
+ * {@code Nested.i} used to produce only the outward connection. The traversal seeded
+ * at the contained boundary member was abandoned during feature group narrowing,
+ * because the level stack counts from the outermost boundary feature and its leading
+ * entry names the level the seed already stands at. Before issue #3038 that
+ * dereferenced null and crashed; that issue stopped the crash, and this one restores
+ * the connection.
+ * </p>
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3040Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3040/Issue3040.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void aFlatBoundaryFeatureGroupConnectsBothWays() throws Exception {
+		assertEquals(List.of("Flat_i_Instance.boundary.alpha -> Flat_i_Instance.leaf_side.leaf.io",
+				"Flat_i_Instance.leaf_side.leaf.io -> Flat_i_Instance.boundary.alpha"), connections("Flat.i"));
+	}
+
+	@Test
+	public void aNestedBoundaryFeatureGroupConnectsBothWays() throws Exception {
+		assertEquals(List.of("Nested_i_Instance.boundary.inner.alpha -> Nested_i_Instance.leaf_side.leaf.io",
+				"Nested_i_Instance.leaf_side.leaf.io -> Nested_i_Instance.boundary.inner.alpha"),
+				connections("Nested.i"));
+	}
+
+	/** The connections of one implementation, sorted, with no diagnostics reported. */
+	private List<String> connections(String implementationName) throws Exception {
+		var pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+		var implementation = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals(implementationName))
+				.findFirst()
+				.orElseThrow();
+		var errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+
+		SystemInstance instance = InstantiateModel.instantiate(implementation, errorManager);
+
+		assertEquals(List.of(),
+				((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource())).getErrors()
+						.stream()
+						.map(message -> message.kind + ": " + message.message)
+						.toList());
+		return instance.getAllConnectionInstances()
+				.stream()
+				.map(connection -> connection.getSource().getInstanceObjectPath() + " -> "
+						+ connection.getDestination().getInstanceObjectPath())
+				.sorted()
+				.toList();
+	}
+}


### PR DESCRIPTION
Fixes #3040

## Summary

Nesting a feature group silently changed which semantic connections a model has. A system whose boundary feature group *nests* the feature group a subcomponent connects to produced only the outward connection instance; the same model with a non-nested boundary produced both directions.

## Root cause

`balanceFeatureGroupEnds()` narrows one end of a semantic connection down through feature group levels, one level per entry on the `upFeature` or `downFeature` stack. The stack counts levels from the outermost boundary feature, but `instantiateExternalConnections()` seeds a traversal from a boundary feature **and, separately, from each feature contained in one**. A traversal seeded at a contained member therefore starts below where the stack starts counting, and its leading entries name levels the end already stands at. Narrowing such an entry looks for a feature among its own children, finds nothing, and the path is lost.

## Fix

Skip an entry that names the level the end already stands at, rather than abandoning the path. Four lines plus the symmetric case.

## Relationship to #3038

This is the same code path seen from the other side, and it corrects an assumption I made there.

#3038 reported a `NullPointerException` from this narrowing loop. PR #3039 stopped the crash by abandoning the path, on the stated assumption that *"the seed at the enclosing feature group enumerates the same semantic connection and reaches the same leaf"*. That assumption was wrong: the enclosing seed produces the outward connection only. So #3039 fixed the reported crash but left a connection instance missing, and this PR is the other half. The null guard from #3038 remains as a safety net, but its comment no longer claims another seed covers whatever reaches it.

## Verification

The fixture holds two system implementations differing only in nesting, so the test states the invariant rather than a bare expected value, and the flat case acts as a control:

```text
Flat.i     Flat_i_Instance.boundary.alpha        -> Flat_i_Instance.leaf_side.leaf.io
           Flat_i_Instance.leaf_side.leaf.io     -> Flat_i_Instance.boundary.alpha

Nested.i   Nested_i_Instance.boundary.inner.alpha -> Nested_i_Instance.leaf_side.leaf.io
           Nested_i_Instance.leaf_side.leaf.io    -> Nested_i_Instance.boundary.inner.alpha
```

Before the fix, `Nested.i` produced only the second line. The test also asserts that neither implementation reports any diagnostic.

`Issue3038Test` asserted the missing-connection behavior and is updated here: the model now yields both directions, both incomplete, each traversing both declarations. Its original obligations are unchanged — instantiation does not throw, no connection has a null endpoint, and no diagnostic is produced.

All 572 tests in `org.osate.core.tests` pass. The change affects enumeration for every model with nested feature groups, and `Issue3038Test` was the only test whose expectations moved.

## How this was found

While developing across-first connection traversal for #3037. The new traversal assembles both directions for this shape, and comparing it against the baseline exposed the gap. Rather than let the two disagree, the baseline is being repaired first so that "across-first reproduces the baseline" stays the invariant and no allowlist entry is needed.

## Not run

A clean root-reactor build and the sibling `aadl-language-server` compile were not run. The change is local to one method with no API change, so the module build plus the full core test suite was the proportionate check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
