### PR TITLE
Count nested required virtual bus overhead once 🤖

### DIFF
--- a/analyses/org.osate.analysis.flows.tests/models/issue3013/.gitignore
+++ b/analyses/org.osate.analysis.flows.tests/models/issue3013/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/analyses/org.osate.analysis.flows.tests/models/issue3013/.project
+++ b/analyses/org.osate.analysis.flows.tests/models/issue3013/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3013</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/analyses/org.osate.analysis.flows.tests/models/issue3013/Issue3013.aadl
+++ b/analyses/org.osate.analysis.flows.tests/models/issue3013/Issue3013.aadl
@@ -1,0 +1,57 @@
+package Issue3013
+public
+	data D
+		properties
+			Data_Size => 100 Bytes;
+	end D;
+
+	virtual bus Inner
+		properties
+			Data_Size => 20 Bytes;
+	end Inner;
+
+	virtual bus Outer
+		properties
+			Data_Size => 10 Bytes;
+			Required_Virtual_Bus_Class => (classifier (Inner));
+	end Outer;
+
+	bus PhysicalBus
+		properties
+			Communication_Properties::Transmission_Time =>
+				[Fixed => 0 ms .. 0 ms; PerByte => 1 ms .. 1 ms;];
+	end PhysicalBus;
+
+	abstract Producer
+		features
+			outgoing: out data port D;
+		flows
+			source1: flow source outgoing;
+	end Producer;
+
+	abstract Consumer
+		features
+			incoming: in data port D;
+		flows
+			sink1: flow sink incoming;
+	end Consumer;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			producer: abstract Producer;
+			consumer: abstract Consumer;
+			bus1: bus PhysicalBus;
+		connections
+			c1: port producer.outgoing -> consumer.incoming {
+				Required_Virtual_Bus_Class => (classifier (Outer));
+				Actual_Connection_Binding => (reference (bus1));
+			};
+		flows
+			f1: end to end flow producer.source1 -> c1 -> consumer.sink1 {
+				Communication_Properties::Latency => 130 ms .. 130 ms;
+			};
+	end Top.i;
+end Issue3013;

--- a/analyses/org.osate.analysis.flows.tests/src/org/osate/analysis/flows/tests/Issue3013Test.java
+++ b/analyses/org.osate.analysis.flows.tests/src/org/osate/analysis/flows/tests/Issue3013Test.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.analysis.flows.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.SystemImplementation;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.analysis.flows.FlowLatencyAnalysisSwitch;
+import org.osate.result.Result;
+import org.osate.result.util.ResultUtil;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3013Test extends XtextTest {
+	private static final String FILE = "org.osate.analysis.flows.tests/models/issue3013/Issue3013.aadl";
+
+	@Inject
+	TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	ValidationTestHelper validationHelper;
+
+	@Test
+	public void nestedRequiredProtocolOverheadIsCountedOnce() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(FILE);
+		validationHelper.assertNoIssues(pkg);
+
+		SystemImplementation top = (SystemImplementation) pkg.getPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(c -> c.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		SystemInstance instance = InstantiateModel.instantiate(top);
+		Result flow = new FlowLatencyAnalysisSwitch(instance)
+				.invoke(instance, instance.getSystemOperationModes().get(0), true, true, true, true, false)
+				.getResults()
+				.get(0);
+
+		assertEquals(130.0, ResultUtil.getReal(flow, 2), 0.0);
+	}
+}

--- a/analyses/org.osate.analysis.flows/src/org/osate/analysis/flows/FlowLatencyAnalysisSwitch.java
+++ b/analyses/org.osate.analysis.flows/src/org/osate/analysis/flows/FlowLatencyAnalysisSwitch.java
@@ -804,7 +804,9 @@ public class FlowLatencyAnalysisSwitch extends AadlProcessingSwitchWithProgress 
 			List<Classifier> reqprotocols = DeploymentProperties.getRequiredVirtualBusClass(cc)
 					.orElse(Collections.emptyList());
 			if (!reqprotocols.isEmpty()) {
-				total = total + computeTotalDataSize(reqprotocols, wrapped, latencyContributor, onBehalfOfConnection);
+				double nestedTotal = computeTotalDataSize(reqprotocols, wrapped, latencyContributor,
+						onBehalfOfConnection);
+				total = total + nestedTotal - wrapped;
 			}
 		}
 		return total;


### PR DESCRIPTION
## Summary

Fixes #3013

Nested Required_Virtual_Bus_Class recursion returned both the already wrapped payload and the nested protocol overhead. The caller then added that full value to its own total, causing the payload to be counted again at every recursive level.

This change subtracts the recursive input size before adding the nested result, so only incremental nested overhead is accumulated while each protocol still receives its correctly wrapped size for transmission-time reporting.

## Regression

Issue3013Test loads a standalone AADL project with a 100-byte payload, a 10-byte outer protocol, and a 20-byte inner protocol on a one-millisecond-per-byte physical bus. It validates the model and asserts a 130 ms maximum latency; the test failed at 240 ms before the fix and passes at 130 ms afterward.

The fixture project ignores both /.aadlbin-gen/ and /instances/.

## Validation

- Focused offline test: 1 test run, 0 failures, 0 errors, 0 skipped.
- Complete offline org.osate.analysis.flows.tests bundle: 36 tests run, 0 failures, 0 errors, 0 skipped.
- Clean offline root-reactor Maven install with tycho.localArtifacts=ignore: BUILD SUCCESS across 137 modules in 4:50.
- git diff --check: clean.

## Dependencies

None. The branch is rebased directly onto current master at a5632651a9.

## Residual risk

Low. The production change is limited to excluding the recursive input payload from the parent protocol total; related flow-analysis tests and the full reactor pass.