### PR TITLE
Include direct connection latency in specified totals 🤖

### DIFF
--- a/analyses/org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/results/testFlowLatency/connect_to_subcomponent.result
+++ b/analyses/org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/results/testFlowLatency/connect_to_subcomponent.result
@@ -10,13 +10,10 @@
     <values xsi:type="result:StringValue" value=""/>
     <values xsi:type="result:RealValue" value="4.0"/>
     <values xsi:type="result:RealValue" value="8.0"/>
-    <values xsi:type="result:RealValue" value="2.0"/>
-    <values xsi:type="result:RealValue" value="4.0"/>
     <values xsi:type="result:RealValue" value="4.0"/>
     <values xsi:type="result:RealValue" value="8.0"/>
-    <diagnostics diagnosticType="WARNING" message="Minimum specified flow latency total 2.00ms less than expected minimum end to end latency 4.00ms (better response time)">
-      <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/connect_to_subcomponent_s1_i1_Instance.aaxl2#//@componentInstance.1/@endToEndFlow.0"/>
-    </diagnostics>
+    <values xsi:type="result:RealValue" value="4.0"/>
+    <values xsi:type="result:RealValue" value="8.0"/>
     <diagnostics diagnosticType="INFO" message="Minimum actual latency total 4.00ms is greater or equal to expected minimum end to end latency 4.00ms">
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/connect_to_subcomponent_s1_i1_Instance.aaxl2#//@componentInstance.1/@endToEndFlow.0"/>
     </diagnostics>
@@ -41,12 +38,6 @@
       <values xsi:type="result:StringValue" value="specified"/>
       <values xsi:type="result:StringValue" value="specified"/>
       <values xsi:type="result:StringValue" value=""/>
-      <diagnostics diagnosticType="INFO" message="Using specified min protocol latency subtotal 0.0 although specified connection latency 1.0 is greater">
-        <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/connect_to_subcomponent_s1_i1_Instance.aaxl2#//@connectionInstance.1"/>
-      </diagnostics>
-      <diagnostics diagnosticType="INFO" message="Using max specified protocol latency subtotal 0.0 although specified connection latency 2.0 is greater">
-        <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/connect_to_subcomponent_s1_i1_Instance.aaxl2#//@connectionInstance.1"/>
-      </diagnostics>
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/connect_to_subcomponent_s1_i1_Instance.aaxl2#//@connectionInstance.1"/>
     </subResults>
     <subResults>
@@ -67,12 +58,6 @@
       <values xsi:type="result:StringValue" value="specified"/>
       <values xsi:type="result:StringValue" value="specified"/>
       <values xsi:type="result:StringValue" value=""/>
-      <diagnostics diagnosticType="INFO" message="Using specified min protocol latency subtotal 0.0 although specified connection latency 1.0 is greater">
-        <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/connect_to_subcomponent_s1_i1_Instance.aaxl2#//@connectionInstance.0"/>
-      </diagnostics>
-      <diagnostics diagnosticType="INFO" message="Using max specified protocol latency subtotal 0.0 although specified connection latency 2.0 is greater">
-        <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/connect_to_subcomponent_s1_i1_Instance.aaxl2#//@connectionInstance.0"/>
-      </diagnostics>
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/connect_to_subcomponent_s1_i1_Instance.aaxl2#//@connectionInstance.0"/>
     </subResults>
     <subResults>

--- a/analyses/org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/results/testFlowLatency/latency.result
+++ b/analyses/org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/results/testFlowLatency/latency.result
@@ -10,13 +10,10 @@
     <values xsi:type="result:StringValue" value=""/>
     <values xsi:type="result:RealValue" value="3.0"/>
     <values xsi:type="result:RealValue" value="6.0"/>
-    <values xsi:type="result:RealValue" value="2.0"/>
-    <values xsi:type="result:RealValue" value="4.0"/>
     <values xsi:type="result:RealValue" value="3.0"/>
     <values xsi:type="result:RealValue" value="6.0"/>
-    <diagnostics diagnosticType="WARNING" message="Minimum specified flow latency total 2.00ms less than expected minimum end to end latency 3.00ms (better response time)">
-      <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/latency_s1_i1_Instance.aaxl2#//@endToEndFlow.0"/>
-    </diagnostics>
+    <values xsi:type="result:RealValue" value="3.0"/>
+    <values xsi:type="result:RealValue" value="6.0"/>
     <diagnostics diagnosticType="INFO" message="Minimum actual latency total 3.00ms is greater or equal to expected minimum end to end latency 3.00ms">
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/latency_s1_i1_Instance.aaxl2#//@endToEndFlow.0"/>
     </diagnostics>
@@ -41,12 +38,6 @@
       <values xsi:type="result:StringValue" value="specified"/>
       <values xsi:type="result:StringValue" value="specified"/>
       <values xsi:type="result:StringValue" value=""/>
-      <diagnostics diagnosticType="INFO" message="Using specified min protocol latency subtotal 0.0 although specified connection latency 1.0 is greater">
-        <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/latency_s1_i1_Instance.aaxl2#//@connectionInstance.0"/>
-      </diagnostics>
-      <diagnostics diagnosticType="INFO" message="Using max specified protocol latency subtotal 0.0 although specified connection latency 2.0 is greater">
-        <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/latency_s1_i1_Instance.aaxl2#//@connectionInstance.0"/>
-      </diagnostics>
       <subResults>
         <values xsi:type="result:RealValue"/>
         <values xsi:type="result:RealValue"/>

--- a/analyses/org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/results/testFlowLatency/transmission_time1.result
+++ b/analyses/org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/results/testFlowLatency/transmission_time1.result
@@ -10,20 +10,20 @@
     <values xsi:type="result:StringValue" value=""/>
     <values xsi:type="result:RealValue" value="3.0"/>
     <values xsi:type="result:RealValue" value="6.0"/>
-    <values xsi:type="result:RealValue" value="2.0"/>
-    <values xsi:type="result:RealValue" value="4.0"/>
+    <values xsi:type="result:RealValue" value="3.0"/>
+    <values xsi:type="result:RealValue" value="6.0"/>
     <values xsi:type="result:RealValue" value="3.0"/>
     <values xsi:type="result:RealValue" value="4.0"/>
-    <diagnostics diagnosticType="WARNING" message="Minimum specified flow latency total 2.00ms less than expected minimum end to end latency 3.00ms (better response time)">
+    <diagnostics diagnosticType="INFO" message="Minimum actual latency total 3.00ms is greater or equal to expected minimum end to end latency 3.00ms">
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/transmission_time1_s1_i1_Instance.aaxl2#/0/@endToEndFlow.0"/>
     </diagnostics>
-    <diagnostics diagnosticType="INFO" message="Minimum actual latency total 3.00ms is greater or equal to expected minimum end to end latency 3.00ms">
+    <diagnostics diagnosticType="ERROR" message="Maximum specified flow latency total 6.00ms exceeds expected maximum end to end latency 4.00ms">
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/transmission_time1_s1_i1_Instance.aaxl2#/0/@endToEndFlow.0"/>
     </diagnostics>
     <diagnostics diagnosticType="ERROR" message="Maximum actual latency total 6.00ms exceeds expected maximum end to end latency 4.00ms">
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/transmission_time1_s1_i1_Instance.aaxl2#/0/@endToEndFlow.0"/>
     </diagnostics>
-    <diagnostics diagnosticType="WARNING" message="Jitter of specified latency total 2.00..4.00ms exceeds expected end to end latency jitter 3.00..4.00ms">
+    <diagnostics diagnosticType="WARNING" message="Jitter of specified latency total 3.00..6.00ms exceeds expected end to end latency jitter 3.00..4.00ms">
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/transmission_time1_s1_i1_Instance.aaxl2#/0/@endToEndFlow.0"/>
     </diagnostics>
     <diagnostics diagnosticType="WARNING" message="Jitter of actual latency total 3.00..6.00ms exceeds expected end to end latency jitter 3.00..4.00ms">
@@ -47,12 +47,6 @@
       <values xsi:type="result:StringValue" value="specified"/>
       <values xsi:type="result:StringValue" value="specified"/>
       <values xsi:type="result:StringValue" value=""/>
-      <diagnostics diagnosticType="INFO" message="Using specified min protocol latency subtotal 0.0 although specified connection latency 1.0 is greater">
-        <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/transmission_time1_s1_i1_Instance.aaxl2#/0/@connectionInstance.0"/>
-      </diagnostics>
-      <diagnostics diagnosticType="INFO" message="Using max specified protocol latency subtotal 0.0 although specified connection latency 2.0 is greater">
-        <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/transmission_time1_s1_i1_Instance.aaxl2#/0/@connectionInstance.0"/>
-      </diagnostics>
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/transmission_time1_s1_i1_Instance.aaxl2#/0/@connectionInstance.0"/>
     </subResults>
     <subResults>

--- a/analyses/org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/results/testFlowLatency/transmission_time2.result
+++ b/analyses/org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/results/testFlowLatency/transmission_time2.result
@@ -10,20 +10,20 @@
     <values xsi:type="result:StringValue" value=""/>
     <values xsi:type="result:RealValue" value="3.0"/>
     <values xsi:type="result:RealValue" value="6.0"/>
-    <values xsi:type="result:RealValue" value="2.0"/>
-    <values xsi:type="result:RealValue" value="4.0"/>
+    <values xsi:type="result:RealValue" value="3.0"/>
+    <values xsi:type="result:RealValue" value="6.0"/>
     <values xsi:type="result:RealValue" value="3.0"/>
     <values xsi:type="result:RealValue" value="4.0"/>
-    <diagnostics diagnosticType="WARNING" message="Minimum specified flow latency total 2.00ms less than expected minimum end to end latency 3.00ms (better response time)">
+    <diagnostics diagnosticType="INFO" message="Minimum actual latency total 3.00ms is greater or equal to expected minimum end to end latency 3.00ms">
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/transmission_time2_s1_i1_Instance.aaxl2#/0/@endToEndFlow.0"/>
     </diagnostics>
-    <diagnostics diagnosticType="INFO" message="Minimum actual latency total 3.00ms is greater or equal to expected minimum end to end latency 3.00ms">
+    <diagnostics diagnosticType="ERROR" message="Maximum specified flow latency total 6.00ms exceeds expected maximum end to end latency 4.00ms">
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/transmission_time2_s1_i1_Instance.aaxl2#/0/@endToEndFlow.0"/>
     </diagnostics>
     <diagnostics diagnosticType="ERROR" message="Maximum actual latency total 6.00ms exceeds expected maximum end to end latency 4.00ms">
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/transmission_time2_s1_i1_Instance.aaxl2#/0/@endToEndFlow.0"/>
     </diagnostics>
-    <diagnostics diagnosticType="WARNING" message="Jitter of specified latency total 2.00..4.00ms exceeds expected end to end latency jitter 3.00..4.00ms">
+    <diagnostics diagnosticType="WARNING" message="Jitter of specified latency total 3.00..6.00ms exceeds expected end to end latency jitter 3.00..4.00ms">
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/transmission_time2_s1_i1_Instance.aaxl2#/0/@endToEndFlow.0"/>
     </diagnostics>
     <diagnostics diagnosticType="WARNING" message="Jitter of actual latency total 3.00..6.00ms exceeds expected end to end latency jitter 3.00..4.00ms">
@@ -47,12 +47,6 @@
       <values xsi:type="result:StringValue" value="specified"/>
       <values xsi:type="result:StringValue" value="specified"/>
       <values xsi:type="result:StringValue" value=""/>
-      <diagnostics diagnosticType="INFO" message="Using specified min protocol latency subtotal 0.0 although specified connection latency 1.0 is greater">
-        <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/transmission_time2_s1_i1_Instance.aaxl2#/0/@connectionInstance.0"/>
-      </diagnostics>
-      <diagnostics diagnosticType="INFO" message="Using max specified protocol latency subtotal 0.0 although specified connection latency 2.0 is greater">
-        <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/transmission_time2_s1_i1_Instance.aaxl2#/0/@connectionInstance.0"/>
-      </diagnostics>
       <modelElement href="org.osate.analysis.flows.tests/models/FlowLatencyCodeCoverage/instances/transmission_time2_s1_i1_Instance.aaxl2#/0/@connectionInstance.0"/>
     </subResults>
     <subResults>

--- a/analyses/org.osate.analysis.flows.tests/models/issue3015/.gitignore
+++ b/analyses/org.osate.analysis.flows.tests/models/issue3015/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/analyses/org.osate.analysis.flows.tests/models/issue3015/.project
+++ b/analyses/org.osate.analysis.flows.tests/models/issue3015/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3015</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/analyses/org.osate.analysis.flows.tests/models/issue3015/Issue3015.aadl
+++ b/analyses/org.osate.analysis.flows.tests/models/issue3015/Issue3015.aadl
@@ -1,0 +1,33 @@
+package Issue3015
+public
+	abstract Producer
+		features
+			outgoing: out feature;
+		flows
+			source1: flow source outgoing;
+	end Producer;
+
+	abstract Consumer
+		features
+			incoming: in feature;
+		flows
+			sink1: flow sink incoming;
+	end Consumer;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			producer: abstract Producer;
+			consumer: abstract Consumer;
+		connections
+			c1: feature producer.outgoing -> consumer.incoming {
+				Communication_Properties::Latency => 5 ms .. 7 ms;
+			};
+		flows
+			f1: end to end flow producer.source1 -> c1 -> consumer.sink1 {
+				Communication_Properties::Latency => 5 ms .. 7 ms;
+			};
+	end Top.i;
+end Issue3015;

--- a/analyses/org.osate.analysis.flows.tests/src/org/osate/analysis/flows/tests/Issue3015Test.java
+++ b/analyses/org.osate.analysis.flows.tests/src/org/osate/analysis/flows/tests/Issue3015Test.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.analysis.flows.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.SystemImplementation;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.analysis.flows.FlowLatencyAnalysisSwitch;
+import org.osate.result.Result;
+import org.osate.result.util.ResultUtil;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3015Test extends XtextTest {
+	private static final String FILE = "org.osate.analysis.flows.tests/models/issue3015/Issue3015.aadl";
+
+	@Inject
+	TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	ValidationTestHelper validationHelper;
+
+	@Test
+	public void directConnectionLatencyIsIncludedInSpecifiedTotal() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(FILE);
+		validationHelper.assertNoIssues(pkg);
+
+		SystemImplementation top = (SystemImplementation) pkg.getPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(c -> c.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		SystemInstance instance = InstantiateModel.instantiate(top);
+		Result flow = new FlowLatencyAnalysisSwitch(instance)
+				.invoke(instance, instance.getSystemOperationModes().get(0), true, true, true, true, false)
+				.getResults()
+				.get(0);
+
+		assertEquals(5.0, ResultUtil.getReal(flow, 1), 0.0);
+		assertEquals(7.0, ResultUtil.getReal(flow, 2), 0.0);
+		assertEquals(5.0, ResultUtil.getReal(flow, 3), 0.0);
+		assertEquals(7.0, ResultUtil.getReal(flow, 4), 0.0);
+	}
+}

--- a/analyses/org.osate.analysis.flows/src/org/osate/analysis/flows/model/LatencyContributor.java
+++ b/analyses/org.osate.analysis.flows/src/org/osate/analysis/flows/model/LatencyContributor.java
@@ -433,8 +433,11 @@ public abstract class LatencyContributor {
 			res = res + lc.getTotalMinimumSpecified();
 		}
 		if (this.relatedElement instanceof ConnectionInstance) {
-			// we compare the subtotals against own
-			if (spec > 0 && res > spec) {
+			// Use the connection latency when no protocol contributes a subtotal.
+			// Otherwise, compare the subtotal against the connection latency.
+			if (res == 0) {
+				res = spec;
+			} else if (spec > 0 && res > spec) {
 				reportWarning("specified min protocol latency subtotal " + res + " exceeds connection latency " + spec);
 			} else {
 				if (spec > 0) {
@@ -456,8 +459,11 @@ public abstract class LatencyContributor {
 			res = res + lc.getTotalMaximumSpecified();
 		}
 		if (this.relatedElement instanceof ConnectionInstance) {
-			// we compare the subtotals against own
-			if (spec > 0 && res > spec) {
+			// Use the connection latency when no protocol contributes a subtotal.
+			// Otherwise, compare the subtotal against the connection latency.
+			if (res == 0) {
+				res = spec;
+			} else if (spec > 0 && res > spec) {
 				reportWarning("specified max protocol latency subtotal " + res + " exceeds connection latency " + spec);
 			} else {
 				if (spec > 0) {


### PR DESCRIPTION
## Summary

Fixes #3015

- Use the connection `Latency` property in specified totals when connection bindings and required virtual buses contribute a zero specified subtotal.
- Preserve the existing protocol and bus subtotal comparison when those contributors provide a nonzero specified latency.
- Refresh the four existing flow-analysis golden results affected by the corrected connection budgets and diagnostics.

## Regression

`Issue3015Test` parses and validates a standalone AADL project containing a direct connection with `Latency => 5 ms .. 7 ms`. It asserts that both actual and specified minimum and maximum totals report 5 ms and 7 ms.

The model project ignores both `/.aadlbin-gen/` and `/instances/`.

## Documentation

The existing latency-analysis help already states that specified end-to-end totals include connection latency and that the connection `Latency` property is used when there is no binding or required virtual bus, or when those contributions are zero. No documentation update is needed.

## Validation

Focused regression, offline:

```text
mvn -o -s releng/osate.releng/settings.xml -Plocal -pl :org.osate.analysis.flows,:org.osate.analysis.flows.tests,:org.osate.plugins.feature -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -Dtest=Issue3015Test -DfailIfNoTests=false clean install
```

Result: `BUILD SUCCESS`; 1 test, 0 failures, 0 errors, 0 skipped.

Complete flow-analysis suite, offline:

```text
mvn -o -s releng/osate.releng/settings.xml -Plocal -pl :org.osate.analysis.flows,:org.osate.analysis.flows.tests,:org.osate.plugins.feature -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -DfailIfNoTests=false clean install
```

Result: `BUILD SUCCESS`; 40 tests, 0 failures, 0 errors, 0 skipped.

Clean root reactor, offline:

```text
mvn -o -s releng/osate.releng/settings.xml -Plocal -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -DfailIfNoTests=false clean install
```

Result: `BUILD SUCCESS`; all 137 reactor modules succeeded in 4:46.

## Dependencies

None outstanding. The branch is rebased onto `master` at `904956cc52`, which includes PR #3062.

## Residual risk

The behavioral change is limited to specified totals and their summary diagnostics when a connection has a zero binding or protocol subtotal. Connections with nonzero protocol or bus specified subtotals retain the existing behavior.
