### PR TITLE
Isolate asynchronous bus queueing by mode 🤖

### DIFF
--- a/analyses/org.osate.analysis.flows.tests/models/issue3012/.gitignore
+++ b/analyses/org.osate.analysis.flows.tests/models/issue3012/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/analyses/org.osate.analysis.flows.tests/models/issue3012/.project
+++ b/analyses/org.osate.analysis.flows.tests/models/issue3012/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3012</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/analyses/org.osate.analysis.flows.tests/models/issue3012/Issue3012.aadl
+++ b/analyses/org.osate.analysis.flows.tests/models/issue3012/Issue3012.aadl
@@ -1,0 +1,52 @@
+package Issue3012
+public
+	bus SharedBus
+		properties
+			Communication_Properties::Transmission_Time => [Fixed => 5 ms .. 5 ms;];
+	end SharedBus;
+
+	abstract Producer
+		features
+			out1: out feature;
+			out2: out feature;
+		flows
+			source1: flow source out1;
+			source2: flow source out2;
+	end Producer;
+
+	abstract Consumer
+		features
+			in1: in feature;
+			in2: in feature;
+		flows
+			sink1: flow sink in1;
+			sink2: flow sink in2;
+	end Consumer;
+
+	system Top
+		modes
+			m1: initial mode;
+			m2: mode;
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			producer: abstract Producer;
+			consumer: abstract Consumer;
+			bus1: bus SharedBus;
+		connections
+			c1: feature producer.out1 -> consumer.in1 {
+				Actual_Connection_Binding => (reference (bus1));
+			} in modes (m1);
+			c2: feature producer.out2 -> consumer.in2 {
+				Actual_Connection_Binding => (reference (bus1));
+			} in modes (m2);
+		flows
+			f1: end to end flow producer.source1 -> c1 -> consumer.sink1 {
+				Communication_Properties::Latency => 5 ms .. 5 ms;
+			} in modes (m1);
+			f2: end to end flow producer.source2 -> c2 -> consumer.sink2 {
+				Communication_Properties::Latency => 5 ms .. 5 ms;
+			} in modes (m2);
+	end Top.i;
+end Issue3012;

--- a/analyses/org.osate.analysis.flows.tests/src/org/osate/analysis/flows/tests/Issue3012Test.java
+++ b/analyses/org.osate.analysis.flows.tests/src/org/osate/analysis/flows/tests/Issue3012Test.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.analysis.flows.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.SystemImplementation;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.analysis.flows.FlowLatencyAnalysisSwitch;
+import org.osate.result.AnalysisResult;
+import org.osate.result.Result;
+import org.osate.result.util.ResultUtil;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3012Test extends XtextTest {
+	private static final String FILE = "org.osate.analysis.flows.tests/models/issue3012/Issue3012.aadl";
+
+	@Inject
+	TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	ValidationTestHelper validationHelper;
+
+	@Test
+	public void busQueueingIsIsolatedBySystemOperationMode() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(FILE);
+		validationHelper.assertNoIssues(pkg);
+
+		SystemImplementation top = (SystemImplementation) pkg.getPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(c -> c.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		SystemInstance instance = InstantiateModel.instantiate(top);
+		AnalysisResult analysis = new FlowLatencyAnalysisSwitch(instance).invoke(instance, null, true, true, true, true,
+				false);
+
+		assertEquals(2, analysis.getResults().size());
+		for (Result flow : analysis.getResults()) {
+			assertEquals(flow.getModelElement().toString(), 5.0, ResultUtil.getReal(flow, 2), 0.0);
+		}
+	}
+}

--- a/analyses/org.osate.analysis.flows/src/org/osate/analysis/flows/FlowLatencyAnalysisSwitch.java
+++ b/analyses/org.osate.analysis.flows/src/org/osate/analysis/flows/FlowLatencyAnalysisSwitch.java
@@ -1048,7 +1048,7 @@ public class FlowLatencyAnalysisSwitch extends AadlProcessingSwitchWithProgress 
 		}
 
 		// Issue 1148
-		fillInQueuingTimes(si);
+		fillInQueuingTimes(si, som);
 	}
 
 	public AnalysisResult invoke(ComponentInstance ci) {
@@ -1097,24 +1097,26 @@ public class FlowLatencyAnalysisSwitch extends AadlProcessingSwitchWithProgress 
 			if (root.getSystemOperationModes().isEmpty()
 					|| root.getSystemOperationModes().get(0).getCurrentModes().isEmpty()) {
 				// no SOM
-				invokeOnSOM(ci, root.getSystemOperationModes().get(0), asynchronousSystem, majorFrameDelay,
+				final SystemOperationMode noModesSom = root.getSystemOperationModes().get(0);
+				invokeOnSOM(ci, noModesSom, asynchronousSystem, majorFrameDelay,
 						worstCaseDeadline, bestCaseEmptyQueue, disableQueuingLatency);
+				fillInQueuingTimes(root, noModesSom);
 			} else {
 				// we need to run it for every SOM
 				for (SystemOperationMode eachsom : root.getSystemOperationModes()) {
 					root.setCurrentSystemOperationMode(eachsom);
 					invokeOnSOM(ci, eachsom, asynchronousSystem, majorFrameDelay, worstCaseDeadline,
 							bestCaseEmptyQueue, disableQueuingLatency);
+					fillInQueuingTimes(root, eachsom);
 					root.clearCurrentSystemOperationMode();
 				}
 			}
 		} else {
 			invokeOnSOM(ci, som, asynchronousSystem, majorFrameDelay, worstCaseDeadline, bestCaseEmptyQueue,
 					disableQueuingLatency);
+			fillInQueuingTimes(root, som);
 		}
 
-		// Issue 1148
-		fillInQueuingTimes(ci.getSystemInstance());
 		final List<Result> finalizedResults = report.finalizeAllEntries();
 
 		return FlowLatencyUtil.recordAsAnalysisResult(finalizedResults, ci, asynchronousSystem, majorFrameDelay,
@@ -1190,15 +1192,15 @@ public class FlowLatencyAnalysisSwitch extends AadlProcessingSwitchWithProgress 
 				root.setCurrentSystemOperationMode(eachsom);
 				invokeOnSOM(etef, eachsom, asynchronousSystem, majorFrameDelay, worstCaseDeadline, bestCaseEmptyQueue,
 						disableQueuingLatency);
+				fillInQueuingTimes(root, eachsom);
 				root.clearCurrentSystemOperationMode();
 			}
 		} else {
 			invokeOnSOM(etef, som, asynchronousSystem, majorFrameDelay, worstCaseDeadline, bestCaseEmptyQueue,
 					disableQueuingLatency);
+			fillInQueuingTimes(root, som);
 		}
 
-		// Issue 1148
-		fillInQueuingTimes(etef.getSystemInstance());
 		final List<Result> finalizedResults = finalizeResults();
 
 		return FlowLatencyUtil.recordAsAnalysisResult(finalizedResults, etef, asynchronousSystem, majorFrameDelay,
@@ -1314,26 +1316,28 @@ public class FlowLatencyAnalysisSwitch extends AadlProcessingSwitchWithProgress 
 	}
 
 	private static final void sortBoundConnectionsHelper(final ComponentInstance compInstance,
-			final Map<ComponentInstance, Set<ConnectionInstance>> map) {
+			final SystemOperationMode som, final Map<ComponentInstance, Set<ConnectionInstance>> map) {
 		for (final ConnectionInstance ci : compInstance.getConnectionInstances()) {
-			final List<InstanceObject> bindings = DeploymentProperties.getActualConnectionBinding(ci)
-					.orElse(Collections.emptyList());
-			for (final InstanceObject io : bindings) {
-				final ComponentInstance componentInstance = (ComponentInstance) io;
-				addToHashedSet(map, componentInstance, ci);
-				processComponentBindings(map, ci, componentInstance);
+			if (ci.isActive(som)) {
+				final List<InstanceObject> bindings = DeploymentProperties.getActualConnectionBinding(ci)
+						.orElse(Collections.emptyList());
+				for (final InstanceObject io : bindings) {
+					final ComponentInstance componentInstance = (ComponentInstance) io;
+					addToHashedSet(map, componentInstance, ci);
+					processComponentBindings(map, ci, componentInstance);
+				}
 			}
 		}
 
 		for (final ComponentInstance child : compInstance.getComponentInstances()) {
-			sortBoundConnectionsHelper(child, map);
+			sortBoundConnectionsHelper(child, som, map);
 		}
 	}
 
 	private static final Map<ComponentInstance, Set<ConnectionInstance>> sortBoundConnections(
-			final SystemInstance system) {
+			final SystemInstance system, final SystemOperationMode som) {
 		final Map<ComponentInstance, Set<ConnectionInstance>> map = new HashMap<>();
-		sortBoundConnectionsHelper(system, map);
+		sortBoundConnectionsHelper(system, som, map);
 		return map;
 	}
 
@@ -1408,11 +1412,11 @@ public class FlowLatencyAnalysisSwitch extends AadlProcessingSwitchWithProgress 
 		}
 	}
 
-	private void fillInQueuingTimes(final SystemInstance system) {
+	private void fillInQueuingTimes(final SystemInstance system, final SystemOperationMode som) {
 		// Nothing to do if there are no asynchronous buses
 		if (!asyncBuses.isEmpty()) {
 			// Get all the connections bound to a bus and group them together by the bus they are bound to
-			final Map<ComponentInstance, Set<ConnectionInstance>> sortedConnections = sortBoundConnections(system);
+			final Map<ComponentInstance, Set<ConnectionInstance>> sortedConnections = sortBoundConnections(system, som);
 			/*
 			 * Go through the list of all the asynchronous buses
 			 */
@@ -1477,6 +1481,12 @@ public class FlowLatencyAnalysisSwitch extends AadlProcessingSwitchWithProgress 
 				}
 			}
 		}
+
+		busOrder.clear();
+		nextBusId = 0;
+		asyncBuses.clear();
+		connectionsToContributors.clear();
+		computedMaxTransmissionLatencies.clear();
 	}
 
 	// *****************************


### PR DESCRIPTION
## Summary

Fixes #3012

Asynchronous bus queue bookkeeping was shared across system operation mode passes, and queue calculation grouped inactive connections with active bus users. The analysis now finalizes queue delays for each SOM, filters bound connections by activity in that SOM, and clears queue state before the next mode.

## Regression

The standalone `issue3012` AADL project models two mutually exclusive connections and end-to-end flows bound to one asynchronous bus with a fixed 5 ms transmission time. `Issue3012Test` validates the model and asserts that both mode-specific flows have a 5 ms maximum instead of the contaminated 10 ms result.

The model project ignores both `/.aadlbin-gen/` and `/instances/` generated directories.

## Validation

- Focused offline regression before the production fix: 1 test run, expected failure (`5.0` expected, `10.0` observed).
- Focused offline regression after the fix: 1 test run, 0 failures.
- Complete offline `org.osate.analysis.flows.tests` bundle: 36 tests run, 0 failures.
- Clean offline root reactor with `-Dtycho.localArtifacts=ignore`: all 137 modules passed in 4:50.

## Dependencies and risk

This branch is rebased directly on `master` and has no pull request dependency. Residual risk is limited to callers that analyze a component or single end-to-end flow across multiple SOMs; those paths now finalize queues at the same per-SOM boundary already used by whole-system analysis, and the complete flow-analysis and root test suites pass.