### PR TITLE
Preserve virtual bus loads across binding paths 🤖

### DIFF
--- a/analyses/org.osate.analysis.resource.budgets.tests/models/issue3009/.gitignore
+++ b/analyses/org.osate.analysis.resource.budgets.tests/models/issue3009/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/analyses/org.osate.analysis.resource.budgets.tests/models/issue3009/.project
+++ b/analyses/org.osate.analysis.resource.budgets.tests/models/issue3009/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3009</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/analyses/org.osate.analysis.resource.budgets.tests/models/issue3009/Issue3009.aadl
+++ b/analyses/org.osate.analysis.resource.budgets.tests/models/issue3009/Issue3009.aadl
@@ -1,0 +1,53 @@
+package Issue3009
+public
+	with SEI;
+
+	data D
+		properties
+			Data_Size => 8 Bytes;
+	end D;
+
+	bus B
+		properties
+			SEI::BandWidthBudget => 64.0 KBytesps;
+			SEI::BandWidthCapacity => 64.0 KBytesps;
+	end B;
+
+	virtual bus VB
+		properties
+			SEI::BandWidthBudget => 16.0 KBytesps;
+			SEI::BandWidthCapacity => 16.0 KBytesps;
+	end VB;
+
+	system Producer
+		features
+			outgoing: out data port D;
+	end Producer;
+
+	system Consumer
+		features
+			incoming: in data port D;
+	end Consumer;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			producer: system Producer;
+			consumer: system Consumer;
+			b1: bus B;
+			b2: bus B;
+			b3: bus B;
+			vb: virtual bus VB;
+		connections
+			c: port producer.outgoing -> consumer.incoming {
+				Actual_Connection_Binding => (reference (vb));
+				SEI::BandWidthBudget => 8.0 KBytesps;
+			};
+		properties
+			Actual_Connection_Binding => (reference (b1), reference (b2), reference (b3)) applies to vb;
+			Communication_Properties::Output_Rate =>
+				[Value_Range => 1000.0 .. 1000.0; Rate_Unit => PerSecond;] applies to producer.outgoing;
+	end Top.i;
+end Issue3009;

--- a/analyses/org.osate.analysis.resource.budgets.tests/src/org/osate/analysis/resource/budgets/tests/Issue3009Test.java
+++ b/analyses/org.osate.analysis.resource.budgets.tests/src/org/osate/analysis/resource/budgets/tests/Issue3009Test.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.analysis.resource.budgets.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.SystemImplementation;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.analysis.resource.budgets.busload.NewBusLoadAnalysis;
+import org.osate.result.Result;
+import org.osate.result.util.ResultUtil;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3009Test extends XtextTest {
+
+	private static final String FILE = "org.osate.analysis.resource.budgets.tests/models/issue3009/Issue3009.aadl";
+
+	@Inject
+	TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	ValidationTestHelper validationHelper;
+
+	@Test
+	public void testVirtualBusLoadIsReportedForEveryBusInBindingPath() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(FILE);
+		validationHelper.assertNoIssues(pkg);
+
+		SystemImplementation top = (SystemImplementation) pkg.getPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(c -> c.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		SystemInstance instance = InstantiateModel.instantiate(top);
+
+		Result somResult = new NewBusLoadAnalysis().invoke(null, instance, false).getResults().get(0);
+		assertEquals(3, somResult.getSubResults().size());
+		for (Result busResult : somResult.getSubResults()) {
+			assertEquals("Virtual bus missing from " + busResult.getMessage(), 1, ResultUtil.getInteger(busResult, 4));
+			assertEquals("Required budget missing from " + busResult.getMessage(), 16.0,
+					ResultUtil.getReal(busResult, 2), 0.0);
+			assertEquals("Actual load missing from " + busResult.getMessage(), 8.0,
+					ResultUtil.getReal(busResult, 3), 0.0);
+
+			Result virtualBusResult = busResult.getSubResults().get(0);
+			assertEquals("vb", virtualBusResult.getMessage());
+			assertEquals(1, virtualBusResult.getSubResults().size());
+			assertEquals("producer.outgoing -> consumer.incoming",
+					virtualBusResult.getSubResults().get(0).getMessage());
+		}
+	}
+}

--- a/analyses/org.osate.analysis.resource.budgets/src/org/osate/analysis/resource/budgets/busload/BusLoadModelBuilder.java
+++ b/analyses/org.osate.analysis.resource.budgets/src/org/osate/analysis/resource/budgets/busload/BusLoadModelBuilder.java
@@ -52,7 +52,6 @@ import org.osate.xtext.aadl2.properties.util.InstanceModelUtil;
 
 final class BusLoadModelBuilder {
 	private final Map<ComponentInstance, Bus> buses = new HashMap<>();
-	private final Map<ComponentInstance, VirtualBus> virtualBuses = new HashMap<>();
 
 	private final SystemInstance systemInstance;
 	private final SystemOperationMode som;
@@ -81,16 +80,12 @@ final class BusLoadModelBuilder {
 		return bus;
 	}
 
-	private VirtualBus getVirtualBus(final ComponentInstance ci) {
+	private static VirtualBus createVirtualBus(final ComponentInstance ci) {
 		if (ci.getCategory() != ComponentCategory.VIRTUAL_BUS) {
 			throw new IllegalArgumentException("Component instance is not a virtual bus");
 		}
-		VirtualBus vb = virtualBuses.get(ci);
-		if (vb == null) {
-			vb = BusloadFactory.eINSTANCE.createVirtualBus();
-			vb.setBusInstance(ci);
-			virtualBuses.put(ci, vb);
-		}
+		final VirtualBus vb = BusloadFactory.eINSTANCE.createVirtualBus();
+		vb.setBusInstance(ci);
 		return vb;
 	}
 
@@ -111,8 +106,6 @@ final class BusLoadModelBuilder {
 				final ComponentCategory cat = ci.getCategory();
 				if (cat == ComponentCategory.BUS) {
 					addBus(model, ci, som);
-				} else if (cat == ComponentCategory.VIRTUAL_BUS) {
-					addVirtualBus(model, ci, som);
 				}
 			}
 		};
@@ -123,17 +116,10 @@ final class BusLoadModelBuilder {
 	private void addBus(final BusLoadModel model, final ComponentInstance bus, final SystemOperationMode som) {
 		final Bus theBus = getBus(bus);
 		model.getRootBuses().add(theBus);
-		addBusOrVirtualBus(model, theBus, bus, som);
+		addBusOrVirtualBus(theBus, bus, som);
 	}
 
-	private void addVirtualBus(final BusLoadModel model, final ComponentInstance vb,
-			final SystemOperationMode som) {
-		final VirtualBus theVirtualBus = getVirtualBus(vb);
-		// Node will attached to the model by the (virtual) bus that it is bound to
-		addBusOrVirtualBus(model, theVirtualBus, vb, som);
-	}
-
-	private void addBusOrVirtualBus(final BusLoadModel model, final BusOrVirtualBus bus, final ComponentInstance ci,
+	private void addBusOrVirtualBus(final BusOrVirtualBus bus, final ComponentInstance ci,
 			final SystemOperationMode som) {
 		final boolean isBroadcast = Sei.getBroadcastProtocol(ci).orElse(false);
 		List<ConnectionInstance> budgetedConnections = InstanceModelUtil.getBoundConnections(ci);
@@ -154,7 +140,12 @@ final class BusLoadModelBuilder {
 		budgetedVBs = filterInMode(budgetedVBs, som);
 
 		budgetedConnections.forEach(connInstance -> bus.getBoundConnections().add(getConnection(connInstance)));
-		budgetedVBs.forEach(vb -> bus.getBoundVirtualBuses().add(getVirtualBus(vb)));
+		for (final ComponentInstance vb : budgetedVBs) {
+			// Each containment path needs its own analysis-model subtree.
+			final VirtualBus theVirtualBus = createVirtualBus(vb);
+			bus.getBoundVirtualBuses().add(theVirtualBus);
+			addBusOrVirtualBus(theVirtualBus, vb, som);
+		}
 	}
 
 	private static <E extends InstanceObject> List<E> filterInMode(final List<E> instanceObjects,


### PR DESCRIPTION
## Summary

- Build a distinct analysis-model virtual bus subtree for each containment path.
- Preserve load and budget reporting for every physical bus in a multi-bus binding sequence.

## Cause and correction

`boundVirtualBuses` is an EMF containment reference. Reusing one analysis-model `VirtualBus` object caused each insertion to reparent it, leaving only the last physical bus with the node. The builder now creates and populates a separate virtual bus subtree at each attachment point.

## Regression

`Issue3009Test` models one virtual bus bound through three physical buses and a connection bound to that virtual bus. It asserts that all three bus results include the virtual bus, its 16 KB/s required budget, and its 8 KB/s actual load.

## Validation

- Focused `Issue3009Test` clean install: 1 test, 0 failures, 0 errors.
- Full `org.osate.analysis.resource.budgets.tests` verify: 16 tests, 0 failures, 0 errors.
- Clean 137-module root-reactor install with `-Dtycho.localArtifacts=ignore`: BUILD SUCCESS.

## Dependencies

None.

## Residual risk

The analysis model duplicates virtual-bus wrapper subtrees per binding path by design; each wrapper references the same underlying AADL component instance.

Fixes #3009
