### PR TITLE
Report an invalid connection direction on the connection instance 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/ConnectionInfo.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/ConnectionInfo.java
@@ -121,9 +121,8 @@ class ConnectionInfo {
 	 * @return if the new segment is a valid continuation of the connection
 	 *         instance
 	 */
-	public boolean addSegment(final Connection newSeg, final ConnectionInstanceEnd srcFi,
+	public void addSegment(final Connection newSeg, final ConnectionInstanceEnd srcFi,
 			final ConnectionInstanceEnd dstFi, final ComponentInstance ci, boolean opposite, boolean[] keep) {
-		boolean valid = true;
 		final Context srcCtx = opposite ? newSeg.getAllDestinationContext() : newSeg.getAllSourceContext();
 		final Context dstCtx = opposite ? newSeg.getAllSourceContext() : newSeg.getAllDestinationContext();
 		final ConnectionEnd source = opposite ? newSeg.getAllDestination() : newSeg.getAllSource();
@@ -138,97 +137,58 @@ class ConnectionInfo {
 		if (srcFi != null) {
 			sources.add(srcFi);
 			if (srcFi instanceof FeatureInstance) {
-				DirectionType dir = ((FeatureInstance) srcFi).getFlowDirection();
-
-				bidirectional &= (dir == DirectionType.IN_OUT);
-				if (goingUp) {
-					valid &= dir.outgoing();
-				} else if (goingDown) {
-					valid &= dir.incoming();
-				} else {
-					valid &= dir.outgoing();
-				}
+				bidirectional &= ((FeatureInstance) srcFi).getFlowDirection() == DirectionType.IN_OUT;
 			}
 		}
 		bidirectional &= newSeg.isAllBidirectional();
 		if (dstFi != null) {
 			destinations.add(dstFi);
 			if (dstFi instanceof FeatureInstance) {
-				DirectionType dir = ((FeatureInstance) dstFi).getFlowDirection();
-
-				bidirectional &= (dir == DirectionType.IN_OUT);
-				if (goingUp) {
-					valid &= dir.outgoing();
-				} else if (goingDown) {
-					valid &= dir.incoming();
-				} else {
-					valid &= dir.incoming();
-				}
+				bidirectional &= ((FeatureInstance) dstFi).getFlowDirection() == DirectionType.IN_OUT;
 			}
 		}
 
 		/*
-		 * Issue 582 -- This does not catch all the bad things that can happen. NOT testing for
-		 * subcomponents being connected to requires (goingup) or provides (goingdon).
+		 * The direction rules used to be applied here, rejecting the segment and with it the
+		 * whole partial path. They now run over materialized connection instances in
+		 * ValidateConnectionsSwitch, so that the connection exists and the diagnostic can be
+		 * attached to it.
 		 */
-		// XXX: the argument below, "this.src", may not be correct, but I'm not really sure what is the correct thing
-		final ConnectionInstanceEnd resolvedSrc = resolveFeatureInstance(this.src, srcFi);
-		// XXX: the argument below, "this.src", may not be correct, but I'm not really sure what is the correct thing
-		final ConnectionInstanceEnd resolvedDst = resolveFeatureInstance(this.src, dstFi);
-		if (resolvedSrc instanceof FeatureInstance) {
-			if (resolvedDst instanceof FeatureInstance) {
-				final FeatureInstance resolvedSrcFI = (FeatureInstance) resolvedSrc;
-				final FeatureInstance resolvedDstFI = (FeatureInstance) resolvedDst;
-				if (resolvedSrcFI.getCategory() == FeatureCategory.DATA_ACCESS
-						&& resolvedDstFI.getCategory() == FeatureCategory.DATA_ACCESS) {
-					if (goingUp || goingDown) {
-						valid &= resolvedSrcFI.getDirection() == resolvedDstFI.getDirection();
-					} else {
-						valid &= resolvedSrcFI.getDirection().getInverseDirection() == resolvedDstFI.getDirection();
-					}
-				}
-			}
-		} else {
-			// TODO ComponentInstance -- Should check connections between components and access features here
-		}
 
-		if (valid) {
-			// handle reaching into feature groups in across connection
-			if (newSeg.isAcross()) {
-				// segment goes across
-				int i = connections.size();
-				Connection root = newSeg.getRootConnection();
-				srcToMatch = opposite ? root.getDestination() : root.getSource();
-				srcToMatch = srcToMatch.getNext();
-				while (keep[0] && i > 0 && srcToMatch != null) {
-					i -= 1;
-					Connection c = connections.get(i);
-					// skip connections that don't go into a feature group
-					if (!connectsSameFeatureGroup(c)) {
-						ConnectionEnd e = opposites.get(i) ? c.getAllSource() : c.getAllDestination();
-						ConnectionEnd cce = srcToMatch.getConnectionEnd();
-						srcToMatch = srcToMatch.getNext();
-						keep[0] = cce == e;
-					}
-				}
-				across = true;
-				acrossConnection = newSeg;
-				dstToMatch = opposite ? root.getSource() : root.getDestination();
-				dstToMatch = dstToMatch.getNext();
-				container = ci;
-			} else if (across && dstToMatch != null) {
-				if (!connectsSameFeatureGroup(newSeg)) {
-					ConnectionEnd e = opposite ? newSeg.getAllDestination() : newSeg.getAllSource();
-					ConnectionEnd cce = dstToMatch.getConnectionEnd();
-					dstToMatch = dstToMatch.getNext();
+		// handle reaching into feature groups in across connection
+		if (newSeg.isAcross()) {
+			// segment goes across
+			int i = connections.size();
+			Connection root = newSeg.getRootConnection();
+			srcToMatch = opposite ? root.getDestination() : root.getSource();
+			srcToMatch = srcToMatch.getNext();
+			while (keep[0] && i > 0 && srcToMatch != null) {
+				i -= 1;
+				Connection c = connections.get(i);
+				// skip connections that don't go into a feature group
+				if (!connectsSameFeatureGroup(c)) {
+					ConnectionEnd e = opposites.get(i) ? c.getAllSource() : c.getAllDestination();
+					ConnectionEnd cce = srcToMatch.getConnectionEnd();
+					srcToMatch = srcToMatch.getNext();
 					keep[0] = cce == e;
 				}
+			}
+			across = true;
+			acrossConnection = newSeg;
+			dstToMatch = opposite ? root.getSource() : root.getDestination();
+			dstToMatch = dstToMatch.getNext();
+			container = ci;
+		} else if (across && dstToMatch != null) {
+			if (!connectsSameFeatureGroup(newSeg)) {
+				ConnectionEnd e = opposite ? newSeg.getAllDestination() : newSeg.getAllSource();
+				ConnectionEnd cce = dstToMatch.getConnectionEnd();
+				dstToMatch = dstToMatch.getNext();
+				keep[0] = cce == e;
 			}
 		}
 		connections.add(newSeg);
 		opposites.add(opposite);
 		contexts.add(ci);
-		return valid;
 	}
 
 	protected boolean connectsSameFeatureGroup(Connection c) {

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateConnectionsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateConnectionsSwitch.java
@@ -477,25 +477,10 @@ public class CreateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 
 		try {
 			boolean[] keep = { false };
-			boolean valid = connInfo.addSegment(newSegment, fromFi, toFi, ci, goOpposite, keep);
+			connInfo.addSegment(newSegment, fromFi, toFi, ci, goOpposite, keep);
 			if (!keep[0]) {
 				return;
 			}
-			if (!valid) {
-				if (toFi == null) {
-					error(ci,
-							"Connection from " + connInfo.src.getInstanceObjectPath() + " via "
-									+ newSegment.getQualifiedName()
-									+ " has no valid direction. Connection instance not created.");
-				} else {
-					error(ci,
-							"Connection from " + connInfo.src.getInstanceObjectPath() + " to "
-									+ toFi.getInstanceObjectPath()
-									+ " has no valid direction. Connection instance not created.");
-				}
-				return;
-			}
-
 			// first check if the connection must end with the new segment
 			if (toEnd instanceof Subcomponent) {
 				ComponentInstance toInstance = ci.findSubcomponentInstance((Subcomponent) toEnd);

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/SegmentDirections.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/SegmentDirections.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.aadl2.instantiation;
+
+import org.osate.aadl2.Connection;
+import org.osate.aadl2.ConnectionEnd;
+import org.osate.aadl2.Context;
+import org.osate.aadl2.DirectionType;
+import org.osate.aadl2.Subcomponent;
+import org.osate.aadl2.instance.ConnectionInstanceEnd;
+import org.osate.aadl2.instance.FeatureCategory;
+import org.osate.aadl2.instance.FeatureInstance;
+
+/**
+ * The direction rules that decide whether one segment of a semantic connection is
+ * legal.
+ *
+ * <p>
+ * These are applied to materialized connection instances during connection
+ * validation, so that a connection whose direction does not work out is reported
+ * against the connection instance itself rather than against a partial path that
+ * only the traversal can see.
+ * </p>
+ */
+class SegmentDirections {
+
+	private SegmentDirections() {
+	}
+
+	/**
+	 * Whether one segment is legal, read from source to destination.
+	 *
+	 * @param declaration the traversed connection declaration
+	 * @param reverse whether the declaration is traversed opposite its declared
+	 *            direction
+	 * @param source the endpoint the segment is entered from
+	 * @param destination the endpoint the segment leaves at
+	 */
+	static boolean isValid(Connection declaration, boolean reverse, ConnectionInstanceEnd source,
+			ConnectionInstanceEnd destination) {
+		Connection root = declaration.getRootConnection();
+		Context sourceContext = reverse ? root.getAllDestinationContext() : root.getAllSourceContext();
+		Context destinationContext = reverse ? root.getAllSourceContext() : root.getAllDestinationContext();
+		ConnectionEnd sourceEnd = reverse ? root.getAllDestination() : root.getAllSource();
+		ConnectionEnd destinationEnd = reverse ? root.getAllSource() : root.getAllDestination();
+		boolean goingUp = !(destinationContext instanceof Subcomponent)
+				&& (sourceEnd instanceof Subcomponent || sourceContext instanceof Subcomponent);
+		boolean goingDown = !(sourceContext instanceof Subcomponent)
+				&& (destinationEnd instanceof Subcomponent || destinationContext instanceof Subcomponent);
+
+		/*
+		 * Travelling up, a segment leaves an outgoing feature and arrives at an outgoing
+		 * one, because the outer feature carries the flow further out. Travelling down,
+		 * both are incoming. Crossing between peers, the source is outgoing and the
+		 * destination incoming.
+		 */
+		if (source instanceof FeatureInstance sourceFeature) {
+			DirectionType direction = sourceFeature.getFlowDirection();
+			if (!(goingDown ? direction.incoming() : direction.outgoing())) {
+				return false;
+			}
+		}
+		if (destination instanceof FeatureInstance destinationFeature) {
+			DirectionType direction = destinationFeature.getFlowDirection();
+			if (!(goingUp ? direction.outgoing() : direction.incoming())) {
+				return false;
+			}
+		}
+		return accessDirectionsAgree(goingUp, goingDown, source, destination);
+	}
+
+	/**
+	 * Whether two connected data accesses face compatible ways.
+	 *
+	 * <p>
+	 * Between peers they must face opposite ways, one providing and one requiring. Up or
+	 * down the hierarchy they must face the same way, because the outer feature passes
+	 * the inner one along rather than consuming it. Access features all report
+	 * {@code in out} as their flow direction, so this distinction is only visible in the
+	 * declared direction.
+	 * </p>
+	 */
+	private static boolean accessDirectionsAgree(boolean goingUp, boolean goingDown, ConnectionInstanceEnd source,
+			ConnectionInstanceEnd destination) {
+		if (!(source instanceof FeatureInstance sourceFeature)
+				|| !(destination instanceof FeatureInstance destinationFeature)) {
+			return true;
+		}
+		if (sourceFeature.getCategory() != FeatureCategory.DATA_ACCESS
+				|| destinationFeature.getCategory() != FeatureCategory.DATA_ACCESS) {
+			return true;
+		}
+		DirectionType sourceDirection = sourceFeature.getDirection();
+		DirectionType destinationDirection = destinationFeature.getDirection();
+		return goingUp || goingDown ? sourceDirection == destinationDirection
+				: sourceDirection.getInverseDirection() == destinationDirection;
+	}
+}

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/ValidateConnectionsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/ValidateConnectionsSwitch.java
@@ -103,7 +103,41 @@ class ValidateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 		removeShortAccessConnections(ci);
 		recordInDataPortConnections(ci);
 		checkEndPointClassifiers(ci);
+		checkSegmentDirections(ci);
 		// more
+	}
+
+	/**
+	 * Report a connection whose direction does not work out.
+	 *
+	 * <p>
+	 * Every segment of a semantic connection has to be traversable in the direction the
+	 * connection runs: travelling up it leaves an outgoing feature and arrives at an
+	 * outgoing one, travelling down both are incoming, and crossing between peers the
+	 * source is outgoing and the destination incoming. Two connected data accesses must
+	 * additionally face opposite ways between peers and the same way up or down, which is
+	 * only visible in their declared direction because access features all report
+	 * {@code in out} as their flow direction.
+	 * </p>
+	 *
+	 * <p>
+	 * The traversal used to apply these rules while extending a partial path, so it
+	 * rejected the path and reported against the component it was working in. The
+	 * connection instance is created now and the error is attached to it, which names the
+	 * connection the reader can see in the instance model and reports it once instead of
+	 * once per rejected candidate.
+	 * </p>
+	 */
+	private void checkSegmentDirections(ComponentInstance ci) {
+		for (ConnectionInstance conni : ci.getConnectionInstances()) {
+			for (ConnectionReference reference : conni.getConnectionReferences()) {
+				if (!SegmentDirections.isValid(reference.getConnection(), reference.isReverse(), reference.getSource(),
+						reference.getDestination())) {
+					error(conni, "Connection has no valid direction");
+					break;
+				}
+			}
+		}
 	}
 
 	/**

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3042Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3042Test.java
@@ -94,13 +94,18 @@ public class Issue3042Test extends XtextTest {
 		assertEquals(List.of("Error on " + CONNECTION + ": Connection has no valid direction"), errors(instantiated));
 	}
 
-	/** Leaving an incoming feature between peers fails the same way. */
+	/**
+	 * A connection whose source is an incoming feature produces nothing at all, and this
+	 * check is not what decides that. The traversal only starts at outgoing features, so
+	 * no path is ever begun; there is no connection instance to attach a diagnostic to and
+	 * no diagnostic either.
+	 */
 	@Test
-	public void leavingAnIncomingFeatureIsReportedOnTheConnectionInstance() throws Exception {
+	public void aConnectionLeavingAnIncomingFeatureIsNeverStarted() throws Exception {
 		Instantiated instantiated = instantiate("Top.in_to_in");
 
-		assertEquals(List.of(CONNECTION), connectionNames(instantiated));
-		assertEquals(List.of("Error on " + CONNECTION + ": Connection has no valid direction"), errors(instantiated));
+		assertEquals(List.of(), connectionNames(instantiated));
+		assertEquals(List.of(), errors(instantiated));
 	}
 
 	private static List<String> connectionNames(Instantiated instantiated) {

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3042Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3042Test.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instance.ConnectionInstance;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * Regression test for issue #3042.
+ *
+ * <p>
+ * A connection whose direction does not work out is instantiated, and connection
+ * validation reports the error against the connection instance. It used to be rejected
+ * while the instance model was being built, with the error attached to whichever
+ * component the traversal was extending a path inside.
+ * </p>
+ *
+ * <p>
+ * The fixture is the existing {@code Issue582/TestAbstractDirection.aadl} rather than a
+ * new one. Its shape is the one that reaches this check: both features are declared
+ * abstract and refined to a direction by extension, so each declaration passes
+ * declarative validation while the instance directions do not compose. A connection
+ * that both declares and violates a direction rule, such as a port connection into an
+ * outgoing port, is rejected by the declarative validator and never reaches the
+ * instantiator at all.
+ * </p>
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3042Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/Issue582/TestAbstractDirection.aadl";
+	private static final String CONNECTION = "srcSys.f0 -> destSys.f0";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	/** Outgoing to incoming between peers is valid, so nothing is reported. */
+	@Test
+	public void aValidDirectionReportsNothing() throws Exception {
+		Instantiated instantiated = instantiate("Top.out_to_in");
+
+		assertEquals(List.of(CONNECTION), connectionNames(instantiated));
+		assertEquals(List.of(), errors(instantiated));
+	}
+
+	/**
+	 * Crossing between peers into an outgoing feature. The connection instance exists and
+	 * carries the error, which is reported once.
+	 */
+	@Test
+	public void anInvalidDirectionIsReportedOnTheConnectionInstance() throws Exception {
+		Instantiated instantiated = instantiate("Top.out_to_out");
+
+		assertEquals(List.of(CONNECTION), connectionNames(instantiated));
+		assertEquals(List.of("Error on " + CONNECTION + ": Connection has no valid direction"), errors(instantiated));
+	}
+
+	/** Leaving an incoming feature between peers fails the same way. */
+	@Test
+	public void leavingAnIncomingFeatureIsReportedOnTheConnectionInstance() throws Exception {
+		Instantiated instantiated = instantiate("Top.in_to_in");
+
+		assertEquals(List.of(CONNECTION), connectionNames(instantiated));
+		assertEquals(List.of("Error on " + CONNECTION + ": Connection has no valid direction"), errors(instantiated));
+	}
+
+	private static List<String> connectionNames(Instantiated instantiated) {
+		return instantiated.instance()
+				.getAllConnectionInstances()
+				.stream()
+				.map(ConnectionInstance::getName)
+				.sorted()
+				.toList();
+	}
+
+	/** Each diagnostic with the name of the element it is attached to. */
+	private static List<String> errors(Instantiated instantiated) {
+		return ((QueuingAnalysisErrorReporter) instantiated.manager()
+				.getReporter(instantiated.instance().eResource())).getErrors()
+				.stream()
+				.map(message -> message.kind + " on "
+						+ (message.where instanceof ConnectionInstance connection ? connection.getName()
+								: String.valueOf(message.where))
+						+ ": " + message.message)
+				.sorted()
+				.toList();
+	}
+
+	private record Instantiated(SystemInstance instance, AnalysisErrorReporterManager manager) {
+	}
+
+	private Instantiated instantiate(String implementation) throws Exception {
+		var pkg = testHelper.parseFile(MODEL);
+		var impl = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals(implementation))
+				.findFirst()
+				.orElseThrow();
+		var manager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+		return new Instantiated(InstantiateModel.instantiate(impl, manager), manager);
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue582AbstractDirectionTest.xtend
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue582AbstractDirectionTest.xtend
@@ -39,6 +39,7 @@ import static extension org.osate.testsupport.AssertHelper.*
 import org.osate.aadl2.SystemImplementation
 import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager
 import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter
+import org.osate.aadl2.instance.ConnectionInstance
 import org.osate.aadl2.instantiation.InstantiateModel
 
 @RunWith(XtextRunner)
@@ -88,26 +89,19 @@ class Issue582AbstractDirectionTest extends XtextTest {
 		
 		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.blank_feature -> destSys.blank_feature"])
 		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.blank_feature -> destSys.in_feature"])
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.blank_feature -> destSys.out_feature"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.blank_feature -> destSys.out_feature"])
 		assertNull(instance.connectionInstances.findFirst[name == "srcSys.in_feature -> destSys.blank_feature"])
 		assertNull(instance.connectionInstances.findFirst[name == "srcSys.in_feature -> destSys.in_feature"])
 		assertNull(instance.connectionInstances.findFirst[name == "srcSys.in_feature -> destSys.out_feature"])
 		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.out_feature -> destSys.blank_feature"])
 		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.out_feature -> destSys.in_feature"])
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.out_feature -> destSys.out_feature"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.out_feature -> destSys.out_feature"])
 		
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 2)
-
-		messages.get(0) => [
-			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals(message, "Connection from Top_allExplicit_Instance.srcSys.blank_feature to Top_allExplicit_Instance.destSys.out_feature has no valid direction. Connection instance not created.")
-		]
-		
-		messages.get(1) => [
-			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals(message, "Connection from Top_allExplicit_Instance.srcSys.out_feature to Top_allExplicit_Instance.destSys.out_feature has no valid direction. Connection instance not created.")
-		]
+		assertEquals(#[
+			"srcSys.blank_feature -> destSys.out_feature: Connection has no valid direction",
+			"srcSys.out_feature -> destSys.out_feature: Connection has no valid direction"
+		].sort, messages.map[(where as ConnectionInstance).name + ": " + message].sort)
 	}
 
 	@Test
@@ -143,14 +137,15 @@ class Issue582AbstractDirectionTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
 		assertTrue(messages.size == 1)
 
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals(message, "Connection from Top_blank_to_out_Instance.srcSys.f0 to Top_blank_to_out_Instance.destSys.f0 has no valid direction. Connection instance not created.")
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("srcSys.f0 -> destSys.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -226,14 +221,15 @@ class Issue582AbstractDirectionTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
 		assertTrue(messages.size == 1)
 
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals(message, "Connection from Top_out_to_out_Instance.srcSys.f0 to Top_out_to_out_Instance.destSys.f0 has no valid direction. Connection instance not created.")
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("srcSys.f0 -> destSys.f0", (where as ConnectionInstance).name)
 		]
 	}
 }

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue582AbstractToDataAccessClassifierTest.xtend
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue582AbstractToDataAccessClassifierTest.xtend
@@ -39,6 +39,7 @@ import static extension org.osate.testsupport.AssertHelper.*
 import org.osate.aadl2.SystemImplementation
 import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager
 import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter
+import org.osate.aadl2.instance.ConnectionInstance
 import org.osate.aadl2.instantiation.InstantiateModel
 
 @RunWith(XtextRunner)
@@ -109,34 +110,37 @@ class Issue582AbstractToDataAccessClassifierTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.p_type -> destSys.p_type"])
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.p_type -> destSys.p_notype"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.p_type -> destSys.p_type"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.p_type -> destSys.p_notype"])
 		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.p_type -> destSys.r_type"])
 		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.p_type -> destSys.r_notype"])
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.p_notype -> destSys.p_type"])
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.p_notype -> destSys.p_notype"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.p_notype -> destSys.p_type"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.p_notype -> destSys.p_notype"])
 		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.p_notype -> destSys.r_type"])
 		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.p_notype -> destSys.r_notype"])
 		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.r_notype -> destSys.p_type"])
 		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.r_type -> destSys.p_notype"])
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.r_type -> destSys.r_type"])
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.r_type -> destSys.r_notype"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.r_type -> destSys.r_type"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.r_type -> destSys.r_notype"])
 		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.r_notype -> destSys.p_type"])
 		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.r_notype -> destSys.p_notype"])
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.r_notype -> destSys.r_type"])
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.r_notype -> destSys.r_notype"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.r_notype -> destSys.r_type"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.r_notype -> destSys.r_notype"])
 		
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 12)
-
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.srcSys.p_type to Top_allExplicit_Instance.destSys.p_type has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.srcSys.p_type to Top_allExplicit_Instance.destSys.p_notype has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.srcSys.p_notype to Top_allExplicit_Instance.destSys.p_type has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.srcSys.p_notype to Top_allExplicit_Instance.destSys.p_notype has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.srcSys.r_type to Top_allExplicit_Instance.destSys.r_type has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.srcSys.r_type to Top_allExplicit_Instance.destSys.r_notype has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.srcSys.r_notype to Top_allExplicit_Instance.destSys.r_type has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.srcSys.r_notype to Top_allExplicit_Instance.destSys.r_notype has no valid direction. Connection instance not created."])
+		assertEquals(16, messages.size)
+		assertEquals(#[
+			"srcSys.p_notype -> destSys.p_notype",
+			"srcSys.p_notype -> destSys.p_type",
+			"srcSys.p_type -> destSys.p_notype",
+			"srcSys.p_type -> destSys.p_type",
+			"srcSys.r_notype -> destSys.r_notype",
+			"srcSys.r_notype -> destSys.r_type",
+			"srcSys.r_type -> destSys.r_notype",
+			"srcSys.r_type -> destSys.r_type"
+		].sort,
+			messages.filter[message == "Connection has no valid direction"]
+				.map[(where as ConnectionInstance).name].sort)
 
 
 		assertNotNull(messages.findFirst[where == instance.connectionInstances.findFirst[name == "srcSys.p_type -> destSys.r_notype"] && kind == QueuingAnalysisErrorReporter.WARNING && message == "Expected feature 'destSys.r_notype' to have classifier 'TestAbstractToDataAccessClassifier::D'"])
@@ -155,7 +159,7 @@ class Issue582AbstractToDataAccessClassifierTest extends XtextTest {
 		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 0)
+		assertEquals(0, messages.size)
 	}
 
 	@Test
@@ -165,14 +169,13 @@ class Issue582AbstractToDataAccessClassifierTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
-		messages.get(0) => [
-			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals(message, "Connection from Top_provides_nt_to_provides_nt_Instance.srcSys.f0 to Top_provides_nt_to_provides_nt_Instance.destSys.f0 has no valid direction. Connection instance not created.")
-		]
+		assertEquals(1, messages.size)
+		assertNotNull(messages.findFirst[kind == QueuingAnalysisErrorReporter.ERROR
+			&& message == "Connection has no valid direction"
+			&& (where as ConnectionInstance).name == "srcSys.f0 -> destSys.f0"])
 	}
 
 	@Test
@@ -182,14 +185,13 @@ class Issue582AbstractToDataAccessClassifierTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
-		messages.get(0) => [
-			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals(message, "Connection from Top_provides_nt_to_provides_t_Instance.srcSys.f0 to Top_provides_nt_to_provides_t_Instance.destSys.f0 has no valid direction. Connection instance not created.")
-		]
+		assertEquals(2, messages.size)
+		assertNotNull(messages.findFirst[kind == QueuingAnalysisErrorReporter.ERROR
+			&& message == "Connection has no valid direction"
+			&& (where as ConnectionInstance).name == "srcSys.f0 -> destSys.f0"])
 	}
 
 	@Test
@@ -202,7 +204,7 @@ class Issue582AbstractToDataAccessClassifierTest extends XtextTest {
 		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 0)
+		assertEquals(0, messages.size)
 	}
 
 	@Test
@@ -215,7 +217,7 @@ class Issue582AbstractToDataAccessClassifierTest extends XtextTest {
 		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.WARNING.assertEquals(kind)
 			assertEquals(message, "Expected feature 'srcSys.f0' to have classifier 'TestAbstractToDataAccessClassifier::D'")
@@ -229,14 +231,13 @@ class Issue582AbstractToDataAccessClassifierTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
-		messages.get(0) => [
-			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals(message, "Connection from Top_provides_t_to_provides_nt_Instance.srcSys.f0 to Top_provides_t_to_provides_nt_Instance.destSys.f0 has no valid direction. Connection instance not created.")
-		]
+		assertEquals(2, messages.size)
+		assertNotNull(messages.findFirst[kind == QueuingAnalysisErrorReporter.ERROR
+			&& message == "Connection has no valid direction"
+			&& (where as ConnectionInstance).name == "srcSys.f0 -> destSys.f0"])
 	}
 
 	@Test
@@ -246,14 +247,13 @@ class Issue582AbstractToDataAccessClassifierTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
-		messages.get(0) => [
-			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals(message, "Connection from Top_provides_t_to_provides_t_Instance.srcSys.f0 to Top_provides_t_to_provides_t_Instance.destSys.f0 has no valid direction. Connection instance not created.")
-		]
+		assertEquals(1, messages.size)
+		assertNotNull(messages.findFirst[kind == QueuingAnalysisErrorReporter.ERROR
+			&& message == "Connection has no valid direction"
+			&& (where as ConnectionInstance).name == "srcSys.f0 -> destSys.f0"])
 	}
 
 	@Test
@@ -266,7 +266,7 @@ class Issue582AbstractToDataAccessClassifierTest extends XtextTest {
 		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.WARNING.assertEquals(kind)
 			assertEquals(message, "Expected feature 'destSys.f0' to have classifier 'TestAbstractToDataAccessClassifier::D'")
@@ -283,7 +283,7 @@ class Issue582AbstractToDataAccessClassifierTest extends XtextTest {
 		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 0)
+		assertEquals(0, messages.size)
 	}
 
 	@Test
@@ -296,7 +296,7 @@ class Issue582AbstractToDataAccessClassifierTest extends XtextTest {
 		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 0)
+		assertEquals(0, messages.size)
 	}
 
 	@Test
@@ -309,7 +309,7 @@ class Issue582AbstractToDataAccessClassifierTest extends XtextTest {
 		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.WARNING.assertEquals(kind)
 			assertEquals(message, "Expected feature 'srcSys.f0' to have classifier 'TestAbstractToDataAccessClassifier::D'")
@@ -323,14 +323,13 @@ class Issue582AbstractToDataAccessClassifierTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
-		messages.get(0) => [
-			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals(message, "Connection from Top_requires_nt_to_requires_nt_Instance.srcSys.f0 to Top_requires_nt_to_requires_nt_Instance.destSys.f0 has no valid direction. Connection instance not created.")
-		]
+		assertEquals(1, messages.size)
+		assertNotNull(messages.findFirst[kind == QueuingAnalysisErrorReporter.ERROR
+			&& message == "Connection has no valid direction"
+			&& (where as ConnectionInstance).name == "srcSys.f0 -> destSys.f0"])
 	}
 
 	@Test
@@ -340,14 +339,13 @@ class Issue582AbstractToDataAccessClassifierTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
-		messages.get(0) => [
-			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals(message, "Connection from Top_requires_nt_to_requires_t_Instance.srcSys.f0 to Top_requires_nt_to_requires_t_Instance.destSys.f0 has no valid direction. Connection instance not created.")
-		]
+		assertEquals(2, messages.size)
+		assertNotNull(messages.findFirst[kind == QueuingAnalysisErrorReporter.ERROR
+			&& message == "Connection has no valid direction"
+			&& (where as ConnectionInstance).name == "srcSys.f0 -> destSys.f0"])
 	}
 
 
@@ -365,7 +363,7 @@ class Issue582AbstractToDataAccessClassifierTest extends XtextTest {
 		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.WARNING.assertEquals(kind)
 			assertEquals(message, "Expected feature 'destSys.f0' to have classifier 'TestAbstractToDataAccessClassifier::D'")
@@ -382,7 +380,7 @@ class Issue582AbstractToDataAccessClassifierTest extends XtextTest {
 		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 0)
+		assertEquals(0, messages.size)
 	}
 
 	@Test
@@ -392,14 +390,13 @@ class Issue582AbstractToDataAccessClassifierTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
-		messages.get(0) => [
-			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals(message, "Connection from Top_requires_t_to_requires_nt_Instance.srcSys.f0 to Top_requires_t_to_requires_nt_Instance.destSys.f0 has no valid direction. Connection instance not created.")
-		]
+		assertEquals(2, messages.size)
+		assertNotNull(messages.findFirst[kind == QueuingAnalysisErrorReporter.ERROR
+			&& message == "Connection has no valid direction"
+			&& (where as ConnectionInstance).name == "srcSys.f0 -> destSys.f0"])
 	}
 
 	@Test
@@ -409,12 +406,11 @@ class Issue582AbstractToDataAccessClassifierTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
-		messages.get(0) => [
-			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals(message, "Connection from Top_requires_t_to_requires_t_Instance.srcSys.f0 to Top_requires_t_to_requires_t_Instance.destSys.f0 has no valid direction. Connection instance not created.")
-		]
+		assertEquals(1, messages.size)
+		assertNotNull(messages.findFirst[kind == QueuingAnalysisErrorReporter.ERROR
+			&& message == "Connection has no valid direction"
+			&& (where as ConnectionInstance).name == "srcSys.f0 -> destSys.f0"])
 	}}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue582NestedAbstractAccessTest.xtend
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue582NestedAbstractAccessTest.xtend
@@ -39,6 +39,7 @@ import static extension org.osate.testsupport.AssertHelper.*
 import org.osate.aadl2.SystemImplementation
 import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager
 import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter
+import org.osate.aadl2.instance.ConnectionInstance
 import org.osate.aadl2.instantiation.InstantiateModel
 
 @RunWith(XtextRunner)
@@ -147,18 +148,23 @@ class Issue582NestedAbstractAccessTest extends XtextTest {
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 6)
+		assertEquals(10, messages.size)
+		assertEquals(#[
+			"srcSys.s.blank_feature -> destSys.provides_feature",
+			"srcSys.s.blank_feature -> destSys.requires_feature",
+			"srcSys.s.provides_feature -> destSys.blank_feature",
+			"srcSys.s.provides_feature -> destSys.provides_feature",
+			"srcSys.s.provides_feature -> destSys.provides_feature",
+			"srcSys.s.provides_feature -> destSys.requires_feature",
+			"srcSys.s.requires_feature -> destSys.blank_feature",
+			"srcSys.s.requires_feature -> destSys.provides_feature",
+			"srcSys.s.requires_feature -> destSys.requires_feature",
+			"srcSys.s.requires_feature -> destSys.requires_feature"
+		].sort,
+			messages.filter[message == "Connection has no valid direction"]
+				.map[(where as ConnectionInstance).name].sort)
 
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.srcSys.s.blank_feature to Top_allExplicit_Instance.destSys.provides_feature has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.srcSys.s.blank_feature to Top_allExplicit_Instance.destSys.requires_feature has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.srcSys.s.provides_feature to Top_allExplicit_Instance.destSys.provides_feature has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.srcSys.s.requires_feature to Top_allExplicit_Instance.destSys.requires_feature has no valid direction. Connection instance not created."])
-		
-		val srcSys = instance.componentInstances.findFirst[name == "srcSys"]
-		assertNotNull(messages.findFirst[where == srcSys && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.srcSys.s.provides_feature to Top_allExplicit_Instance.srcSys.provides_to_requires_feature has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == srcSys && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.srcSys.s.requires_feature to Top_allExplicit_Instance.srcSys.requires_to_provides_feature has no valid direction. Connection instance not created."])
-
-		assertEquals(17, instance.connectionInstances.size)
+		assertEquals(27, instance.connectionInstances.size)
 	}
 
 	@Test
@@ -220,13 +226,14 @@ class Issue582NestedAbstractAccessTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_blank_to_provides_to_provides_Instance.srcSys.s.f0 to Top_blank_to_provides_to_provides_Instance.destSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("srcSys.s.f0 -> destSys.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -276,13 +283,14 @@ class Issue582NestedAbstractAccessTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_blank_to_requires_to_requires_Instance.srcSys.s.f0 to Top_blank_to_requires_to_requires_Instance.destSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("srcSys.s.f0 -> destSys.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -345,13 +353,14 @@ class Issue582NestedAbstractAccessTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_provides_to_provides_to_provides_Instance.srcSys.s.f0 to Top_provides_to_provides_to_provides_Instance.destSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("srcSys.s.f0 -> destSys.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -375,13 +384,14 @@ class Issue582NestedAbstractAccessTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_provides_to_requires_to_blank_Instance.srcSys.s.f0 to Top_provides_to_requires_to_blank_Instance.srcSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("srcSys.s.f0 -> destSys.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -392,13 +402,14 @@ class Issue582NestedAbstractAccessTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_provides_to_requires_to_provides_Instance.srcSys.s.f0 to Top_provides_to_requires_to_provides_Instance.srcSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("srcSys.s.f0 -> destSys.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -409,13 +420,14 @@ class Issue582NestedAbstractAccessTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_provides_to_requires_to_requires_Instance.srcSys.s.f0 to Top_provides_to_requires_to_requires_Instance.srcSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("srcSys.s.f0 -> destSys.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -465,13 +477,14 @@ class Issue582NestedAbstractAccessTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_requires_to_provides_to_blank_Instance.srcSys.s.f0 to Top_requires_to_provides_to_blank_Instance.srcSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("srcSys.s.f0 -> destSys.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -482,13 +495,14 @@ class Issue582NestedAbstractAccessTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_requires_to_provides_to_provides_Instance.srcSys.s.f0 to Top_requires_to_provides_to_provides_Instance.srcSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("srcSys.s.f0 -> destSys.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -499,13 +513,14 @@ class Issue582NestedAbstractAccessTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_requires_to_provides_to_requires_Instance.srcSys.s.f0 to Top_requires_to_provides_to_requires_Instance.srcSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("srcSys.s.f0 -> destSys.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -542,13 +557,14 @@ class Issue582NestedAbstractAccessTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_requires_to_requires_to_requires_Instance.srcSys.s.f0 to Top_requires_to_requires_to_requires_Instance.destSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("srcSys.s.f0 -> destSys.f0", (where as ConnectionInstance).name)
 		]
 	}
 }

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue582NestedAbstractDirection_InToComponentTest.xtend
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue582NestedAbstractDirection_InToComponentTest.xtend
@@ -31,6 +31,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.osate.aadl2.AadlPackage
 import org.osate.aadl2.SystemImplementation
+import org.osate.aadl2.instance.ConnectionInstance
 import org.osate.aadl2.instantiation.InstantiateModel
 import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager
 import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter
@@ -56,22 +57,23 @@ class Issue582NestedAbstractDirection_InToComponentTest extends XtextTest {
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 10)
-		
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.destSys.blank_feature to Top_allExplicit_Instance.srcSys.blank_to_out_feature has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.destSys.blank_feature to Top_allExplicit_Instance.srcSys.in_to_out_feature has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.destSys.blank_feature to Top_allExplicit_Instance.srcSys.out_to_out_feature has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.destSys.out_feature to Top_allExplicit_Instance.srcSys.blank_to_out_feature has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.destSys.out_feature to Top_allExplicit_Instance.srcSys.in_to_out_feature has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.destSys.out_feature to Top_allExplicit_Instance.srcSys.out_to_out_feature has no valid direction. Connection instance not created."])
-		
-		val srcSys = instance.componentInstances.findFirst[name == "srcSys"]
-		assertNotNull(messages.findFirst[where == srcSys && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.destSys.blank_feature to Top_allExplicit_Instance.srcSys.s.out_feature has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == srcSys && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.destSys.blank_feature to Top_allExplicit_Instance.srcSys.s.out_feature has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == srcSys && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.destSys.out_feature to Top_allExplicit_Instance.srcSys.s.out_feature has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == srcSys && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.destSys.out_feature to Top_allExplicit_Instance.srcSys.s.out_feature has no valid direction. Connection instance not created."])
+		assertEquals(10, messages.size)
+		assertEquals(#[
+			"destSys.blank_feature -> srcSys.s.blank_feature",
+			"destSys.blank_feature -> srcSys.s.in_feature",
+			"destSys.blank_feature -> srcSys.s.out_feature",
+			"destSys.blank_feature -> srcSys.s.out_feature",
+			"destSys.blank_feature -> srcSys.s.out_feature",
+			"destSys.out_feature -> srcSys.s.blank_feature",
+			"destSys.out_feature -> srcSys.s.in_feature",
+			"destSys.out_feature -> srcSys.s.out_feature",
+			"destSys.out_feature -> srcSys.s.out_feature",
+			"destSys.out_feature -> srcSys.s.out_feature"
+		].sort,
+			messages.filter[message == "Connection has no valid direction"]
+				.map[(where as ConnectionInstance).name].sort)
 
-		assertEquals(8, instance.connectionInstances.size)
+		assertEquals(18, instance.connectionInstances.size)
 	}
 
 	@Test
@@ -146,12 +148,13 @@ class Issue582NestedAbstractDirection_InToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_blank_to_in_to_out_Instance.destSys.f0 to Top_blank_to_in_to_out_Instance.srcSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("destSys.f0 -> srcSys.s.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -162,13 +165,14 @@ class Issue582NestedAbstractDirection_InToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_blank_to_out_to_blank_Instance.destSys.f0 to Top_blank_to_out_to_blank_Instance.srcSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("destSys.f0 -> srcSys.s.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -192,13 +196,14 @@ class Issue582NestedAbstractDirection_InToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_blank_to_out_to_out_Instance.destSys.f0 to Top_blank_to_out_to_out_Instance.srcSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("destSys.f0 -> srcSys.s.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -248,13 +253,14 @@ class Issue582NestedAbstractDirection_InToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_in_to_in_to_blank_Instance.destSys.f0 to Top_in_to_in_to_blank_Instance.srcSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("destSys.f0 -> srcSys.s.f0", (where as ConnectionInstance).name)
 		]
 	}
 	
@@ -278,13 +284,14 @@ class Issue582NestedAbstractDirection_InToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_in_to_in_to_out_Instance.destSys.f0 to Top_in_to_in_to_out_Instance.srcSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("destSys.f0 -> srcSys.s.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -295,13 +302,14 @@ class Issue582NestedAbstractDirection_InToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_in_to_out_to_blank_Instance.destSys.f0 to Top_in_to_out_to_blank_Instance.srcSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("destSys.f0 -> srcSys.s.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -325,13 +333,14 @@ class Issue582NestedAbstractDirection_InToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_in_to_out_to_out_Instance.destSys.f0 to Top_in_to_out_to_out_Instance.srcSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("destSys.f0 -> srcSys.s.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -342,13 +351,14 @@ class Issue582NestedAbstractDirection_InToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_out_to_blank_to_blank_Instance.destSys.f0 to Top_out_to_blank_to_blank_Instance.srcSys.s.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("destSys.f0 -> srcSys.s.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -372,13 +382,14 @@ class Issue582NestedAbstractDirection_InToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_out_to_blank_to_out_Instance.destSys.f0 to Top_out_to_blank_to_out_Instance.srcSys.s.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("destSys.f0 -> srcSys.s.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -389,13 +400,14 @@ class Issue582NestedAbstractDirection_InToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_out_to_in_to_blank_Instance.destSys.f0 to Top_out_to_in_to_blank_Instance.srcSys.s.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("destSys.f0 -> srcSys.s.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -419,13 +431,14 @@ class Issue582NestedAbstractDirection_InToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_out_to_in_to_out_Instance.destSys.f0 to Top_out_to_in_to_out_Instance.srcSys.s.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("destSys.f0 -> srcSys.s.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -436,13 +449,14 @@ class Issue582NestedAbstractDirection_InToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_out_to_out_to_blank_Instance.destSys.f0 to Top_out_to_out_to_blank_Instance.srcSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("destSys.f0 -> srcSys.s.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -466,13 +480,14 @@ class Issue582NestedAbstractDirection_InToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "destSys.f0 -> srcSys.s.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_out_to_out_to_out_Instance.destSys.f0 to Top_out_to_out_to_out_Instance.srcSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("destSys.f0 -> srcSys.s.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -489,10 +504,11 @@ class Issue582NestedAbstractDirection_InToComponentTest extends XtextTest {
 //		assertNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
 //
 //		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-//		assertTrue(messages.size == 1)
+//		assertEquals(1, messages.size)
 //		messages.get(0) => [
 //			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-//			assertEquals("Connection from Top_in_nt_to_in_nt_Instance.srcSys.f0 to Top_in_nt_to_in_nt_Instance.destSys.f0 has no valid direction. Connection instance not created.", message)
+//			assertEquals("Connection has no valid direction", message)
+//assertEquals("destSys.f0 -> srcSys.s.f0", (where as ConnectionInstance).name)
 //		]
 //	}
 

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue582NestedAbstractDirection_OutToComponentTest.xtend
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue582NestedAbstractDirection_OutToComponentTest.xtend
@@ -31,6 +31,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.osate.aadl2.AadlPackage
 import org.osate.aadl2.SystemImplementation
+import org.osate.aadl2.instance.ConnectionInstance
 import org.osate.aadl2.instantiation.InstantiateModel
 import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager
 import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter
@@ -56,18 +57,23 @@ class Issue582NestedAbstractDirection_OutToComponentTest extends XtextTest {
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 6)
-		
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.srcSys.s.blank_feature to Top_allExplicit_Instance.destSys.out_feature has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.srcSys.s.blank_feature to Top_allExplicit_Instance.destSys.out_feature has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.srcSys.s.out_feature to Top_allExplicit_Instance.destSys.out_feature has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == instance && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.srcSys.s.out_feature to Top_allExplicit_Instance.destSys.out_feature has no valid direction. Connection instance not created."])
-		
-		val srcSys = instance.componentInstances.findFirst[name == "srcSys"]
-		assertNotNull(messages.findFirst[where == srcSys && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.srcSys.s.blank_feature to Top_allExplicit_Instance.srcSys.blank_to_in_feature has no valid direction. Connection instance not created."])
-		assertNotNull(messages.findFirst[where == srcSys && kind == QueuingAnalysisErrorReporter.ERROR && message == "Connection from Top_allExplicit_Instance.srcSys.s.out_feature to Top_allExplicit_Instance.srcSys.out_to_in_feature has no valid direction. Connection instance not created."])
+		assertEquals(10, messages.size)
+		assertEquals(#[
+			"srcSys.s.blank_feature -> destSys.blank_feature",
+			"srcSys.s.blank_feature -> destSys.in_feature",
+			"srcSys.s.blank_feature -> destSys.out_feature",
+			"srcSys.s.blank_feature -> destSys.out_feature",
+			"srcSys.s.blank_feature -> destSys.out_feature",
+			"srcSys.s.out_feature -> destSys.blank_feature",
+			"srcSys.s.out_feature -> destSys.in_feature",
+			"srcSys.s.out_feature -> destSys.out_feature",
+			"srcSys.s.out_feature -> destSys.out_feature",
+			"srcSys.s.out_feature -> destSys.out_feature"
+		].sort,
+			messages.filter[message == "Connection has no valid direction"]
+				.map[(where as ConnectionInstance).name].sort)
 
-		assertEquals(8, instance.connectionInstances.size)
+		assertEquals(18, instance.connectionInstances.size)
 	}
 
 	@Test
@@ -103,13 +109,14 @@ class Issue582NestedAbstractDirection_OutToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_blank_to_blank_to_out_Instance.srcSys.s.f0 to Top_blank_to_blank_to_out_Instance.destSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("srcSys.s.f0 -> destSys.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -120,13 +127,14 @@ class Issue582NestedAbstractDirection_OutToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_blank_to_in_to_blank_Instance.srcSys.s.f0 to Top_blank_to_in_to_blank_Instance.srcSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("srcSys.s.f0 -> destSys.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -150,13 +158,14 @@ class Issue582NestedAbstractDirection_OutToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_blank_to_in_to_out_Instance.srcSys.s.f0 to Top_blank_to_in_to_out_Instance.destSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("srcSys.s.f0 -> destSys.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -193,13 +202,14 @@ class Issue582NestedAbstractDirection_OutToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_blank_to_out_to_out_Instance.srcSys.s.f0 to Top_blank_to_out_to_out_Instance.destSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("srcSys.s.f0 -> destSys.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -353,13 +363,14 @@ class Issue582NestedAbstractDirection_OutToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_out_to_blank_to_out_Instance.srcSys.s.f0 to Top_out_to_blank_to_out_Instance.destSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("srcSys.s.f0 -> destSys.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -370,13 +381,14 @@ class Issue582NestedAbstractDirection_OutToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_out_to_in_to_blank_Instance.srcSys.s.f0 to Top_out_to_in_to_blank_Instance.srcSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("srcSys.s.f0 -> destSys.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -387,13 +399,14 @@ class Issue582NestedAbstractDirection_OutToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_out_to_in_to_in_Instance.srcSys.s.f0 to Top_out_to_in_to_in_Instance.srcSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("srcSys.s.f0 -> destSys.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -404,13 +417,14 @@ class Issue582NestedAbstractDirection_OutToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_out_to_in_to_out_Instance.srcSys.s.f0 to Top_out_to_in_to_out_Instance.srcSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("srcSys.s.f0 -> destSys.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -447,13 +461,14 @@ class Issue582NestedAbstractDirection_OutToComponentTest extends XtextTest {
 		val errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory)
 		val instance = InstantiateModel.instantiate(sysImpl, errorManager)
 		
-		assertNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
+		assertNotNull(instance.connectionInstances.findFirst[name == "srcSys.s.f0 -> destSys.f0"])
 
 		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-		assertTrue(messages.size == 1)
+		assertEquals(1, messages.size)
 		messages.get(0) => [
 			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-			assertEquals("Connection from Top_out_to_out_to_out_Instance.srcSys.s.f0 to Top_out_to_out_to_out_Instance.destSys.f0 has no valid direction. Connection instance not created.", message)
+			assertEquals("Connection has no valid direction", message)
+			assertEquals("srcSys.s.f0 -> destSys.f0", (where as ConnectionInstance).name)
 		]
 	}
 
@@ -470,10 +485,11 @@ class Issue582NestedAbstractDirection_OutToComponentTest extends XtextTest {
 //		assertNull(instance.connectionInstances.findFirst[name == "srcSys.f0 -> destSys.f0"])
 //
 //		val messages = (errorManager.getReporter(instance.eResource) as QueuingAnalysisErrorReporter).errors
-//		assertTrue(messages.size == 1)
+//		assertEquals(1, messages.size)
 //		messages.get(0) => [
 //			QueuingAnalysisErrorReporter.ERROR.assertEquals(kind)
-//			assertEquals("Connection from Top_in_nt_to_in_nt_Instance.srcSys.f0 to Top_in_nt_to_in_nt_Instance.destSys.f0 has no valid direction. Connection instance not created.", message)
+//			assertEquals("Connection has no valid direction", message)
+//assertEquals("srcSys.s.f0 -> destSys.f0", (where as ConnectionInstance).name)
 //		]
 //	}
 


### PR DESCRIPTION
Fixes #3042

## Summary

A connection whose direction does not work out is now instantiated, and connection validation reports the error against the connection instance. Previously the traversal rejected the partial path while building the model and attached the error to whichever component it happened to be working in.

## What changed

`ConnectionInfo.addSegment()` no longer computes a validity flag from the direction rules, and `appendSegment()` no longer abandons the path or reports. The rules move to `SegmentDirections` and are applied by `ValidateConnectionsSwitch` to the connection references of each materialized connection, which carry the same declaration, orientation, and endpoints the traversal used. The connection is left in the model, matching how the other checks in that class behave.

The message is `Connection has no valid direction`, attached to the connection instance.

The rules themselves are unchanged:

- Travelling up, a segment leaves an outgoing feature and arrives at an outgoing one; travelling down both ends are incoming; crossing between peers the source is outgoing and the destination incoming.
- Two connected data accesses must face opposite ways between peers and the same way up or down. This is visible only in the declared direction, because access features all report `in out` as their flow direction.

## Why this is better

- The error points at something a reader can find in the instance model, rather than at a component that merely happened to be under traversal.
- It is reported once per connection instead of once per rejected candidate. One bad declaration used to produce several identical errors reached from different partial paths, which is why one test asserted the same message 24 times.
- The old message named the ultimate source of a *partial path*, an artefact of how paths are grown.

## Effect beyond the diagnostic

Relocating the check changes which connections are enumerated, not only where the error goes, and this is the part worth reviewing.

A path that used to be cut short at the violation now continues to its real end, so it becomes one longer connection rather than stopping at an intermediate feature. In `Top.allExplicit` of the nested access fixture the root goes from 17 connections to 27, `srcSys` is left with none, and the reported direction errors go from 6 to 10, all now on root connections rather than two of them on connections inside `srcSys`.

## Tests

`Issue3042Test` is the regression test. It uses the existing `Issue582/TestAbstractDirection.aadl` rather than a new fixture, because that shape is the one that reaches this check: both features are declared abstract and refined to a direction by extension, so each declaration passes declarative validation while the instance directions do not compose. A connection that both declares and violates a direction rule, such as a port connection into an outgoing port or two sibling accesses that both provide, is rejected by the declarative validator and never reaches the instantiator at all; a fixture written that way would test nothing here.

Its third assertion records a boundary of the change: a connection whose source is an incoming feature still produces nothing, because the traversal only starts at outgoing features.

47 assertions in five `Issue582` tests are updated. Their expected values are measured rather than derived, because the old messages cannot be mapped to connection names mechanically: the old text names a partial path's ultimate source, and in the nested fixtures a message attached to `srcSys` can belong to a connection contained in the root. Message assertions are now order independent, since a model with both a classifier warning and a direction error on one connection reports the warning first and assertions on `messages.get(0)` would otherwise break for unrelated reasons.

All 575 tests in `org.osate.core.tests` pass. No other test in the bundle changed.

## Effect on issue #3037

This removes the one diagnostic across-first connection traversal could not reproduce. It rejects a segment before any path exists, so it has no partial path to name and no component to attribute an error to. With the check on the connection instance both strategies report identically, and across-first no longer needs direction filtering while enumerating.

## Not run

A clean root-reactor build and the sibling `aadl-language-server` compile were not run. The change is confined to the instantiation bundle with no API change, so the module build plus the full core test suite was the proportionate check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
