### PR TITLE
Give a port beside a connected access feature its own connection instance

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/ConnectionInfo.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/ConnectionInfo.java
@@ -37,8 +37,10 @@ import static org.osate.aadl2.instance.FeatureCategory.SUBPROGRAM_ACCESS;
 import static org.osate.aadl2.instance.FeatureCategory.SUBPROGRAM_GROUP_ACCESS;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.emf.common.util.EList;
 import org.osate.aadl2.ConnectedElement;
@@ -81,6 +83,19 @@ class ConnectionInfo {
 	ConnectedElement dstToMatch;
 	ComponentInstance container;
 
+	/**
+	 * Issue 3044: the feature instances that the traversal continues into beyond the component
+	 * where this path stops. Connection instances for them are created further in, so ending this
+	 * path at them would add a second, shorter connection instance for the same features.
+	 */
+	private Set<FeatureInstance> continuedEnds = Collections.emptySet();
+
+	/**
+	 * Issue 3044: the feature instances that this path can neither continue into nor end at. They
+	 * are reported instead of becoming a connection instance.
+	 */
+	private Set<FeatureInstance> deadEnds = Collections.emptySet();
+
 	private ConnectionInfo(final ConnectionInfo info) {
 		src = info.src;
 		connections = new ArrayList<Connection>(info.connections);
@@ -95,6 +110,8 @@ class ConnectionInfo {
 		srcToMatch = info.srcToMatch;
 		dstToMatch = info.dstToMatch;
 		container = info.container;
+		continuedEnds = info.continuedEnds;
+		deadEnds = info.deadEnds;
 	}
 
 	private ConnectionInfo(final ConnectionInstanceEnd s) {
@@ -202,6 +219,53 @@ class ConnectionInfo {
 
 	public ConnectionInfo cloneInfo() {
 		return new ConnectionInfo(this);
+	}
+
+	/**
+	 * Record the feature instances that this path must not end at because the traversal continues
+	 * into them.
+	 */
+	public void setContinuedEnds(final Set<FeatureInstance> fis) {
+		continuedEnds = fis;
+	}
+
+	/**
+	 * Does the traversal continue into this feature instance, or into a feature group that contains
+	 * it, beyond the component where this path stops?
+	 */
+	public boolean isContinuedEnd(final FeatureInstance fi) {
+		return containsSelfOrContainer(continuedEnds, fi);
+	}
+
+	/**
+	 * Record the feature instances that this path can neither continue into nor end at.
+	 */
+	public void setDeadEnds(final Set<FeatureInstance> fis) {
+		deadEnds = fis;
+	}
+
+	/**
+	 * Is this feature instance, or a feature group that contains it, one that the path can neither
+	 * continue into nor end at?
+	 */
+	public boolean isDeadEnd(final FeatureInstance fi) {
+		return containsSelfOrContainer(deadEnds, fi);
+	}
+
+	/**
+	 * The end of a path is only known once it has been narrowed and expanded, and both of those can
+	 * reach below the member the decision was made for, so a member stands for everything under it.
+	 */
+	private static boolean containsSelfOrContainer(final Set<FeatureInstance> fis, final FeatureInstance fi) {
+		if (fis.isEmpty()) {
+			return false;
+		}
+		for (Element current = fi; current instanceof FeatureInstance feature; current = feature.getOwner()) {
+			if (fis.contains(feature)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	public ConnectionInstance createConnectionInstance(final String name, final ConnectionInstanceEnd dst) {

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateConnectionsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateConnectionsSwitch.java
@@ -37,8 +37,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Set;
 import java.util.Stack;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -67,6 +69,7 @@ import org.osate.aadl2.FeatureGroupType;
 import org.osate.aadl2.InternalFeature;
 import org.osate.aadl2.Mode;
 import org.osate.aadl2.ModeTransition;
+import org.osate.aadl2.NamedElement;
 import org.osate.aadl2.Parameter;
 import org.osate.aadl2.ParameterConnection;
 import org.osate.aadl2.Port;
@@ -719,6 +722,14 @@ public class CreateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 								final ConnectionInfo clone = connInfo.cloneInfo();
 								clone.complete = true;
 								finalizeConnectionInstance(ci, clone, toFi);
+							} else {
+								/*
+								 * Issue 3044: The flag above answers the question for the destination feature as
+								 * a whole, but a feature group answers it member by member. The connections we
+								 * keep may continue only some of its members, an access member reaching a
+								 * subprogram for instance, and leave the rest with nowhere to go.
+								 */
+								stopAtUncontinuedMembers(ci, connInfo, toFeature, toFi, toCi, conns, finalComponent);
 							}
 
 							// we have ingoing connections that start with toFeature
@@ -760,6 +771,180 @@ public class CreateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 					// should be the same
 					warning(ci, "Did not match popped downIndex");
 				}
+			}
+		}
+	}
+
+	/**
+	 * Issue 3044: Stop the path at the destination component for the members of the destination
+	 * feature that the internal connections of that component do not continue.
+	 *
+	 * <p>
+	 * Nothing happens when every part of the feature continues inside, and nothing happens when the
+	 * connections cannot be related to the feature at all, which leaves the traversal as it was for
+	 * a shape we did not recognize. Otherwise the path is finalized with the members it may not end
+	 * at recorded on it, because which member it ends at is only decided while it is finalized: the
+	 * feature group stack narrows the end for a path that already identifies a member, and
+	 * expansion pairs up the members for a path that does not.
+	 * </p>
+	 *
+	 * <p>
+	 * A connection ending component ends the connection for every member with nowhere to go.
+	 * Anywhere else, only a member that triggers a mode transition of the component ends one, since
+	 * a mode transition is an end in itself. The other members can reach no component that ends a
+	 * connection, so stopping at them would materialize an incomplete connection; they are recorded
+	 * as dead ends and reported when the path resolves to one of them.
+	 * </p>
+	 *
+	 * @param ci the component that contains the segment that arrives at the destination component
+	 * @param connInfo the path that arrives at the destination component
+	 * @param toFeature the feature of the destination component the path arrives at
+	 * @param toFi the instance of that feature
+	 * @param toCi the destination component
+	 * @param conns the internal connections of the destination component the traversal continues with
+	 * @param finalComponent whether the destination component is connection ending
+	 */
+	private void stopAtUncontinuedMembers(final ComponentInstance ci, final ConnectionInfo connInfo,
+			final Feature toFeature, final ConnectionInstanceEnd toFi, final ComponentInstance toCi,
+			final List<Connection> conns, final boolean finalComponent) {
+		if (!(toFi instanceof FeatureInstance dstFi) || dstFi.getFeatureInstances().isEmpty()) {
+			return;
+		}
+
+		final Set<FeatureInstance> continued = continuedFeatures(dstFi, toFeature, conns);
+
+		if (continued.isEmpty()) {
+			return;
+		}
+
+		final List<FeatureInstance> uncontinued = new ArrayList<>();
+		collectUncontinuedLeaves(dstFi, continued, uncontinued);
+		if (uncontinued.isEmpty()) {
+			return;
+		}
+
+		final Set<FeatureInstance> deadEnds = new LinkedHashSet<>();
+		if (!finalComponent) {
+			collectDeadEnds(dstFi, continued, toCi, deadEnds);
+		}
+
+		final ConnectionInfo clone = connInfo.cloneInfo();
+		clone.complete = true;
+		clone.setContinuedEnds(continued);
+		clone.setDeadEnds(deadEnds);
+		finalizeConnectionInstance(ci, clone, dstFi);
+	}
+
+	/**
+	 * The feature instances under the feature a path arrives at that the internal connections of
+	 * the destination component continue.
+	 *
+	 * <p>
+	 * A connection names a path below the feature it reaches the component through, {@code fg.inner.p}
+	 * for instance, so what continues is the feature itself or a feature nested below it at any
+	 * depth.
+	 * </p>
+	 */
+	private static Set<FeatureInstance> continuedFeatures(final FeatureInstance dstFi, final Feature toFeature,
+			final List<Connection> conns) {
+		final Set<FeatureInstance> continued = new LinkedHashSet<>();
+
+		for (final Connection conn : conns) {
+			final Connection root = conn.getRootConnection();
+			addContinuedFeature(dstFi, toFeature, root.getSource(), continued);
+			addContinuedFeature(dstFi, toFeature, root.getDestination(), continued);
+		}
+		return continued;
+	}
+
+	/**
+	 * Add the feature instance that one end of an internal connection continues, if that end names
+	 * the feature the path arrives at or something below it.
+	 */
+	private static void addContinuedFeature(final FeatureInstance dstFi, final Feature toFeature,
+			final ConnectedElement end, final Set<FeatureInstance> continued) {
+		if (end == null) {
+			return;
+		}
+
+		final Context context = end.getContext();
+
+		if (context == null) {
+			// the end is the feature itself, so the whole feature continues inside
+			if (namesFeature(end.getConnectionEnd(), toFeature)) {
+				continued.add(dstFi);
+			}
+			return;
+		}
+		if (!namesFeature(context, toFeature)) {
+			// the end is inside the component, or in another feature of it
+			return;
+		}
+
+		// walk the named path down the feature instance hierarchy
+		FeatureInstance current = dstFi;
+		for (ConnectedElement step = end; step != null && current != null; step = step.getNext()) {
+			current = (FeatureInstance) AadlUtil.findNamedElementInList(current.getFeatureInstances(),
+					step.getConnectionEnd().getName());
+		}
+		if (current != null) {
+			continued.add(current);
+		}
+	}
+
+	private static boolean namesFeature(final NamedElement element, final Feature feature) {
+		// a refinement keeps the name of the feature it refines
+		return element instanceof Feature named && feature.getName().equalsIgnoreCase(named.getName());
+	}
+
+	/**
+	 * Collect the features under the feature a path stops at that can neither be continued nor end
+	 * a connection there, including a feature whose every part is one of those.
+	 *
+	 * <p>
+	 * A feature the traversal continues into is not dead: it ends a connection instance created
+	 * further in, which the continued ends take care of. A feature that triggers a mode transition
+	 * of the component is not dead either, because the mode transition ends the connection. Neither
+	 * makes the feature group containing it dead.
+	 * </p>
+	 *
+	 * @return whether this feature is dead
+	 */
+	private static boolean collectDeadEnds(final FeatureInstance fi, final Set<FeatureInstance> continued,
+			final ComponentInstance toCi, final Set<FeatureInstance> dead) {
+		if (continued.contains(fi) || isModeTransitionTrigger(toCi, fi)) {
+			return false;
+		}
+		if (fi.getFeatureInstances().isEmpty()) {
+			dead.add(fi);
+			return true;
+		}
+
+		boolean allDead = true;
+
+		for (final FeatureInstance member : fi.getFeatureInstances()) {
+			allDead &= collectDeadEnds(member, continued, toCi, dead);
+		}
+		if (allDead) {
+			dead.add(fi);
+		}
+		return allDead;
+	}
+
+	/**
+	 * Collect the leaves under a feature that the traversal does not continue. A leaf is continued
+	 * when the traversal continues into it or into a feature that contains it.
+	 */
+	private static void collectUncontinuedLeaves(final FeatureInstance fi, final Set<FeatureInstance> continued,
+			final List<FeatureInstance> result) {
+		if (continued.contains(fi)) {
+			return;
+		}
+		if (fi.getFeatureInstances().isEmpty()) {
+			result.add(fi);
+		} else {
+			for (final FeatureInstance member : fi.getFeatureInstances()) {
+				collectUncontinuedLeaves(member, continued, result);
 			}
 		}
 	}
@@ -921,6 +1106,24 @@ public class CreateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 		}
 		if (unresolvedEndpoint) {
 			return null;
+		}
+
+		/*
+		 * Issue 3044: This path stops at a component that the traversal continues into for some of
+		 * the members of the feature it stops at. A member the traversal continues into ends a
+		 * connection instance created further in, so this path must not end at it. A member that
+		 * the traversal can neither continue into nor stop at ends no connection instance at all,
+		 * and that is reported here because this is where the end of the path is known.
+		 */
+		if (dstI instanceof FeatureInstance dstFi) {
+			if (connInfo.isContinuedEnd(dstFi)) {
+				return null;
+			}
+			if (connInfo.isDeadEnd(dstFi)) {
+				warning(dstFi, "Could not continue connection from " + connInfo.src.getInstanceObjectPath() + " through "
+						+ dstFi.getInstanceObjectPath() + ". No connection instance created.");
+				return null;
+			}
 		}
 
 		// with aggregate data ports will be sources/destinations missing

--- a/core/org.osate.core.tests/models/issue3044/.gitignore
+++ b/core/org.osate.core.tests/models/issue3044/.gitignore
@@ -1,0 +1,1 @@
+/.aadlbin-gen/

--- a/core/org.osate.core.tests/models/issue3044/.project
+++ b/core/org.osate.core.tests/models/issue3044/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3044</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3044/Issue3044.aadl
+++ b/core/org.osate.core.tests/models/issue3044/Issue3044.aadl
@@ -1,0 +1,48 @@
+package Issue3044
+public
+	feature group ServiceGroup
+		features
+			shared_call: provides subprogram access;
+			signal_line: out data port;
+	end ServiceGroup;
+
+	thread ProviderSide
+		features
+			service_bundle: feature group ServiceGroup;
+	end ProviderSide;
+
+	thread implementation ProviderSide.impl
+		subcomponents
+			worker_unit: subprogram;
+		connections
+			internal_supply: subprogram access worker_unit -> service_bundle.shared_call;
+	end ProviderSide.impl;
+
+	subprogram ServiceClient
+		features
+			requested_call: requires subprogram access;
+	end ServiceClient;
+
+	thread RequesterSide
+		features
+			service_bundle: feature group inverse of ServiceGroup;
+	end RequesterSide;
+
+	thread implementation RequesterSide.impl
+		subcomponents
+			worker_unit: subprogram ServiceClient;
+		connections
+			internal_demand: subprogram access worker_unit.requested_call <-> service_bundle.shared_call;
+	end RequesterSide.impl;
+
+	process DemoTop
+	end DemoTop;
+
+	process implementation DemoTop.impl
+		subcomponents
+			provider_side: thread ProviderSide.impl;
+			requester_side: thread RequesterSide.impl;
+		connections
+			across_link: feature group provider_side.service_bundle <-> requester_side.service_bundle;
+	end DemoTop.impl;
+end Issue3044;

--- a/core/org.osate.core.tests/models/issue3044/UncontinuedMembers.aadl
+++ b/core/org.osate.core.tests/models/issue3044/UncontinuedMembers.aadl
@@ -1,0 +1,62 @@
+package UncontinuedMembers
+public
+	feature group SensorGroup
+	features
+		data_line: out data port;
+		alarm_line: out event port;
+		spare_line: out data port;
+	end SensorGroup;
+
+	thread Emitter
+	features
+		data_out: out data port;
+		alarm_out: out event port;
+		spare_out: out data port;
+	end Emitter;
+
+	process Sender
+	features
+		sensor_bundle: feature group SensorGroup;
+	end Sender;
+
+	process implementation Sender.impl
+	subcomponents
+		emitter: thread Emitter;
+	connections
+		from_data: port emitter.data_out -> sensor_bundle.data_line;
+		from_alarm: port emitter.alarm_out -> sensor_bundle.alarm_line;
+		from_spare: port emitter.spare_out -> sensor_bundle.spare_line;
+	end Sender.impl;
+
+	thread Consumer
+	features
+		data_in: in data port;
+	end Consumer;
+
+	process Receiver
+	features
+		sensor_bundle: feature group inverse of SensorGroup;
+	end Receiver;
+
+	process implementation Receiver.impl
+	subcomponents
+		consumer: thread Consumer;
+	connections
+		to_consumer: port sensor_bundle.data_line -> consumer.data_in;
+	modes
+		quiet: initial mode;
+		alerted: mode;
+		raise_alert: quiet -[ sensor_bundle.alarm_line ]-> alerted;
+	end Receiver.impl;
+
+	system TriggerTop
+	end TriggerTop;
+
+	system implementation TriggerTop.impl
+	subcomponents
+		sender: process Sender.impl;
+		receiver: process Receiver.impl;
+	connections
+		bundle_link: feature group sender.sensor_bundle -> receiver.sensor_bundle;
+	end TriggerTop.impl;
+end UncontinuedMembers;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2032Test.xtend
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2032Test.xtend
@@ -49,7 +49,41 @@ class Issue2032Test {
 
 	@Test
 	def void testShortAccessConnections_Cleanup() {
-		test3("ShortAccessConnections.aadl")
+		val pkg = testHelper.parseFile(PROJECT_LOCATION + "ShortAccessConnections.aadl")
+
+		val cls = pkg.ownedPublicSection.ownedClassifiers
+		assertTrue('System implementation "' + ROOT_IMPL + '" not found', cls.exists[name == ROOT_IMPL])
+
+		// Instantiate system
+		val sysImpl = cls.findFirst[name == ROOT_IMPL] as SystemImplementation
+		val instance = InstantiateModel.instantiate(sysImpl)
+		assertEquals(ROOT_INSTANCE, instance.name)
+
+		/*
+		 * Issue 3044: The port of the feature group gets a connection instance of its own, in
+		 * addition to the two orientations of the access connection. It is not connected inside
+		 * either thread, so the feature group connection is the whole of it.
+		 */
+		val myP = instance.componentInstances.get(0)
+		assertEquals(3, myP.connectionInstances.size)
+		assertEquals('t1.fg.p -> t2.fgi.p, t1.s -> t2.s.rsa, t2.s.rsa -> t1.s',
+			myP.connectionInstances.map[name].sort.join(', '))
+
+		val portConn = myP.connectionInstances.findFirst[name == 't1.fg.p -> t2.fgi.p']
+		assertEquals(1, portConn.connectionReferences.size)
+		assertEquals("ca", portConn.connectionReferences.get(0).connection.name)
+
+		// Each access connection instance should have 3 connection references
+		val accessConns = myP.connectionInstances.filter[it !== portConn].toList
+		val connRefs1 = accessConns.get(0).connectionReferences
+		val connRefs2 = accessConns.get(1).connectionReferences
+		assertEquals(3, connRefs1.size)
+		assertEquals(3, connRefs2.size)
+
+		// The two access connection instances should follow opposite paths
+		assertEquals(connRefs1.get(0).connection, connRefs2.get(2).connection)
+		assertEquals(connRefs1.get(1).connection, connRefs2.get(1).connection)
+		assertEquals(connRefs1.get(2).connection, connRefs2.get(0).connection)
 	}
 
 	@Test

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3044Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3044Test.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instance.ConnectionInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * A port that shares a feature group with a connected access feature must still get its
+ * own connection instance.
+ *
+ * <p>
+ * {@code ServiceGroup} carries an access feature and an out data port, and connects two
+ * threads. The access feature continues inside the requester thread, into its subprogram;
+ * the port continues nowhere, so the connection between the two ports is maximal and
+ * complete. Both connections belong in the instance model.
+ * </p>
+ *
+ * <p>
+ * The traversal decides whether to create a connection instance that stops at the
+ * destination thread by looking at that thread's internal connections as a whole. An
+ * access connection is never ignored, so nothing records that the port member had no
+ * continuation, no path stops at the feature group, and the port connection is silently
+ * absent. Nothing is reported and the declarative model is valid, so any analysis over
+ * port connections simply sees no flow between the two ports.
+ * </p>
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3044Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3044/Issue3044.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void aPortBesideAConnectedAccessFeatureIsStillInstantiated() throws Exception {
+		var pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+		var instance = InstantiateModel.instantiate(findImplementation(pkg, "DemoTop.impl"));
+
+		assertEquals(List.of(
+				"DemoTop_impl_Instance.provider_side.service_bundle.signal_line"
+						+ " -> DemoTop_impl_Instance.requester_side.service_bundle.signal_line",
+				"DemoTop_impl_Instance.provider_side.worker_unit"
+						+ " -> DemoTop_impl_Instance.requester_side.worker_unit.requested_call"),
+				instance.getAllConnectionInstances().stream().map(Issue3044Test::describe).sorted().toList());
+	}
+
+	private static ComponentImplementation findImplementation(AadlPackage pkg, String name) {
+		return (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals(name))
+				.findFirst()
+				.orElseThrow();
+	}
+
+	private static String describe(ConnectionInstance connection) {
+		return connection.getSource().getInstanceObjectPath() + " -> "
+				+ connection.getDestination().getInstanceObjectPath();
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3044Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3044Test.java
@@ -35,7 +35,10 @@ import org.junit.runner.RunWith;
 import org.osate.aadl2.AadlPackage;
 import org.osate.aadl2.ComponentImplementation;
 import org.osate.aadl2.instance.ConnectionInstance;
+import org.osate.aadl2.instance.InstanceObject;
 import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
 import org.osate.testsupport.Aadl2InjectorProvider;
 import org.osate.testsupport.TestHelper;
 
@@ -66,6 +69,7 @@ import com.itemis.xtext.testing.XtextTest;
 @InjectWith(Aadl2InjectorProvider.class)
 public class Issue3044Test extends XtextTest {
 	private static final String MODEL = "org.osate.core.tests/models/issue3044/Issue3044.aadl";
+	private static final String UNCONTINUED_MODEL = "org.osate.core.tests/models/issue3044/UncontinuedMembers.aadl";
 
 	@Inject
 	private TestHelper<AadlPackage> testHelper;
@@ -85,6 +89,42 @@ public class Issue3044Test extends XtextTest {
 				"DemoTop_impl_Instance.provider_side.worker_unit"
 						+ " -> DemoTop_impl_Instance.requester_side.worker_unit.requested_call"),
 				instance.getAllConnectionInstances().stream().map(Issue3044Test::describe).sorted().toList());
+	}
+
+	/**
+	 * A member with nowhere to go inside a component that does not end connections gets a
+	 * connection instance only when it triggers a mode transition of that component.
+	 *
+	 * <p>
+	 * {@code SensorGroup} carries three ports and connects two processes. Inside the receiving
+	 * process, {@code data_line} continues to a thread, {@code alarm_line} continues nowhere but
+	 * triggers a mode transition, and {@code spare_line} continues nowhere at all. The mode
+	 * transition ends a connection, so {@code alarm_line} gets one; {@code spare_line} can reach no
+	 * component that ends a connection, so it gets a diagnostic instead of an incomplete connection.
+	 * </p>
+	 */
+	@Test
+	public void aModeTransitionTriggerEndsAConnectionAndADeadMemberIsReported() throws Exception {
+		var pkg = testHelper.parseFile(UNCONTINUED_MODEL);
+		validationHelper.assertNoIssues(pkg);
+		var errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+		var instance = InstantiateModel.instantiate(findImplementation(pkg, "TriggerTop.impl"), errorManager);
+
+		assertEquals(List.of(
+				"TriggerTop_impl_Instance.sender.emitter.alarm_out"
+						+ " -> TriggerTop_impl_Instance.receiver.sensor_bundle.alarm_line",
+				"TriggerTop_impl_Instance.sender.emitter.data_out -> TriggerTop_impl_Instance.receiver.consumer.data_in"),
+				instance.getAllConnectionInstances().stream().map(Issue3044Test::describe).sorted().toList());
+
+		var messages = ((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource())).getErrors();
+		assertEquals(List.of("Warning|TriggerTop_impl_Instance.receiver.sensor_bundle.spare_line"
+				+ "|Could not continue connection from TriggerTop_impl_Instance.sender.emitter.spare_out"
+				+ " through TriggerTop_impl_Instance.receiver.sensor_bundle.spare_line."
+				+ " No connection instance created."),
+				messages.stream()
+						.map(message -> message.kind + "|" + ((InstanceObject) message.where).getInstanceObjectPath()
+								+ "|" + message.message)
+						.toList());
 	}
 
 	private static ComponentImplementation findImplementation(AadlPackage pkg, String name) {


### PR DESCRIPTION
Fixes #3044.

## Problem

A port that shares a feature group with a connected access feature gets no connection instance, so an ordinary port connection between two threads disappears from the instance model. Nothing is reported and the declarative model is valid, so latency, flow, and binding analyses simply see no flow between the two ports.

When a path reaches a component through a feature group, `CreateConnectionsSwitch.appendSegment()` decides whether to also create a connection instance that *stops* at that component from a single flag over the whole feature: were any internal connections ignored? An access connection is never ignored, so the flag stays `false` when the group's access member is connected inside. The traversal continues to the access member only, and the path that would have carried the group's port member is never created.

## Fix

A feature group answers that question member by member. `appendSegment()` now resolves which features under the destination feature the kept connections continue. Each connection names a path below the feature it enters through (`fg.inner.p`), so a continuation is resolved to a feature instance at whatever depth the connection reaches. When that does not cover the whole feature, the path is finalized with the members it may not end at recorded on it.

Which member a path ends at is only decided while it is finalized — the feature group stack narrows the end for a path that already identifies a member, expansion pairs up members for a path that does not — so the two sets recorded on `ConnectionInfo` are consulted in `addConnectionInstance()`, where the end is known, and a member stands for everything under it.

**A member the traversal continues into is not an end of this path.** Its connection instance is created further in, and ending here as well would add a second, shorter connection instance for the same features: for the reported model, an access connection between the two access features beside the correct one from the subprogram to the requires access.

**A member with nowhere to go** ends the connection when the component is connection-ending. Anywhere else it ends one only if it triggers a mode transition of the component, since a mode transition is an end in itself. The rest can reach no component that ends a connection, so stopping at them would materialize an incomplete connection; they are reported instead, with the same kind of diagnostic the traversal already gives for a path it cannot continue:

> Could not continue connection from `...sender.emitter.spare_out` through `...receiver.sensor_bundle.spare_line`. No connection instance created.

| destination | nothing continues inside | some members continue |
|---|---|---|
| thread, device, processor | instance, no diagnostic (unchanged) | **instance, no diagnostic (was silent)** |
| process, system, abstract | instance + warning (unchanged) | **mode transition trigger: instance; otherwise warning, no instance** |

## Tests

- `Issue3044Test.aPortBesideAConnectedAccessFeatureIsStillInstantiated` (first commit, the regression test) fails at the base and passes with the fix.
- `Issue3044Test.aModeTransitionTriggerEndsAConnectionAndADeadMemberIsReported` covers the non-connection-ending row over `UncontinuedMembers.aadl`: a feature group connects two processes, and inside the receiving one, one member continues to a thread, one continues nowhere but triggers a mode transition, and one continues nowhere at all. It asserts the two connection instances, the absence of a third, and the diagnostic naming the member with nowhere to go.
- `Issue2032Test.testShortAccessConnections_Cleanup` pinned the defect: its fixture is the reported shape and it asserted the two orientations of the access connection as the only connection instances of the process. It now asserts the port connection alongside them, that the port connection is the feature group connection alone, and that the access connections are unchanged.
- Full reactor build with tests: 2326 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)