### PR TITLE
Fix ormore fault tree probabilities 🤖

### DIFF
--- a/emv2/org.osate.aadl2.errormodel.faulttree.tests/models/issue2927/.gitignore
+++ b/emv2/org.osate.aadl2.errormodel.faulttree.tests/models/issue2927/.gitignore
@@ -1,0 +1,1 @@
+/.aadlbin-gen/

--- a/emv2/org.osate.aadl2.errormodel.faulttree.tests/models/issue2927/.project
+++ b/emv2/org.osate.aadl2.errormodel.faulttree.tests/models/issue2927/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue2927</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/emv2/org.osate.aadl2.errormodel.faulttree.tests/models/issue2927/Issue2927.aadl
+++ b/emv2/org.osate.aadl2.errormodel.faulttree.tests/models/issue2927/Issue2927.aadl
@@ -1,0 +1,74 @@
+package issue2927
+public
+	annex EMV2 {**
+		error behavior Simple
+		states
+			Good: initial state;
+			Failed: state;
+		end behavior;
+	**};
+
+	system power_bus
+		annex EMV2 {**
+			use behavior issue2927::Simple;
+
+			component error behavior
+			events
+				PowerBusFail: error event;
+			transitions
+				Good -[PowerBusFail]-> Failed;
+			end component;
+
+			properties
+				EMV2::OccurrenceDistribution => [ProbabilityValue => 10.0e-6; Distribution => Fixed;]
+					applies to PowerBusFail;
+		**};
+	end power_bus;
+
+	system implementation power_bus.i
+	end power_bus.i;
+
+	system redundant_thing
+	end redundant_thing;
+
+	system implementation redundant_thing.four
+		subcomponents
+			power_bus_1: system power_bus.i;
+			power_bus_2: system power_bus.i;
+			power_bus_3: system power_bus.i;
+			power_bus_4: system power_bus.i;
+	end redundant_thing.four;
+
+	system implementation redundant_thing.i4_2 extends redundant_thing.four
+		annex EMV2 {**
+			use behavior issue2927::Simple;
+
+			composite error behavior
+			states
+				[2 ormore (power_bus_1.Failed, power_bus_2.Failed, power_bus_3.Failed, power_bus_4.Failed)]-> Failed;
+			end composite;
+		**};
+	end redundant_thing.i4_2;
+
+	system implementation redundant_thing.i4_3 extends redundant_thing.four
+		annex EMV2 {**
+			use behavior issue2927::Simple;
+
+			composite error behavior
+			states
+				[3 ormore (power_bus_1.Failed, power_bus_2.Failed, power_bus_3.Failed, power_bus_4.Failed)]-> Failed;
+			end composite;
+		**};
+	end redundant_thing.i4_3;
+
+	system implementation redundant_thing.i4_4 extends redundant_thing.four
+		annex EMV2 {**
+			use behavior issue2927::Simple;
+
+			composite error behavior
+			states
+				[4 ormore (power_bus_1.Failed, power_bus_2.Failed, power_bus_3.Failed, power_bus_4.Failed)]-> Failed;
+			end composite;
+		**};
+	end redundant_thing.i4_4;
+end issue2927;

--- a/emv2/org.osate.aadl2.errormodel.faulttree.tests/src/org/osate/aadl2/errormodel/faulttree/tests/issues/Issue2927Test.java
+++ b/emv2/org.osate.aadl2.errormodel.faulttree.tests/src/org/osate/aadl2/errormodel/faulttree/tests/issues/Issue2927Test.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to the Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.aadl2.errormodel.faulttree.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.errormodel.FaultTree.FaultTree;
+import org.osate.aadl2.errormodel.FaultTree.LogicOperation;
+import org.osate.aadl2.errormodel.faulttree.generation.CreateFTAModel;
+import org.osate.aadl2.errormodel.tests.ErrorModelInjectorProvider;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+
+@RunWith(XtextRunner.class)
+@InjectWith(ErrorModelInjectorProvider.class)
+public class Issue2927Test {
+	private static final String MODEL_PATH = "org.osate.aadl2.errormodel.faulttree.tests/models/issue2927/Issue2927.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	private AadlPackage model;
+
+	@Before
+	public void parseModel() throws Exception {
+		model = testHelper.parseFile(MODEL_PATH);
+		validationHelper.assertNoIssues(model);
+	}
+
+	@Test
+	public void computesKOrMoreFailureProbabilities() throws Exception {
+		assertProbability("redundant_thing.i4_2", 5.9999200003E-10);
+		assertProbability("redundant_thing.i4_3", 3.99997E-15);
+		assertProbability("redundant_thing.i4_4", 1E-20);
+	}
+
+	private void assertProbability(final String classifierName, final double expected) throws Exception {
+		var classifier = model.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(candidate -> candidateNameMatches(candidate.getName(), classifierName))
+				.findFirst();
+		assertTrue("Missing classifier " + classifierName, classifier.isPresent());
+
+		var instance = InstantiateModel.instantiate((ComponentImplementation) classifier.get());
+		assertKOrMoreProbability(CreateFTAModel.createFaultTree((SystemInstance) instance, "state Failed"), expected);
+	}
+
+	private static boolean candidateNameMatches(final String candidateName, final String expectedName) {
+		return candidateName != null && candidateName.equalsIgnoreCase(expectedName);
+	}
+
+	private static void assertKOrMoreProbability(final FaultTree faultTree, final double expected) {
+		var kOrMoreEvent = faultTree.getEvents()
+				.stream()
+				.filter(event -> event.getSubEventLogic() == LogicOperation.KORMORE)
+				.findFirst();
+		assertTrue("The generated fault tree does not contain a k-or-more event", kOrMoreEvent.isPresent());
+		var actualProbability = kOrMoreEvent.get().getComputedProbability();
+		assertEquals("Unexpected k-or-more probability", expected, actualProbability.doubleValue(), expected * 1.0E-12);
+	}
+}

--- a/emv2/org.osate.aadl2.errormodel.faulttree/src/org/osate/aadl2/errormodel/FaultTree/util/FaultTreeUtils.java
+++ b/emv2/org.osate.aadl2.errormodel.faulttree/src/org/osate/aadl2/errormodel/FaultTree/util/FaultTreeUtils.java
@@ -623,32 +623,19 @@ public class FaultTreeUtils {
 		// "Computing k-out-of-n System Reliability", by R. E. Barlow and K. D. Heidtmann
 		// in IEEE Transactions on Reliability, Vol R-33, No 4, October 1984
 		//
-		// The general intuition of this algorithm goes as follows, using LaTex notation for the equations
-		// Conventions:
-		// $q_i$ is the failure rate of component i
-		// $p_i$ is the reliability rate of component i, $p_i = 1 - q_i$
-		// Re(k, n) is the probability that there are exactly k working components out of n
+		// If p_i is the probability of event i, the generating function
 		//
-		// Borderline cases as managed by the following conventions:
-		// $\forall j \in \{1 .. n\}, Re(-1, j) = Re(j+1, j) = 0$
-		// $Re(0, 0) = 0$
+		// g(z) = \prod_{i=1}^n ((1 - p_i) + p_i z)
 		//
-		// Barlow and Heidtmann propose the following generating function
-		//
-		// g(z)=\prod_{i=1}^n (q_i + p_i z)
-		//
-		// By recurrence, one can establish that $g(z)=\prod_{i=1}^n (q_i + p_i z)=\sum_{i=0}^ n Re(i,n) z^i$
-		// using $Re(i,j) = q_j * Re(i, j - 1) + p_j * Re(i-1, j-1)$.
-		//
-		// It follows that computing $Re(k, n)$ for some $k \leq n$ is equivalent to computing the k-th element in the polynom
-		// g (z) = \sum_{i=0}^ n g_i z^i$ and perform term identification
+		// has the probability that exactly j events occur as the coefficient of z^j. The recurrence below computes those
+		// coefficients, offset by one in A to match the original algorithm's indexing.
 
 		// For simplicity, we implement PROGRAM 1
 		// Note: to match the original algorithm, we start with index at 1, up-to index n + 1
 
 		int n = event.getSubEvents().size();
-		BigDecimal[] probabilities = new BigDecimal[n + 2];
-		Arrays.fill(probabilities, BigDecimal.ZERO);
+		BigDecimal[] eventProbabilities = new BigDecimal[n + 2];
+		Arrays.fill(eventProbabilities, BigDecimal.ZERO);
 
 		BigDecimal[] A = new BigDecimal[n + 2];
 		Arrays.fill(A, BigDecimal.ZERO);
@@ -657,26 +644,25 @@ public class FaultTreeUtils {
 
 		int k = 1;
 		for (Event subEvent : event.getSubEvents()) {
-			probabilities[k] = BigOne.subtract(getScaledProbability(subEvent));
+			eventProbabilities[k] = getScaledProbability(subEvent);
 			k++;
 		}
 
 		for (int j = 1; j <= n; j++) {
 			for (int i = j + 1; i >= 1; i--) {
 				// At each step, we perform A(i) = A(i) + P(j) * (A(i - 1) - A(i))
-				A[i] = A[i].add(probabilities[j].multiply(A[i - 1].subtract(A[i])));
+				A[i] = A[i].add(eventProbabilities[j].multiply(A[i - 1].subtract(A[i])));
 			}
 		}
 
-		// The associated failure probability of k or more is $1 - \Sum_{j=k}^n Re(j, n)$
-		BigDecimal R = BigZero;
+		// The probability that k or more events occur is the sum of the coefficients for k through n.
+		BigDecimal result = BigZero;
 
 		for (int j = event.getK() + 1; j <= n + 1; j++) {
-			R = R.add(A[j]);
+			result = result.add(A[j]);
 		}
 
-		R = BigOne.subtract(R);
-		return R;
+		return result;
 	}
 
 	public static BigDecimal pANDEvents(Event event) {


### PR DESCRIPTION
## Summary

- calculate k-or-more probabilities from event-occurrence probabilities instead of their complements
- sum the requested upper tail directly so k-of-n is not reversed to n-k+1-of-n
- add an end-to-end regression model covering 2-of-4, 3-of-4, and 4-of-4 gates

Fixes #2927

## Testing

- regression confirmed failing before the production fix
- focused Issue2927Test Tycho build
- complete org.osate.aadl2.errormodel.faulttree.tests suite: 65 tests passed