### PR TITLE
Include nested required virtual bus sampling latency 🤖

### DIFF
--- a/analyses/org.osate.analysis.flows.tests/models/issue3014/.gitignore
+++ b/analyses/org.osate.analysis.flows.tests/models/issue3014/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/analyses/org.osate.analysis.flows.tests/models/issue3014/.project
+++ b/analyses/org.osate.analysis.flows.tests/models/issue3014/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3014</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/analyses/org.osate.analysis.flows.tests/models/issue3014/Issue3014.aadl
+++ b/analyses/org.osate.analysis.flows.tests/models/issue3014/Issue3014.aadl
@@ -1,0 +1,43 @@
+package Issue3014
+public
+	virtual bus Inner
+		properties
+			Period => 10 ms;
+	end Inner;
+
+	virtual bus Outer
+		properties
+			Required_Virtual_Bus_Class => (classifier (Inner));
+	end Outer;
+
+	abstract Producer
+		features
+			outgoing: out feature;
+		flows
+			source1: flow source outgoing;
+	end Producer;
+
+	abstract Consumer
+		features
+			incoming: in feature;
+		flows
+			sink1: flow sink incoming;
+	end Consumer;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			producer: abstract Producer;
+			consumer: abstract Consumer;
+		connections
+			c1: feature producer.outgoing -> consumer.incoming {
+				Required_Virtual_Bus_Class => (classifier (Outer));
+			};
+		flows
+			f1: end to end flow producer.source1 -> c1 -> consumer.sink1 {
+				Communication_Properties::Latency => 10 ms .. 10 ms;
+			};
+	end Top.i;
+end Issue3014;

--- a/analyses/org.osate.analysis.flows.tests/src/org/osate/analysis/flows/tests/Issue3014Test.java
+++ b/analyses/org.osate.analysis.flows.tests/src/org/osate/analysis/flows/tests/Issue3014Test.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.analysis.flows.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.SystemImplementation;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.analysis.flows.FlowLatencyAnalysisSwitch;
+import org.osate.result.Result;
+import org.osate.result.util.ResultUtil;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3014Test extends XtextTest {
+	private static final String FILE = "org.osate.analysis.flows.tests/models/issue3014/Issue3014.aadl";
+
+	@Inject
+	TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	ValidationTestHelper validationHelper;
+
+	@Test
+	public void nestedRequiredProtocolSamplingIsIncluded() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(FILE);
+		validationHelper.assertNoIssues(pkg);
+
+		SystemImplementation top = (SystemImplementation) pkg.getPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(c -> c.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		SystemInstance instance = InstantiateModel.instantiate(top);
+		Result flow = new FlowLatencyAnalysisSwitch(instance)
+				.invoke(instance, instance.getSystemOperationModes().get(0), true, true, true, true, false)
+				.getResults()
+				.get(0);
+
+		assertEquals(10.0, ResultUtil.getReal(flow, 2), 0.0);
+	}
+}

--- a/analyses/org.osate.analysis.flows/src/org/osate/analysis/flows/FlowLatencyAnalysisSwitch.java
+++ b/analyses/org.osate.analysis.flows/src/org/osate/analysis/flows/FlowLatencyAnalysisSwitch.java
@@ -829,9 +829,10 @@ public class FlowLatencyAnalysisSwitch extends AadlProcessingSwitchWithProgress 
 			final LatencyContributor latencyContributor, final ConnectionInstance onBehalfOfConnection) {
 		boolean willDoVirtualBuses = false;
 		boolean willDoBuses = false;
+		List<InstanceObject> bindings = Collections.emptyList();
 		if (connOrVB instanceof InstanceObject) {
 			// look for actual binding if we have a connection instance or virtual bus instance
-			List<InstanceObject> bindings = DeploymentProperties.getActualConnectionBinding(connOrVB)
+			bindings = DeploymentProperties.getActualConnectionBinding(connOrVB)
 					.orElse(Collections.emptyList());
 			for (InstanceObject componentInstance : bindings) {
 				if (((ComponentInstance) componentInstance).getCategory().equals(ComponentCategory.VIRTUAL_BUS)) {
@@ -840,35 +841,33 @@ public class FlowLatencyAnalysisSwitch extends AadlProcessingSwitchWithProgress 
 					willDoBuses = true;
 				}
 			}
-			/**
-			 * required virtual bus class indicates protocols the connection intends to use.
-			 * We also can have an actual connection binding to a virtual bus
-			 * If we have that we want to use that virtual bus overhead
-			 */
-			if (!willDoVirtualBuses) {
-				List<Classifier> protocols = DeploymentProperties.getRequiredVirtualBusClass(connOrVB)
-						.orElse(Collections.emptyList());
-				// XXX: [Code Coverage] protocols cannot be null.
-				if ((protocols != null) && (protocols.size() > 0)) {
-					if (willDoBuses) {
-						latencyContributor.reportInfo("Adding required virtual bus contributions to bound bus");
-					}
-					for (Classifier cc : protocols) {
-						processSamplingAndQueuingTimes(cc, null, latencyContributor);
-						processActualConnectionBindingsSampling(cc, latencyContributor, onBehalfOfConnection);
-					}
+		}
+		/**
+		 * required virtual bus class indicates protocols the connection intends to use.
+		 * We also can have an actual connection binding to a virtual bus
+		 * If we have that we want to use that virtual bus overhead
+		 */
+		if (!willDoVirtualBuses) {
+			List<Classifier> protocols = DeploymentProperties.getRequiredVirtualBusClass(connOrVB)
+					.orElse(Collections.emptyList());
+			// XXX: [Code Coverage] protocols cannot be null.
+			if ((protocols != null) && (protocols.size() > 0)) {
+				if (willDoBuses) {
+					latencyContributor.reportInfo("Adding required virtual bus contributions to bound bus");
 				}
-			}
-
-			for (InstanceObject componentInstance : bindings) {
-				processSamplingAndQueuingTimes(componentInstance, onBehalfOfConnection, latencyContributor);
-				if (((ComponentInstance) componentInstance).getCategory().equals(ComponentCategory.VIRTUAL_BUS)) {
-					processActualConnectionBindingsSampling(componentInstance, latencyContributor,
-							onBehalfOfConnection);
+				for (Classifier cc : protocols) {
+					processSamplingAndQueuingTimes(cc, null, latencyContributor);
+					processActualConnectionBindingsSampling(cc, latencyContributor, onBehalfOfConnection);
 				}
 			}
 		}
 
+		for (InstanceObject componentInstance : bindings) {
+			processSamplingAndQueuingTimes(componentInstance, onBehalfOfConnection, latencyContributor);
+			if (((ComponentInstance) componentInstance).getCategory().equals(ComponentCategory.VIRTUAL_BUS)) {
+				processActualConnectionBindingsSampling(componentInstance, latencyContributor, onBehalfOfConnection);
+			}
+		}
 	}
 
 	private final static Set<ComponentCategory> hasPeriod = EnumSet.of(ComponentCategory.THREAD,


### PR DESCRIPTION
Fixes #3014

## Cause and correction

Required virtual bus sampling traversal was contained inside the InstanceObject guard in FlowLatencyAnalysisSwitch.processActualConnectionBindingsSampling. The first required classifier was processed, but recursion stopped as soon as the current element was a classifier rather than an instance.

Move required-class traversal outside the instance-only binding lookup. Nested required virtual bus classifiers now contribute their sampling and queuing times, while actual connection bindings remain limited to instance objects.

## Regression

Add a standalone issue3014 AADL project where a connection requires an outer virtual bus and that classifier requires an inner virtual bus with a 10 ms period. Issue3014Test validates the model, instantiates Top.i, runs asynchronous flow latency analysis, and asserts a 10 ms maximum latency. The model project ignores both /.aadlbin-gen/ and /instances/.

## Validation

All Maven commands ran offline.

- Focused Issue3014Test: 1 test, 0 failures, 0 errors
- Related Issue3013Test: 1 test, 0 failures, 0 errors
- Complete org.osate.analysis.flows.tests bundle: 39 tests, 0 failures, 0 errors
- Clean root reactor with -Dtycho.localArtifacts=ignore: 137 modules succeeded

Focused command:

    mvn -o -s releng/osate.releng/settings.xml -Plocal -pl :org.osate.analysis.flows,:org.osate.analysis.flows.tests,:org.osate.plugins.feature -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -Dtest=Issue3014Test -DfailIfNoTests=false clean install

Root command:

    mvn -o -s releng/osate.releng/settings.xml -Plocal -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -DfailIfNoTests=false clean install

## Dependencies and risk

No unmerged PR dependencies; the branch is rebased onto master. Residual risk is low because the change reuses the existing recursive required-class traversal and leaves actual-binding lookup instance-only.