### PR TITLE
Include specified bus latency in asynchronous queue waits 🤖

### DIFF
--- a/analyses/org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/results/testFlowLatency/required_vb2.result
+++ b/analyses/org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/results/testFlowLatency/required_vb2.result
@@ -55,7 +55,7 @@
   <results message="Latency results for etef2" resultType="FAILURE">
     <values xsi:type="result:StringValue" value=""/>
     <values xsi:type="result:RealValue" value="12.0"/>
-    <values xsi:type="result:RealValue" value="16.0"/>
+    <values xsi:type="result:RealValue" value="24.0"/>
     <values xsi:type="result:RealValue" value="12.0"/>
     <values xsi:type="result:RealValue" value="16.0"/>
     <values xsi:type="result:RealValue" value="2.0"/>
@@ -69,13 +69,13 @@
     <diagnostics diagnosticType="ERROR" message="Maximum specified flow latency total 16.0ms exceeds expected maximum end to end latency 4.00ms">
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/required_vb2_s1_i1_Instance.aaxl2#//@endToEndFlow.1"/>
     </diagnostics>
-    <diagnostics diagnosticType="ERROR" message="Maximum actual latency total 16.0ms exceeds expected maximum end to end latency 4.00ms">
+    <diagnostics diagnosticType="ERROR" message="Maximum actual latency total 24.0ms exceeds expected maximum end to end latency 4.00ms">
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/required_vb2_s1_i1_Instance.aaxl2#//@endToEndFlow.1"/>
     </diagnostics>
     <diagnostics diagnosticType="WARNING" message="Jitter of specified latency total 12.0..16.0ms exceeds expected end to end latency jitter 2.00..4.00ms">
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/required_vb2_s1_i1_Instance.aaxl2#//@endToEndFlow.1"/>
     </diagnostics>
-    <diagnostics diagnosticType="WARNING" message="Jitter of actual latency total 12.0..16.0ms exceeds expected end to end latency jitter 2.00..4.00ms">
+    <diagnostics diagnosticType="WARNING" message="Jitter of actual latency total 12.0..24.0ms exceeds expected end to end latency jitter 2.00..4.00ms">
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/required_vb2_s1_i1_Instance.aaxl2#//@endToEndFlow.1"/>
     </diagnostics>
     <subResults>
@@ -133,7 +133,7 @@
       </subResults>
       <subResults>
         <values xsi:type="result:RealValue"/>
-        <values xsi:type="result:RealValue"/>
+        <values xsi:type="result:RealValue" value="8.0"/>
         <values xsi:type="result:RealValue"/>
         <values xsi:type="result:RealValue"/>
         <values xsi:type="result:StringValue" value="queued"/>
@@ -168,7 +168,7 @@
   <results message="Latency results for etef3" resultType="FAILURE">
     <values xsi:type="result:StringValue" value=""/>
     <values xsi:type="result:RealValue" value="17.0"/>
-    <values xsi:type="result:RealValue" value="22.0"/>
+    <values xsi:type="result:RealValue" value="30.0"/>
     <values xsi:type="result:RealValue" value="17.0"/>
     <values xsi:type="result:RealValue" value="22.0"/>
     <values xsi:type="result:RealValue" value="2.0"/>
@@ -182,13 +182,13 @@
     <diagnostics diagnosticType="ERROR" message="Maximum specified flow latency total 22.0ms exceeds expected maximum end to end latency 4.00ms">
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/required_vb2_s1_i1_Instance.aaxl2#//@endToEndFlow.2"/>
     </diagnostics>
-    <diagnostics diagnosticType="ERROR" message="Maximum actual latency total 22.0ms exceeds expected maximum end to end latency 4.00ms">
+    <diagnostics diagnosticType="ERROR" message="Maximum actual latency total 30.0ms exceeds expected maximum end to end latency 4.00ms">
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/required_vb2_s1_i1_Instance.aaxl2#//@endToEndFlow.2"/>
     </diagnostics>
     <diagnostics diagnosticType="WARNING" message="Jitter of specified latency total 17.0..22.0ms exceeds expected end to end latency jitter 2.00..4.00ms">
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/required_vb2_s1_i1_Instance.aaxl2#//@endToEndFlow.2"/>
     </diagnostics>
-    <diagnostics diagnosticType="WARNING" message="Jitter of actual latency total 17.0..22.0ms exceeds expected end to end latency jitter 2.00..4.00ms">
+    <diagnostics diagnosticType="WARNING" message="Jitter of actual latency total 17.0..30.0ms exceeds expected end to end latency jitter 2.00..4.00ms">
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/required_vb2_s1_i1_Instance.aaxl2#//@endToEndFlow.2"/>
     </diagnostics>
     <subResults>
@@ -259,7 +259,7 @@
       </subResults>
       <subResults>
         <values xsi:type="result:RealValue"/>
-        <values xsi:type="result:RealValue"/>
+        <values xsi:type="result:RealValue" value="8.0"/>
         <values xsi:type="result:RealValue"/>
         <values xsi:type="result:RealValue"/>
         <values xsi:type="result:StringValue" value="queued"/>

--- a/analyses/org.osate.analysis.flows.tests/models/issue3011/.gitignore
+++ b/analyses/org.osate.analysis.flows.tests/models/issue3011/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/analyses/org.osate.analysis.flows.tests/models/issue3011/.project
+++ b/analyses/org.osate.analysis.flows.tests/models/issue3011/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3011</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/analyses/org.osate.analysis.flows.tests/models/issue3011/Issue3011.aadl
+++ b/analyses/org.osate.analysis.flows.tests/models/issue3011/Issue3011.aadl
@@ -1,0 +1,49 @@
+package Issue3011
+public
+	bus SharedBus
+		properties
+			Communication_Properties::Latency => 5 ms .. 5 ms;
+	end SharedBus;
+
+	abstract Producer
+		features
+			out1: out feature;
+			out2: out feature;
+		flows
+			source1: flow source out1;
+			source2: flow source out2;
+	end Producer;
+
+	abstract Consumer
+		features
+			in1: in feature;
+			in2: in feature;
+		flows
+			sink1: flow sink in1;
+			sink2: flow sink in2;
+	end Consumer;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			producer: abstract Producer;
+			consumer: abstract Consumer;
+			bus1: bus SharedBus;
+		connections
+			c1: feature producer.out1 -> consumer.in1 {
+				Actual_Connection_Binding => (reference (bus1));
+			};
+			c2: feature producer.out2 -> consumer.in2 {
+				Actual_Connection_Binding => (reference (bus1));
+			};
+		flows
+			f1: end to end flow producer.source1 -> c1 -> consumer.sink1 {
+				Communication_Properties::Latency => 10 ms .. 10 ms;
+			};
+			f2: end to end flow producer.source2 -> c2 -> consumer.sink2 {
+				Communication_Properties::Latency => 10 ms .. 10 ms;
+			};
+	end Top.i;
+end Issue3011;

--- a/analyses/org.osate.analysis.flows.tests/src/org/osate/analysis/flows/tests/Issue3011Test.java
+++ b/analyses/org.osate.analysis.flows.tests/src/org/osate/analysis/flows/tests/Issue3011Test.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.analysis.flows.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.SystemImplementation;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.analysis.flows.FlowLatencyAnalysisSwitch;
+import org.osate.result.AnalysisResult;
+import org.osate.result.Result;
+import org.osate.result.util.ResultUtil;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3011Test extends XtextTest {
+	private static final String PROJECT = "org.osate.analysis.flows.tests/models/issue3011/";
+
+	@Inject
+	TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	ValidationTestHelper validationHelper;
+
+	@Test
+	public void specifiedBusLatencyContributesToQueueWait() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(PROJECT + "Issue3011.aadl");
+		validationHelper.assertNoIssues(pkg);
+
+		SystemImplementation top = (SystemImplementation) pkg.getPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(c -> c.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		SystemInstance instance = InstantiateModel.instantiate(top);
+		AnalysisResult analysis = new FlowLatencyAnalysisSwitch(instance).invoke(instance,
+				instance.getSystemOperationModes().get(0), true, true, true, true, false);
+
+		assertEquals(2, analysis.getResults().size());
+		for (Result flow : analysis.getResults()) {
+			assertEquals(flow.getModelElement().toString(), 10.0, ResultUtil.getReal(flow, 2), 0.0);
+		}
+	}
+}

--- a/analyses/org.osate.analysis.flows.tests/src/org/osate/analysis/flows/tests/RequiredVBTest.xtend
+++ b/analyses/org.osate.analysis.flows.tests/src/org/osate/analysis/flows/tests/RequiredVBTest.xtend
@@ -75,7 +75,7 @@ class RequiredVBTest extends XtextTest {
 		val target = resab.modelElement as NamedElement
 		assertEquals(target.name,"etef2")
 		assertTrue((resab.values.get(1) as RealValue).value == (12.0))
-		assertTrue((resab.values.get(2) as RealValue).value == (16.0))
+		assertTrue((resab.values.get(2) as RealValue).value == (24.0))
 		assertTrue((resab.values.get(3) as RealValue).value == (12.0))
 		assertTrue((resab.values.get(4) as RealValue).value == (16.0))
 		assertTrue((resab.values.get(5) as RealValue).value == (2.0))

--- a/analyses/org.osate.analysis.flows.ui/help/markdown/latency.md
+++ b/analyses/org.osate.analysis.flows.ui/help/markdown/latency.md
@@ -414,7 +414,7 @@ period property values with threads and devices.
 
 ### Queuing Delay in Asynchronous Communication ###
 
-As described above, when a bus is periodic (has a **Period** property association), the period is used to determine the worst-case sampling delay.  When a bus does not have a period, a sender may need to wait for other users of the bus to finish sending data on the bus before it can access it.  Analysis computes the worst-case queuing delay based on the **Transmission_Time** property of the bus and the **Data_Size** of the information that flows over the bus.  Specifically, the maximum queuing delay for a connection is the sum off all the maximum transmission times for any other connections bound to the bus.  The data sizes for the communication includes the data overhead imposed by the bus, connections, and any higher-level protocols (virtual buses) encountered.
+As described above, when a bus is periodic (has a **Period** property association), the period is used to determine the worst-case sampling delay.  When a bus does not have a period, a sender may need to wait for other users of the bus to finish sending data on the bus before it can access it.  Analysis computes the worst-case queuing delay from the maximum communication latency of each connection bound to the bus.  The communication latency is calculated from the bus **Transmission_Time** property and the **Data_Size** of the information that flows over the bus.  If no usable transmission time can be calculated, the bus **Latency** property is used as a fallback.  Specifically, the maximum queuing delay for a connection is the sum of the maximum communication latencies, including any latency fallback, for all other connections bound to the bus.  The data size for the communication includes the data overhead imposed by the bus, connections, and any higher-level protocols (virtual buses) encountered.
 
 > Buses with a period will always have a non-zero sampling delay and no queuing delay.
 >
@@ -584,9 +584,11 @@ specified by a **Data_Size** property on the virtual bus or bus. This will be
 added to the size of the application data when used in computing the 
 transmission time.
 
-If *Transmission_Time* is not present, the **Latency** property value 
-associated with the virtual bus, bus, or other component the connection is bound 
-to, is used.
+If no usable *Transmission_Time* contribution can be calculated, the
+**Latency** property value associated with the virtual bus, bus, or other
+component the connection is bound to is used as a fallback. For an asynchronous
+bus, its maximum fallback latency also represents how long the connection can
+occupy the bus when the analysis calculates other connections' queuing delays.
 
 If neither *Transmission_Time* nor *Latency* property is specified for the bus 
 or virtual bus then no latency contribution is assumed. 

--- a/analyses/org.osate.analysis.flows/src/org/osate/analysis/flows/FlowLatencyAnalysisSwitch.java
+++ b/analyses/org.osate.analysis.flows/src/org/osate/analysis/flows/FlowLatencyAnalysisSwitch.java
@@ -702,7 +702,7 @@ public class FlowLatencyAnalysisSwitch extends AadlProcessingSwitchWithProgress 
 				if (targetMedium instanceof ComponentInstance) {
 					computedMaxTransmissionLatencies.put(
 							new Pair<>((ComponentInstance) targetMedium, onBehalfOfConnection),
-							busTransferTime.getMaximum());
+							busLatency.getMaximum());
 				}
 			} else {
 				// XXX: [Code Coverage] Only executable if maxBusTransferTime or maxBusLatency is negative.


### PR DESCRIPTION
## Summary

Fix asynchronous bus queue accounting when communication latency falls back from `Transmission_Time` to `Latency`. The analysis now records the selected bus latency maximum for competing-connection wait calculations instead of recording the zero transfer-time value.

Clarify in the flow-latency help that `Latency` is the fallback when no usable `Transmission_Time` contribution can be calculated and that its maximum participates in asynchronous queue waits. Existing required-virtual-bus expectations are updated to include the corrected wait.

Fixes #3011

## Regression

`Issue3011.aadl` defines two connections bound to one asynchronous bus with `Latency => 5 ms .. 5 ms` and no `Transmission_Time`. `Issue3011Test` validates the model and asserts that each flow maximum is 10 ms: 5 ms for its own transfer plus 5 ms waiting for the competing connection.

Before the fix, the regression executed one test and failed with an actual maximum of 5 ms. After the fix, it reports 10 ms and passes.

## Validation

All Maven commands ran offline with `-o`.

- Focused regression:
  `mvn -o -s releng/osate.releng/settings.xml -Plocal -pl :org.osate.analysis.flows,:org.osate.analysis.flows.tests,:org.osate.analysis.flows.ui,:org.osate.plugins.feature -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -Dtest=Issue3011Test -DfailIfNoTests=false clean install`
  Result: 1 test, 0 failures, BUILD SUCCESS.
- Related characterizations used the same focused reactor with `-Dtest=QueuingTest`, `TransmissionTimeTest`, `RequiredVBTest`, and `FlowLatencyCodeCoverageTest` in separate runs.
  Results: 1, 1, 1, and 4 tests respectively; all passed.
- Clean root reactor:
  `mvn -o -s releng/osate.releng/settings.xml -Plocal -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -DfailIfNoTests=false clean install`
  Result: all 137 modules passed in 4:47, BUILD SUCCESS.

## Dependencies

None. The branch is rebased directly onto current `master` at `a5632651a9`.

## Residual risk

The production change is limited to maximum asynchronous queue accounting when the specified bus latency fallback is selected. The normal `Transmission_Time` path is unchanged, covered by its existing test, and the complete reactor passes.