### PR TITLE
Make broadcast budget mismatch warnings order-independent 🤖

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target/
 .DS_Store
+.aadlbin-gen/
+instances/

--- a/analyses/org.osate.analysis.resource.budgets.tests/models/issue3010/.gitignore
+++ b/analyses/org.osate.analysis.resource.budgets.tests/models/issue3010/.gitignore
@@ -1,0 +1,1 @@
+/.aadlbin-gen/

--- a/analyses/org.osate.analysis.resource.budgets.tests/models/issue3010/.project
+++ b/analyses/org.osate.analysis.resource.budgets.tests/models/issue3010/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3010</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/analyses/org.osate.analysis.resource.budgets.tests/models/issue3010/Issue3010.aadl
+++ b/analyses/org.osate.analysis.resource.budgets.tests/models/issue3010/Issue3010.aadl
@@ -1,0 +1,54 @@
+package Issue3010
+public
+	with SEI;
+
+	data D
+		properties
+			Data_Size => 8 Bytes;
+	end D;
+
+	bus BroadcastBus
+		properties
+			SEI::BandWidthBudget => 64.0 KBytesps;
+			SEI::BandWidthCapacity => 64.0 KBytesps;
+			SEI::Broadcast_Protocol => true;
+	end BroadcastBus;
+
+	system Producer
+		features
+			outgoing: out data port D;
+	end Producer;
+
+	system Consumer
+		features
+			in1: in data port D;
+			in2: in data port D;
+			in3: in data port D;
+	end Consumer;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			producer: system Producer;
+			consumer: system Consumer;
+			bus1: bus BroadcastBus;
+		connections
+			c1: port producer.outgoing -> consumer.in1 {
+				Actual_Connection_Binding => (reference (bus1));
+				SEI::BandWidthBudget => 8.0 KBytesps;
+			};
+			c2: port producer.outgoing -> consumer.in2 {
+				Actual_Connection_Binding => (reference (bus1));
+				SEI::BandWidthBudget => 16.0 KBytesps;
+			};
+			c3: port producer.outgoing -> consumer.in3 {
+				Actual_Connection_Binding => (reference (bus1));
+				SEI::BandWidthBudget => 16.0 KBytesps;
+			};
+		properties
+			Communication_Properties::Output_Rate =>
+				[Value_Range => 1000.0 .. 1000.0; Rate_Unit => PerSecond;] applies to producer.outgoing;
+	end Top.i;
+end Issue3010;

--- a/analyses/org.osate.analysis.resource.budgets.tests/src/org/osate/analysis/resource/budgets/tests/Issue3010Test.java
+++ b/analyses/org.osate.analysis.resource.budgets.tests/src/org/osate/analysis/resource/budgets/tests/Issue3010Test.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.analysis.resource.budgets.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.SystemImplementation;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.analysis.resource.budgets.busload.NewBusLoadAnalysis;
+import org.osate.result.Diagnostic;
+import org.osate.result.DiagnosticType;
+import org.osate.result.Result;
+import org.osate.result.util.ResultUtil;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3010Test extends XtextTest {
+
+	private static final String FILE = "org.osate.analysis.resource.budgets.tests/models/issue3010/Issue3010.aadl";
+
+	@Inject
+	TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	ValidationTestHelper validationHelper;
+
+	@Test
+	public void testBroadcastBudgetMismatchIsIndependentOfConnectionOrder() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(FILE);
+		validationHelper.assertNoIssues(pkg);
+
+		SystemImplementation top = (SystemImplementation) pkg.getPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(c -> c.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		SystemInstance instance = InstantiateModel.instantiate(top);
+
+		Result busResult = new NewBusLoadAnalysis().invoke(null, instance, false)
+				.getResults()
+				.get(0)
+				.getSubResults()
+				.get(0);
+		assertEquals(1, ResultUtil.getInteger(busResult, 6));
+
+		Result broadcastResult = busResult.getSubResults().get(0);
+		assertEquals(16.0, ResultUtil.getReal(broadcastResult, 0), 0.0);
+		assertEquals(8.0, ResultUtil.getReal(broadcastResult, 1), 0.0);
+		assertEquals(3, broadcastResult.getDiagnostics().size());
+		for (Diagnostic diagnostic : broadcastResult.getDiagnostics()) {
+			assertEquals(DiagnosticType.WARNING, diagnostic.getDiagnosticType());
+			assertTrue(diagnostic.getMessage().endsWith("KB/s; using maximum"));
+		}
+	}
+}

--- a/analyses/org.osate.analysis.resource.budgets/src/org/osate/analysis/resource/budgets/busload/NewBusLoadAnalysis.java
+++ b/analyses/org.osate.analysis.resource.budgets/src/org/osate/analysis/resource/budgets/busload/NewBusLoadAnalysis.java
@@ -367,7 +367,7 @@ public final class NewBusLoadAnalysis {
 				final double current = c.getBudget();
 				maxBudget = Math.max(maxBudget, current);
 				if (last != null) {
-					unequal = last.getBudget() != current;
+					unequal |= last.getBudget() != current;
 				}
 				last = c;
 			}


### PR DESCRIPTION
Fixes #3010

## Cause and correction

Broadcast budget analysis replaced the `unequal` flag for every adjacent connection pair. A later equal pair therefore cleared an earlier mismatch and suppressed all warnings. Preserve the flag once any mismatch is found so warning generation is independent of connection order.

Repository-level ignore rules were also added for generated `.aadlbin-gen/` and `instances/` directories so analysis runs do not dirty fixture worktrees.

## Regression coverage

The new `Issue3010.aadl` model defines three connections sharing a broadcast source with budgets of 8, 16, and 16 KB/s. `Issue3010Test` validates the model, runs bus-load analysis, confirms the 16 KB/s maximum and 8 KB/s actual load, and requires one mismatch warning for each of the three connections.

The regression failed before the fix with `expected:<3> but was:<0>` and passes afterward.

## Validation

- Focused offline `Issue3010Test`: 1 test, 0 failures, 0 errors
- Related offline `Issue2205Test`: 15 tests, 0 failures, 0 errors
- Clean offline root reactor with `-Dtycho.localArtifacts=ignore`: all 137 modules passed

## Dependencies and residual risk

No dependencies or required merge ordering.

Residual risk is low. The production change only preserves an already detected mismatch; maximum-budget calculation and warning contents are unchanged.