### PR TITLE
Remove unavailable Yakindu p2 dependency 🤖

### DIFF
--- a/core/org.osate.core.feature/feature.xml
+++ b/core/org.osate.core.feature/feature.xml
@@ -67,7 +67,6 @@
       <import plugin="org.eclipse.xtext.ui.codetemplates.ui" version="2.20.0" match="compatible"/>
       <import plugin="org.eclipse.xtext.common.types.ui" version="2.20.0" match="compatible"/>
       <import plugin="org.eclipse.jdt.core" version="3.13.0" match="compatible"/>
-      <import plugin="org.yakindu.base.xtext.utils.jface" version="3.5.9" match="compatible"/>
       <import plugin="org.eclipse.equinox.common" version="3.5.0" match="compatible"/>
       <import plugin="org.apache.commons.logging" version="1.1.1" match="compatible"/>
       <import plugin="com.google.guava" version="30.1.0" match="greaterOrEqual"/>

--- a/core/org.osate.xtext.aadl2.ui/META-INF/MANIFEST.MF
+++ b/core/org.osate.xtext.aadl2.ui/META-INF/MANIFEST.MF
@@ -30,8 +30,7 @@ Require-Bundle: org.eclipse.ui.editors;bundle-version="[3.7.0,4.0.0)",
  org.eclipse.xtext.xbase.lib;bundle-version="[2.20.0,3.0.0)",
  org.eclipse.xtend.lib;bundle-version="[2.20.0,3.0.0)",
  org.osate.pluginsupport;bundle-version="[7.2.0,8.0.0)",
- org.eclipse.jdt.core;bundle-version="[3.13.0,4.0.0)",
- org.yakindu.base.xtext.utils.jface;bundle-version="[3.5.9,4.0.0)"
+ org.eclipse.jdt.core;bundle-version="[3.13.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.osate.xtext.aadl2.ui,
  org.osate.xtext.aadl2.ui.containers,

--- a/core/org.osate.xtext.aadl2.ui/plugin.xml
+++ b/core/org.osate.xtext.aadl2.ui/plugin.xml
@@ -26,6 +26,12 @@ censes only apply to the Third Party Software and not any other portion of this 
 
 <plugin>
     <extension
+            point="org.eclipse.ui.startup">
+        <startup
+                class="org.osate.xtext.aadl2.ui.propertyview.ActiveEditorTracker">
+        </startup>
+    </extension>
+    <extension
             point="org.eclipse.ui.editors">
         <editor
             class="org.osate.xtext.aadl2.ui.Aadl2ExecutableExtensionFactory:org.eclipse.xtext.ui.editor.XtextEditor"

--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/ActiveEditorTracker.java
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/ActiveEditorTracker.java
@@ -1,0 +1,332 @@
+/**
+ * Copyright (c) 2015 committers of YAKINDU and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * Contributors:
+ * committers of YAKINDU - initial API and implementation
+ *
+*/
+package org.osate.xtext.aadl2.ui.propertyview;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.emf.common.ui.URIEditorInput;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.emf.edit.domain.IEditingDomainProvider;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IEditorReference;
+import org.eclipse.ui.IFileEditorInput;
+import org.eclipse.ui.IPageListener;
+import org.eclipse.ui.IPartListener;
+import org.eclipse.ui.IStartup;
+import org.eclipse.ui.IWindowListener;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.IWorkbenchPartReference;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+
+/**
+ * Get the last active editor in general or of a specific type.
+ *
+ * Please note that the ActiveEditorTracker currently only supports one single
+ * workbench window properly.
+ *
+ * @author patrick.koenemann@itemis.de
+ * @author alexander.nyssen@itemis.de
+ *
+ */
+public class ActiveEditorTracker implements IPageListener, IPartListener,
+		IStartup, IWindowListener {
+
+	private static final String SINGLETON_MSG = "This class is a singleton and may only be instantiated once!";
+
+	private IWorkbenchWindow workbenchWindow;
+
+	private Map<String, IEditorPart> activeEditors = new HashMap<String, IEditorPart>();
+
+	private String lastActiveEditorId;
+
+	private IWorkbenchPage activePage;
+
+	private static ActiveEditorTracker INSTANCE;
+
+	public ActiveEditorTracker() {
+		if (INSTANCE != null)
+			throw new IllegalStateException(SINGLETON_MSG);
+		INSTANCE = this;
+	}
+
+	public void earlyStartup() {
+		PlatformUI.getWorkbench().addWindowListener(this);
+	}
+
+	/**
+	 * @return The last active editor in the current active workbench page.
+	 */
+	public static IEditorPart getLastActiveEditor() {
+		if (INSTANCE == null) {
+			// not yet initialized, e.g. when another early startups blocks us!
+			// Let's try to get the current active editor instead.
+			if (PlatformUI.getWorkbench() != null) {
+				if (PlatformUI.getWorkbench().getActiveWorkbenchWindow() != null) {
+					return PlatformUI.getWorkbench().getActiveWorkbenchWindow()
+							.getActivePage().getActiveEditor();
+				}
+			}
+			return null;
+		}
+		return INSTANCE.getLastActiveEditorInternal();
+	}
+
+	/**
+	 * @return The last active editor with the given editor ID in the current
+	 *         active workbench page.
+	 */
+	public static IEditorPart getLastEditor(String editorId) {
+		if (INSTANCE == null) {
+			// not yet initialized, e.g. when another early startups blocks us!
+			// Let's try to get any editor with the specified id instead.
+			if (PlatformUI.getWorkbench() != null) {
+				final IWorkbenchWindow window = PlatformUI.getWorkbench()
+						.getActiveWorkbenchWindow();
+				if (window != null) {
+					final IWorkbenchPage page = window.getActivePage();
+					if (page != null) {
+						for (IEditorReference ref : page.getEditorReferences()) {
+							if (ref.getId().equals(editorId)) {
+								return ref.getEditor(false);
+							}
+						}
+					}
+				}
+			}
+			return null;
+		}
+		return INSTANCE.getEditorById(editorId);
+	}
+
+	/**
+	 *
+	 * @return The EMF resource set of the last active editor (if it is still
+	 *         open).
+	 */
+	public static ResourceSet getLastActiveEditorResourceSet() {
+		final IEditorPart editor = getLastActiveEditor();
+		if (editor == null)
+			return null;
+		EditingDomain domain = null;
+		if (editor instanceof IEditingDomainProvider) {
+			domain = ((IEditingDomainProvider) editor).getEditingDomain();
+		} else if (editor.getAdapter(IEditingDomainProvider.class) != null) {
+			domain = ((IEditingDomainProvider) editor
+					.getAdapter(IEditingDomainProvider.class))
+					.getEditingDomain();
+		} else if (editor.getAdapter(EditingDomain.class) != null) {
+			domain = (EditingDomain) editor.getAdapter(EditingDomain.class);
+		}
+		if (domain == null) {
+			return null;
+		}
+
+		return domain.getResourceSet();
+	}
+
+	/**
+	 * @return The project which contains the file that is open in the last
+	 *         active editor in the current workbench page.
+	 */
+	public static IProject getLastActiveEditorProject() {
+		final IEditorPart editor = getLastActiveEditor();
+		if (editor == null)
+			return null;
+		final IEditorInput editorInput = editor.getEditorInput();
+		if (editorInput instanceof IFileEditorInput) {
+			final IFileEditorInput input = (IFileEditorInput) editorInput;
+			return input.getFile().getProject();
+		} else if (editorInput instanceof URIEditorInput) {
+			final URI uri = ((URIEditorInput) editorInput).getURI();
+			if (uri.isPlatformResource()) {
+				final String platformString = uri.toPlatformString(true);
+				return ResourcesPlugin.getWorkspace().getRoot().findMember(platformString).getProject();
+			}
+		}
+		return null;
+	}
+
+	public void pageActivated(IWorkbenchPage page) {
+		this.activePage = page;
+	}
+
+	public void pageClosed(IWorkbenchPage page) {
+		if (page == activePage) {
+			activePage = null;
+		}
+		lastActiveEditorId = null;
+	}
+
+	public void pageOpened(IWorkbenchPage page) {
+		// do nothing
+	}
+
+	public void partActivated(IWorkbenchPart part) {
+		if (part instanceof IEditorPart) {
+			setActiveEditor((IEditorPart) part);
+		}
+	}
+
+	public void partBroughtToTop(IWorkbenchPart part) {
+		if (part instanceof IEditorPart) {
+			setActiveEditor((IEditorPart) part);
+		}
+	}
+
+	public void partClosed(IWorkbenchPart part) {
+		if (part instanceof IEditorPart) {
+			String id = null;
+			for (Entry<String, IEditorPart> entry : activeEditors.entrySet()) {
+				if (entry.getValue().equals(part)) {
+					id = entry.getKey();
+					break;
+				}
+			}
+			if (id != null) {
+				activeEditors.remove(id);
+				if (id.equals(lastActiveEditorId)) {
+					lastActiveEditorId = null;
+				}
+			}
+		}
+	}
+
+	public void partDeactivated(IWorkbenchPart part) {
+		if (part instanceof IEditorPart) {
+			// do nothing
+		}
+	}
+
+	private IEditorPart getLastActiveEditorInternal() {
+		if (activePage == null) {
+			initialize(PlatformUI.getWorkbench().getActiveWorkbenchWindow());
+			if (activePage == null)
+				return null;
+		}
+		boolean updated = false;
+		if (lastActiveEditorId == null) {
+			final IEditorPart editor = activePage.getActiveEditor();
+			if (editor != null) {
+				setActiveEditor(editor);
+			}
+			updated = true;
+		}
+		IEditorPart editor = getEditorById(lastActiveEditorId);
+		if (editor == null && !updated) {
+			editor = activePage.getActiveEditor();
+			if (editor != null) {
+				setActiveEditor(editor);
+			}
+		}
+		return editor;
+	}
+
+	private IEditorPart getEditorById(String editorId) {
+		if (activePage == null || editorId == null)
+			return null;
+		final IEditorPart editor = activeEditors.get(editorId);
+		final String id = checkEditorAndGetId(editor);
+		if (id != null && id.equals(editorId)) {
+			return editor;
+		}
+		return null;
+	}
+
+	private String checkEditorAndGetId(IEditorPart editor) {
+		if (editor == null)
+			return null;
+		for (IEditorReference ref : activePage.getEditorReferences()) {
+			if (editor.equals(ref.getEditor(false))) {
+				return ref.getId();
+			}
+		}
+		return null;
+	}
+
+	public IWorkbenchPage getActivePage() {
+		return activePage;
+	}
+
+	/**
+	 * Set the active editor
+	 */
+	private void setActiveEditor(IEditorPart part) {
+		if (part == null) {
+			lastActiveEditorId = null;
+			return;
+		}
+		final IWorkbenchPartReference reference = activePage.getReference(part);
+		if (reference == null)
+			throw new IllegalStateException("Impossible?!");
+		lastActiveEditorId = reference.getId();
+		activeEditors.put(lastActiveEditorId, part);
+	}
+
+	public void partOpened(IWorkbenchPart part) {
+		if (part instanceof IEditorPart) {
+			setActiveEditor((IEditorPart) part);
+		}
+	}
+
+	public void dispose() {
+		if (workbenchWindow == null) {
+			return;
+		}
+		workbenchWindow.removePageListener(this);
+		workbenchWindow.getPartService().removePartListener(this);
+		workbenchWindow = null;
+	}
+
+	public void windowActivated(IWorkbenchWindow window) {
+		initialize(window);
+	}
+
+	protected void initialize(IWorkbenchWindow window) {
+		if (workbenchWindow != null && !workbenchWindow.equals(window)) {
+			/*
+			 * TODO: implement logic for keeping track of editors in multiple
+			 * workbench windows!
+			 */
+		}
+		this.workbenchWindow = window;
+		if (window == null)
+			return;
+		this.activePage = window.getActivePage();
+		final IEditorPart editor = this.activePage.getActiveEditor();
+		if (editor != null) {
+			lastActiveEditorId = checkEditorAndGetId(editor);
+			activeEditors.put(lastActiveEditorId, editor);
+		}
+		window.addPageListener(this);
+		window.getPartService().addPartListener(this);
+	}
+
+	public void windowDeactivated(IWorkbenchWindow window) {
+		// not of interest
+	}
+
+	public void windowClosed(IWorkbenchWindow window) {
+		dispose();
+	}
+
+	public void windowOpened(IWorkbenchWindow window) {
+		// not of interest
+	}
+}

--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/CompletionProposalAdapter.java
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/CompletionProposalAdapter.java
@@ -1,0 +1,601 @@
+/**
+ * Copyright (c) 2015 committers of YAKINDU and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * Contributors:
+ * committers of YAKINDU - initial API and implementation
+ *
+*/
+package org.osate.xtext.aadl2.ui.propertyview;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.eclipse.core.runtime.ListenerList;
+import org.eclipse.jface.bindings.keys.KeyStroke;
+import org.eclipse.jface.fieldassist.ContentProposalAdapter;
+import org.eclipse.jface.text.contentassist.CompletionProposal;
+import org.eclipse.jface.text.contentassist.ContentAssistEvent;
+import org.eclipse.jface.text.contentassist.ContentAssistant;
+import org.eclipse.jface.text.contentassist.ICompletionListener;
+import org.eclipse.jface.text.contentassist.ICompletionProposal;
+import org.eclipse.jface.text.contentassist.IContentAssistant;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+
+/**
+ * This is a stripped copy from {@link ContentProposalAdapter} that delegates
+ * the popup to a {@link CompletionProposal} managed by a
+ * {@link IContentAssistant}.
+ *
+ * @author patrick.koenemann@itemis.de
+ *
+ */
+public class CompletionProposalAdapter implements ICompletionListener {
+
+	private final IContentAssistant contentAssistant;
+
+	/**
+	 * <p>
+	 * This adapter installs listener on the given control and delegates the
+	 * completion proposal popup request to the given {@link IContentAssistant}.
+	 * </p>
+	 *
+	 * <p>
+	 * FIXME: Parameter <code>autoActivationCharacters</code> is untested.
+	 * </p>
+	 *
+	 * @param control
+	 * @param contentAssistant
+	 * @param keyStroke
+	 * @param autoActivationCharacters
+	 */
+	public CompletionProposalAdapter(Control control,
+			IContentAssistant contentAssistant, KeyStroke keyStroke,
+			char[] autoActivationCharacters) {
+
+		this.control = control;
+
+		this.triggerKeyStroke = keyStroke;
+		if (autoActivationCharacters != null) {
+			this.autoActivateString = new String(autoActivationCharacters);
+		}
+
+		this.contentAssistant = contentAssistant;
+		addControlListener(control);
+	}
+
+	/**
+	 * Flag that controls the printing of debug info.
+	 */
+	public static final boolean DEBUG = false;
+
+	/*
+	 * The control for which content proposals are provided.
+	 */
+	private Control control;
+
+	/*
+	 * The keystroke that signifies content proposals should be shown.
+	 */
+	private KeyStroke triggerKeyStroke;
+
+	/*
+	 * The String containing characters that auto-activate the popup.
+	 */
+	private String autoActivateString;
+
+	/*
+	 * The listener we install on the control.
+	 */
+	private Listener controlListener;
+
+	/*
+	 * The list of IContentProposalListener2 listeners.
+	 */
+	private ListenerList proposalListeners2 = new ListenerList();
+
+	/*
+	 * Flag that indicates whether the adapter is enabled. In some cases,
+	 * adapters may be installed but depend upon outside state.
+	 */
+	private boolean isEnabled = true;
+
+	/*
+	 * The delay in milliseconds used when autoactivating the popup.
+	 */
+	private int autoActivationDelay = 0;
+
+	/*
+	 * A boolean indicating whether a keystroke has been received. Used to see
+	 * if an autoactivation delay was interrupted by a keystroke.
+	 */
+	private boolean receivedKeyDown;
+
+	/**
+	 * Get the control on which the content proposal adapter is installed.
+	 *
+	 * @return the control on which the proposal adapter is installed.
+	 */
+	public Control getControl() {
+		return control;
+	}
+
+	/**
+	 * Return a boolean indicating whether the receiver is enabled.
+	 *
+	 * @return <code>true</code> if the adapter is enabled, and
+	 *         <code>false</code> if it is not.
+	 */
+	public boolean isEnabled() {
+		return isEnabled;
+	}
+
+	/**
+	 * Return the array of characters on which the popup is autoactivated.
+	 *
+	 * @return An array of characters that trigger auto-activation of content
+	 *         proposal. If specified, these characters will trigger
+	 *         auto-activation of the proposal popup, regardless of whether an
+	 *         explicit invocation keyStroke was specified. If this parameter is
+	 *         <code>null</code>, then only a specified keyStroke will invoke
+	 *         content proposal. If this value is <code>null</code> and the
+	 *         keyStroke value is <code>null</code>, then all alphanumeric
+	 *         characters will auto-activate content proposal.
+	 */
+	public char[] getAutoActivationCharacters() {
+		if (autoActivateString == null) {
+			return null;
+		}
+		return autoActivateString.toCharArray();
+	}
+
+	/**
+	 * Set the array of characters that will trigger autoactivation of the
+	 * popup.
+	 *
+	 * @param autoActivationCharacters
+	 *            An array of characters that trigger auto-activation of content
+	 *            proposal. If specified, these characters will trigger
+	 *            auto-activation of the proposal popup, regardless of whether
+	 *            an explicit invocation keyStroke was specified. If this
+	 *            parameter is <code>null</code>, then only a specified
+	 *            keyStroke will invoke content proposal. If this parameter is
+	 *            <code>null</code> and the keyStroke value is <code>null</code>
+	 *            , then all alphanumeric characters will auto-activate content
+	 *            proposal.
+	 *
+	 */
+	public void setAutoActivationCharacters(char[] autoActivationCharacters) {
+		if (autoActivationCharacters == null) {
+			this.autoActivateString = null;
+		} else {
+			this.autoActivateString = new String(autoActivationCharacters);
+		}
+	}
+
+	/**
+	 * Set the delay, in milliseconds, used before any autoactivation is
+	 * triggered.
+	 *
+	 * @return the time in milliseconds that will pass before a popup is
+	 *         automatically opened
+	 */
+	public int getAutoActivationDelay() {
+		return autoActivationDelay;
+
+	}
+
+	/**
+	 * Set the delay, in milliseconds, used before autoactivation is triggered.
+	 *
+	 * @param delay
+	 *            the time in milliseconds that will pass before a popup is
+	 *            automatically opened
+	 */
+	public void setAutoActivationDelay(int delay) {
+		autoActivationDelay = delay;
+
+	}
+
+	/**
+	 * Set the boolean flag that determines whether the adapter is enabled.
+	 *
+	 * @param enabled
+	 *            <code>true</code> if the adapter is enabled and responding to
+	 *            user input, <code>false</code> if it is ignoring user input.
+	 *
+	 */
+	public void setEnabled(boolean enabled) {
+		// If we are disabling it while it's proposing content, close the
+		// content proposal popup.
+		if (isEnabled && !enabled) {
+			// if (popup != null) {
+			// popup.close();
+			// }
+		}
+		isEnabled = enabled;
+	}
+
+	/**
+	 * Add the specified listener to the list of content proposal listeners that
+	 * are notified when a content proposal popup is opened or closed.
+	 */
+	public void addContentProposalListener(ICompletionProposalListener listener) {
+		proposalListeners2.add(listener);
+	}
+
+	/**
+	 * Remove the specified listener from the list of content proposal listeners
+	 * that are notified when a content proposal popup is opened or closed.
+	 */
+	public void removeContentProposalListener(
+			ICompletionProposalListener listener) {
+		proposalListeners2.remove(listener);
+	}
+
+	/*
+	 * Add our listener to the control. Debug information to be left in until
+	 * this support is stable on all platforms.
+	 */
+	private void addControlListener(Control control) {
+		if (DEBUG) {
+			System.out
+					.println("ContentProposalListener#installControlListener()"); //$NON-NLS-1$
+		}
+
+		if (controlListener != null) {
+			return;
+		}
+		controlListener = new Listener() {
+			public void handleEvent(Event e) {
+				if (!isEnabled) {
+					return;
+				}
+
+				switch (e.type) {
+				case SWT.Traverse:
+				case SWT.KeyDown:
+					if (DEBUG) {
+						StringBuffer sb;
+						if (e.type == SWT.Traverse) {
+							sb = new StringBuffer("Traverse"); //$NON-NLS-1$
+						} else {
+							sb = new StringBuffer("KeyDown"); //$NON-NLS-1$
+						}
+						sb.append(" received by adapter"); //$NON-NLS-1$
+						dump(sb.toString(), e);
+					}
+					// If the popup is open, it gets first shot at the
+					// keystroke and should set the doit flags appropriately.
+					// if (popup != null) {
+					// popup.getTargetControlListener().handleEvent(e);
+					// if (DEBUG) {
+					// StringBuffer sb;
+					// if (e.type == SWT.Traverse) {
+					//								sb = new StringBuffer("Traverse"); //$NON-NLS-1$
+					// } else {
+					//								sb = new StringBuffer("KeyDown"); //$NON-NLS-1$
+					// }
+					//							sb.append(" after being handled by popup"); //$NON-NLS-1$
+					// dump(sb.toString(), e);
+					// }
+					// // See
+					// https://bugs.eclipse.org/bugs/show_bug.cgi?id=192633
+					// // If the popup is open and this is a valid character, we
+					// // want to watch for the modified text.
+					// if (propagateKeys && e.character != 0)
+					// watchModify = true;
+					//
+					// return;
+					// }
+
+					// We were only listening to traverse events for the popup
+					if (e.type == SWT.Traverse) {
+						return;
+					}
+
+					// The popup is not open. We are looking at keydown events
+					// for a trigger to open the popup.
+					if (triggerKeyStroke != null) {
+						// Either there are no modifiers for the trigger and we
+						// check the character field...
+						if ((triggerKeyStroke.getModifierKeys() == KeyStroke.NO_KEY && triggerKeyStroke
+								.getNaturalKey() == e.character) ||
+						// ...or there are modifiers, in which case the
+						// keycode and state must match
+								(triggerKeyStroke.getNaturalKey() == e.keyCode && ((triggerKeyStroke
+										.getModifierKeys() & e.stateMask) == triggerKeyStroke
+										.getModifierKeys()))) {
+							// We never propagate the keystroke for an explicit
+							// keystroke invocation of the popup
+							e.doit = false;
+							openProposalPopup(false);
+							return;
+						}
+					}
+					/*
+					 * The triggering keystroke was not invoked. If a character
+					 * was typed, compare it to the autoactivation characters.
+					 */
+					if (e.character != 0) {
+						if (autoActivateString != null) {
+							if (autoActivateString.indexOf(e.character) >= 0) {
+								autoActivate();
+							} else {
+								// No autoactivation occurred, so record the key
+								// down as a means to interrupt any
+								// autoactivation that is pending due to
+								// autoactivation delay.
+								receivedKeyDown = true;
+								// watch the modify so we can close the popup in
+								// cases where there is no longer a trigger
+								// character in the content
+								// watchModify = true;
+							}
+						} else {
+							// The autoactivate string is null. If the trigger
+							// is also null, we want to act on any modification
+							// to the content. Set a flag so we'll catch this
+							// in the modify event.
+							if (triggerKeyStroke == null) {
+								// watchModify = true;
+							}
+						}
+					} else {
+						// A non-character key has been pressed. Interrupt any
+						// autoactivation that is pending due to autoactivation
+						// delay.
+						receivedKeyDown = true;
+					}
+					break;
+
+				// There are times when we want to monitor content changes
+				// rather than individual keystrokes to determine whether
+				// the popup should be closed or opened based on the entire
+				// content of the control.
+				// The watchModify flag ensures that we don't autoactivate if
+				// the content change was caused by something other than typing.
+				// See https://bugs.eclipse.org/bugs/show_bug.cgi?id=183650
+				// case SWT.Modify:
+				// if (allowsAutoActivate() && watchModify) {
+				// if (DEBUG) {
+				//								dump("Modify event triggers popup open or close", e); //$NON-NLS-1$
+				// }
+				// watchModify = false;
+				// // We are in autoactivation mode, either for specific
+				// // characters or for all characters. In either case,
+				// // we should close the proposal popup when there is no
+				// // content in the control.
+				// if (isControlContentEmpty()) {
+				// // see https://bugs.eclipse.org/bugs/show_bug.cgi?id=192633
+				// closeProposalPopup();
+				// } else {
+				// // See https://bugs.eclipse.org/bugs/show_bug.cgi?id=147377
+				// // Given that we will close the popup when there are
+				// // no valid proposals, we must consider reopening it on any
+				// // content change when there are no particular autoActivation
+				// // characters
+				// if (autoActivateString == null) {
+				// autoActivate();
+				// } else {
+				// // Autoactivation characters are defined, but this
+				// // modify event does not involve one of them. See
+				// // if any of the autoactivation characters are left
+				// // in the content and close the popup if none remain.
+				// if (!shouldPopupRemainOpen())
+				// closeProposalPopup();
+				// }
+				// }
+				// }
+				// break;
+				default:
+					break;
+				}
+			}
+
+			/**
+			 * Dump the given events to "standard" output.
+			 *
+			 * @param who
+			 *            who is dumping the event
+			 * @param e
+			 *            the event
+			 */
+			private void dump(String who, Event e) {
+				StringBuffer sb = new StringBuffer(
+						"--- [ContentProposalAdapter]\n"); //$NON-NLS-1$
+				sb.append(who);
+				sb.append(" - e: keyCode=" + e.keyCode + hex(e.keyCode)); //$NON-NLS-1$
+				sb.append("; character=" + e.character + hex(e.character)); //$NON-NLS-1$
+				sb.append("; stateMask=" + e.stateMask + hex(e.stateMask)); //$NON-NLS-1$
+				sb.append("; doit=" + e.doit); //$NON-NLS-1$
+				sb.append("; detail=" + e.detail + hex(e.detail)); //$NON-NLS-1$
+				sb.append("; widget=" + e.widget); //$NON-NLS-1$
+				System.out.println(sb);
+			}
+
+			private String hex(int i) {
+				return "[0x" + Integer.toHexString(i) + ']'; //$NON-NLS-1$
+			}
+		};
+		control.addListener(SWT.KeyDown, controlListener);
+		control.addListener(SWT.Traverse, controlListener);
+		control.addListener(SWT.Modify, controlListener);
+
+		if (DEBUG) {
+			System.out
+					.println("ContentProposalAdapter#installControlListener() - installed"); //$NON-NLS-1$
+		}
+	}
+
+	/**
+	 * Open the proposal popup and display the proposals provided by the
+	 * proposal provider. If there are no proposals to be shown, do not show the
+	 * popup. This method returns immediately. That is, it does not wait for the
+	 * popup to open or a proposal to be selected.
+	 *
+	 * @param autoActivated
+	 *            a boolean indicating whether the popup was autoactivated. If
+	 *            false, a beep will sound when no proposals can be shown.
+	 */
+	private void openProposalPopup(boolean autoActivated) {
+		if (isValid() && isEnabled()) {
+
+			// XXX here we delegate the request!
+			contentAssistant.showPossibleCompletions();
+
+			((ContentAssistant) contentAssistant).addCompletionListener(this);
+		}
+	}
+
+	/**
+	 * Open the proposal popup and display the proposals provided by the
+	 * proposal provider. This method returns immediately. That is, it does not
+	 * wait for a proposal to be selected. This method is used by subclasses to
+	 * explicitly invoke the opening of the popup. If there are no proposals to
+	 * show, the popup will not open and a beep will be sounded.
+	 */
+	protected void openProposalPopup() {
+		openProposalPopup(false);
+	}
+
+	/*
+	 * Check that the control and content adapter are valid.
+	 */
+	private boolean isValid() {
+		return control != null && !control.isDisposed();
+	}
+
+	/**
+	 * Autoactivation has been triggered. Open the popup using any specified
+	 * delay.
+	 */
+	private void autoActivate() {
+		if (autoActivationDelay > 0) {
+			Runnable runnable = new Runnable() {
+				public void run() {
+					receivedKeyDown = false;
+					try {
+						Thread.sleep(autoActivationDelay);
+					} catch (InterruptedException e) {
+					}
+					if (!isValid() || receivedKeyDown) {
+						return;
+					}
+					getControl().getDisplay().syncExec(new Runnable() {
+						public void run() {
+							openProposalPopup(true);
+						}
+					});
+				}
+			};
+			Thread t = new Thread(runnable);
+			t.start();
+		} else {
+			// Since we do not sleep, we must open the popup
+			// in an async exec. This is necessary because
+			// this method may be called in the middle of handling
+			// some event that will cause the cursor position or
+			// other important info to change as a result of this
+			// event occurring.
+			getControl().getDisplay().asyncExec(new Runnable() {
+				public void run() {
+					if (isValid()) {
+						openProposalPopup(true);
+					}
+				}
+			});
+		}
+	}
+
+	/*
+	 * The proposal popup has opened. Notify interested listeners.
+	 */
+	private void notifyPopupOpened() {
+		if (DEBUG) {
+			System.out.println("Notify listeners - popup opened."); //$NON-NLS-1$
+		}
+		final Object[] listenerArray = proposalListeners2.getListeners();
+		for (int i = 0; i < listenerArray.length; i++) {
+			((ICompletionProposalListener) listenerArray[i])
+					.proposalPopupOpened(this);
+		}
+	}
+
+	/*
+	 * The proposal popup has closed. Notify interested listeners.
+	 */
+	private void notifyPopupClosed() {
+		if (DEBUG) {
+			System.out.println("Notify listeners - popup closed."); //$NON-NLS-1$
+		}
+		final Object[] listenerArray = proposalListeners2.getListeners();
+		for (int i = 0; i < listenerArray.length; i++) {
+			((ICompletionProposalListener) listenerArray[i])
+					.proposalPopupClosed(this);
+		}
+	}
+
+	/**
+	 * Answers a boolean indicating whether the main proposal popup is open.
+	 *
+	 * @return <code>true</code> if the proposal popup is open, and
+	 *         <code>false</code> if it is not.
+	 *
+	 * @since 3.6
+	 */
+	public boolean isProposalPopupOpen() {
+		if (isValid() && isProposalPopupActive())
+			return true;
+		return false;
+	}
+
+	/**
+	 * @return <code>true</code> if the content assistant has the completion
+	 *         proposal popup open; <code>false</code> otherwise.
+	 */
+	private boolean isProposalPopupActive() {
+		/*
+		 * Unfortunately, the method is protected so we use java reflection to
+		 * access it.
+		 */
+		try {
+			final Method m = ContentAssistant.class
+					.getDeclaredMethod("isProposalPopupActive");
+			m.setAccessible(true);
+			try {
+				final Object result = m.invoke(contentAssistant);
+				if (result != null && result instanceof Boolean) {
+					return (Boolean) result;
+				} else {
+					throw new IllegalStateException(
+							"Method is expected to return boolean!");
+				}
+			} catch (InvocationTargetException e) {
+				throw e.getCause(); // cause was thrown by method m.
+			}
+		} catch (Throwable e) {
+			e.printStackTrace();
+			return false;
+		}
+	}
+
+	public void assistSessionStarted(ContentAssistEvent event) {
+		notifyPopupOpened();
+	}
+
+	public void assistSessionEnded(ContentAssistEvent event) {
+		notifyPopupClosed();
+	}
+
+	public void selectionChanged(ICompletionProposal proposal,
+			boolean smartToggle) {
+		// do nothing
+	}
+
+}

--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/FilteringMenuManager.java
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/FilteringMenuManager.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2011 itemis AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * 	itemis AG - initial API and implementation
+ *
+ */
+package org.osate.xtext.aadl2.ui.propertyview;
+
+import org.eclipse.jface.action.IContributionItem;
+import org.eclipse.jface.action.MenuManager;
+import org.eclipse.xtext.util.Arrays;
+
+/**
+ * Copied from DiagramContextMenuProvider
+ *
+ * @author muelder
+ *
+ */
+public class FilteringMenuManager extends MenuManager {
+
+	private String[] exclusionSet = { "replaceWithMenu", "compareWithMenu", "ValidationAction", "team.main",
+			"org.eclipse.jst.ws.atk.ui.webservice.category.popupMenu",
+			"org.eclipse.tptp.platform.analysis.core.ui.internal.actions.MultiAnalysisActionDelegate",
+			"org.eclipse.debug.ui.contextualLaunch.run.submenu", "org.eclipse.debug.ui.contextualLaunch.debug.submenu",
+			"org.eclipse.debug.ui.contextualLaunch.profile.submenu",
+			"org.eclipse.cdt.ui.buildConfigContributionM",
+			"org.eclipse.mylyn.resources.ui.ui.interest.remove.element" };
+
+	public FilteringMenuManager() {
+	}
+
+	public FilteringMenuManager(String text, String id) {
+		super(text, null, id);
+	}
+
+	protected boolean allowItem(IContributionItem itemToAdd) {
+		if (itemToAdd.getId() != null && Arrays.contains(exclusionSet, itemToAdd.getId()))
+			itemToAdd.setVisible(false);
+		return super.allowItem(itemToAdd);
+	}
+}

--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/ICompletionProposalListener.java
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/ICompletionProposalListener.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2015 committers of YAKINDU and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * Contributors:
+ * committers of YAKINDU - initial API and implementation
+ *
+*/
+package org.osate.xtext.aadl2.ui.propertyview;
+
+/**
+ * This interface is used to listen to additional notifications from a
+ * {@link CompletionProposalAdapter}.
+ *
+ * @author patrick.koenemann@itemis.de
+ *
+ */
+public interface ICompletionProposalListener {
+	/**
+	 * A completion proposal popup has been opened.
+	 *
+	 * @param adapter
+	 *            the CompletionProposalAdapter which is adapting content proposal
+	 *            behavior to a control
+	 */
+	public void proposalPopupOpened(CompletionProposalAdapter adapter);
+
+	/**
+	 * A completion proposal popup has been closed.
+	 *
+	 * @param adapter
+	 *            the CompletionProposalAdapter which is adapting content proposal
+	 *            behavior to a control
+	 */
+	public void proposalPopupClosed(CompletionProposalAdapter adapter);
+}

--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/IXtextFakeContextResourcesProvider.java
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/IXtextFakeContextResourcesProvider.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2015 committers of YAKINDU and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * Contributors:
+ * committers of YAKINDU - initial API and implementation
+ *
+*/
+package org.osate.xtext.aadl2.ui.propertyview;
+
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.xtext.resource.XtextResource;
+
+/**
+ *
+ * @author alexander.nyssen@itemis.de
+ *
+ */
+public interface IXtextFakeContextResourcesProvider {
+
+	public static final IXtextFakeContextResourcesProvider NULL_CONTEXT_PROVIDER = new IXtextFakeContextResourcesProvider() {
+		public void populateFakeResourceSet(
+				ResourceSet fakeResourceSet, XtextResource fakeResource) {
+		};
+	};
+
+	/**
+	 * Populate the fake resource set with additional resources that may be
+	 * needed for scoping/linking. The fake resource used will be passe in as
+	 * context information. Note that at the time this callback is invoked, the
+	 * fake resource will not be contained in the fake resource set, because
+	 * that may cause problems when working with the resource set (as the fake
+	 * resource does actually not exist in the file system).
+	 *
+	 * @param fakeResourceSet
+	 *            the {@link ResourceSet} to populate
+	 * @param fakeResource
+	 *            the fake {@link XtextResource} as context information.
+	 */
+	void populateFakeResourceSet(ResourceSet fakeResourceSet,
+			XtextResource fakeResource);
+}

--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/OsateFakeResourceContext.java
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/OsateFakeResourceContext.java
@@ -24,8 +24,6 @@
 package org.osate.xtext.aadl2.ui.propertyview;
 
 import org.eclipse.core.resources.IProject;
-import org.yakindu.base.xtext.utils.jface.viewers.context.XtextFakeResourceContext;
-
 import com.google.inject.Injector;
 
 /**

--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/OsateSourceViewerEx.java
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/OsateSourceViewerEx.java
@@ -28,8 +28,6 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.projection.ProjectionDocument;
 import org.eclipse.swt.custom.StyledText;
-import org.yakindu.base.xtext.utils.jface.viewers.XtextSourceViewerEx;
-
 /**
  * @since 2.0
  */

--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/OsateStyledTextCellEditor.java
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/OsateStyledTextCellEditor.java
@@ -30,16 +30,13 @@ import org.eclipse.swt.widgets.Menu;
 import org.eclipse.ui.IWorkbenchPartSite;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
-import org.yakindu.base.xtext.utils.jface.viewers.XtextStyledTextCellEditor;
-import org.yakindu.base.xtext.utils.jface.viewers.context.IXtextFakeContextResourcesProvider;
-
 import com.google.inject.Injector;
 
 /**
  * @since 2.0
  */
 public class OsateStyledTextCellEditor extends XtextStyledTextCellEditor {
-	private static final String CONTEXTMENUID = "org.yakindu.base.xtext.utils.jface.viewers.StyledTextXtextAdapterContextMenu";
+	private static final String CONTEXTMENUID = "org.osate.xtext.aadl2.ui.propertyview.StyledTextXtextAdapterContextMenu";
 
 	private final IProject project;
 

--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/OsateStyledTextXtextAdapter.java
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/OsateStyledTextXtextAdapter.java
@@ -27,9 +27,6 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.jface.text.source.AnnotationModel;
 import org.eclipse.xtext.ui.editor.XtextSourceViewer;
 import org.eclipse.xtext.ui.editor.model.XtextDocument;
-import org.yakindu.base.xtext.utils.jface.viewers.StyledTextXtextAdapter;
-import org.yakindu.base.xtext.utils.jface.viewers.context.IXtextFakeContextResourcesProvider;
-
 import com.google.inject.Injector;
 
 /**

--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/StyledTextCellEditor.java
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/StyledTextCellEditor.java
@@ -1,0 +1,512 @@
+
+/*******************************************************************************
+ * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Tom Eicher <eclipse@tom.eicher.name> - fix minimum width
+ *******************************************************************************/
+package org.osate.xtext.aadl2.ui.propertyview;
+
+import java.text.MessageFormat;
+
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.jface.viewers.CellEditor;
+import org.eclipse.jface.viewers.TextCellEditor;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.custom.VerifyKeyListener;
+import org.eclipse.swt.events.FocusAdapter;
+import org.eclipse.swt.events.FocusEvent;
+import org.eclipse.swt.events.KeyAdapter;
+import org.eclipse.swt.events.KeyEvent;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.events.MouseAdapter;
+import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.TraverseEvent;
+import org.eclipse.swt.events.TraverseListener;
+import org.eclipse.swt.events.VerifyEvent;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Text;
+
+/**
+ * This is a complete copy of {@link TextCellEditor}. Only the control is
+ * changed from {@link Text} to {@link StyledText}, with some small
+ * modifications.
+ *
+ * @author muelder
+ *
+ */
+public class StyledTextCellEditor extends CellEditor {
+
+	/**
+	 * The text control; initially <code>null</code>.
+	 */
+	protected StyledText text;
+
+	private ModifyListener modifyListener;
+
+	/**
+	 * State information for updating action enablement
+	 */
+	private boolean isSelection = false;
+
+	private boolean isDeleteable = false;
+
+	private boolean isSelectable = false;
+
+	private VerifyKeyListener verifyKeyListener;
+
+	/**
+	 * Creates a new text string cell editor with no control The cell editor
+	 * value is the string itself, which is initially the empty string.
+	 * Initially, the cell editor has no cell validator.
+	 *
+	 * @since 2.1
+	 */
+	public StyledTextCellEditor() {
+	}
+
+	/**
+	 * Checks to see if the "deletable" state (can delete/ nothing to delete)
+	 * has changed and if so fire an enablement changed notification.
+	 */
+	private void checkDeleteable() {
+		boolean oldIsDeleteable = isDeleteable;
+		isDeleteable = isDeleteEnabled();
+		if (oldIsDeleteable != isDeleteable) {
+			fireEnablementChanged(DELETE);
+		}
+	}
+
+	/**
+	 * Checks to see if the "selectable" state (can select) has changed and if
+	 * so fire an enablement changed notification.
+	 */
+	private void checkSelectable() {
+		boolean oldIsSelectable = isSelectable;
+		isSelectable = isSelectAllEnabled();
+		if (oldIsSelectable != isSelectable) {
+			fireEnablementChanged(SELECT_ALL);
+		}
+	}
+
+	/**
+	 * Checks to see if the selection state (selection / no selection) has
+	 * changed and if so fire an enablement changed notification.
+	 */
+	private void checkSelection() {
+		boolean oldIsSelection = isSelection;
+		isSelection = text.getSelectionCount() > 0;
+		if (oldIsSelection != isSelection) {
+			fireEnablementChanged(COPY);
+			fireEnablementChanged(CUT);
+		}
+	}
+
+	/*
+	 * (non-Javadoc) Method declared on CellEditor.
+	 */
+	protected Control createControl(Composite parent) {
+		text = createStyledText(parent);
+		text.setAlwaysShowScrollBars(false);
+		text.addSelectionListener(new SelectionAdapter() {
+			public void widgetDefaultSelected(SelectionEvent e) {
+				handleDefaultSelection(e);
+			}
+		});
+		text.addKeyListener(new KeyAdapter() {
+			// hook key pressed - see PR 14201
+			public void keyPressed(KeyEvent e) {
+				keyReleaseOccured(e);
+
+				// as a result of processing the above call, clients may have
+				// disposed this cell editor
+				if ((getControl() == null) || getControl().isDisposed()) {
+					return;
+				}
+				checkSelection(); // see explanation below
+				checkDeleteable();
+				checkSelectable();
+			}
+		});
+		text.addTraverseListener(new TraverseListener() {
+			public void keyTraversed(TraverseEvent e) {
+				if (e.detail == SWT.TRAVERSE_ESCAPE || e.detail == SWT.TRAVERSE_RETURN) {
+					e.doit = false;
+				}
+			}
+		});
+		// We really want a selection listener but it is not supported so we
+		// use a key listener and a mouse listener to know when selection
+		// changes
+		// may have occurred
+		text.addMouseListener(new MouseAdapter() {
+			public void mouseUp(MouseEvent e) {
+				checkSelection();
+				checkDeleteable();
+				checkSelectable();
+			}
+		});
+		text.addFocusListener(new FocusAdapter() {
+			public void focusLost(FocusEvent e) {
+				StyledTextCellEditor.this.focusLost();
+			}
+		});
+
+		text.setFont(parent.getFont());
+		text.setBackground(parent.getBackground());
+		text.setText("");//$NON-NLS-1$
+		text.addModifyListener(getModifyListener());
+		text.addVerifyKeyListener(getVerifyKeyListener());
+		return text;
+	}
+
+	protected VerifyKeyListener getVerifyKeyListener() {
+		if (verifyKeyListener == null) {
+			verifyKeyListener = new VerifyKeyListener() {
+
+				@Override
+				public void verifyKey(VerifyEvent event) {
+					if (event.stateMask == SWT.CTRL) {
+						switch (event.character) {
+							case '\u0003' : // copy action
+								performCopy();
+								break;
+							case '\u0018' : // cut action
+								performCut();
+								break;
+							case '\u0001' : // selectAll action
+								performSelectAll();
+								break;
+						}
+						event.doit = true;
+					}
+				}
+			};
+		}
+		return verifyKeyListener;
+	}
+
+	/**
+	 * Hook changing creation of Control
+	 *
+	 * @param parent
+	 * @return
+	 */
+	protected StyledText createStyledText(Composite parent) {
+		return new StyledText(parent, getStyle());
+	}
+
+	/**
+	 * The <code>TextCellEditor</code> implementation of this
+	 * <code>CellEditor</code> framework method returns the text string.
+	 *
+	 * @return the text string
+	 */
+	protected Object doGetValue() {
+		if(text.isDisposed())
+			return null;
+		return text.getText();
+	}
+
+	/*
+	 * (non-Javadoc) Method declared on CellEditor.
+	 */
+	protected void doSetFocus() {
+		if (text != null) {
+			text.setFocus();
+			checkSelection();
+			checkDeleteable();
+			checkSelectable();
+		}
+	}
+
+	/**
+	 * The <code>TextCellEditor</code> implementation of this
+	 * <code>CellEditor</code> framework method accepts a text string (type
+	 * <code>String</code>).
+	 *
+	 * @param value
+	 *            a text string (type <code>String</code>)
+	 */
+	protected void doSetValue(Object value) {
+		Assert.isTrue(text != null && (value instanceof String));
+		text.removeModifyListener(getModifyListener());
+		text.setText((String) value);
+		text.addModifyListener(getModifyListener());
+	}
+
+	/**
+	 * Processes a modify event that occurred in this text cell editor. This
+	 * framework method performs validation and sets the error message
+	 * accordingly, and then reports a change via
+	 * <code>fireEditorValueChanged</code>. Subclasses should call this method
+	 * at appropriate times. Subclasses may extend or reimplement.
+	 *
+	 * @param e
+	 *            the SWT modify event
+	 */
+	protected void editOccured(ModifyEvent e) {
+		String value = text.getText();
+		if (value == null) {
+			value = "";//$NON-NLS-1$
+		}
+		Object typedValue = value;
+		boolean oldValidState = isValueValid();
+		boolean newValidState = isCorrect(typedValue);
+		if (!newValidState) {
+			// try to insert the current value into the error message.
+			setErrorMessage(MessageFormat.format(getErrorMessage(),
+					new Object[] { value }));
+		}
+		valueChanged(oldValidState, newValidState);
+	}
+
+	/**
+	 * Since a text editor field is scrollable we don't set a minimumSize.
+	 */
+	public LayoutData getLayoutData() {
+		LayoutData data = new LayoutData();
+		data.minimumWidth = 0;
+		return data;
+	}
+
+	/**
+	 * Return the modify listener.
+	 */
+	private ModifyListener getModifyListener() {
+		if (modifyListener == null) {
+			modifyListener = new ModifyListener() {
+				public void modifyText(ModifyEvent e) {
+					editOccured(e);
+				}
+			};
+		}
+		return modifyListener;
+	}
+
+	/**
+	 * Handles a default selection event from the text control by applying the
+	 * editor value and deactivating this cell editor.
+	 *
+	 * @param event
+	 *            the selection event
+	 *
+	 * @since 3.0
+	 */
+	protected void handleDefaultSelection(SelectionEvent event) {
+		// same with enter-key handling code in keyReleaseOccured(e);
+		fireApplyEditorValue();
+		deactivate();
+	}
+
+	/**
+	 * The <code>TextCellEditor</code> implementation of this
+	 * <code>CellEditor</code> method returns <code>true</code> if the current
+	 * selection is not empty.
+	 */
+	public boolean isCopyEnabled() {
+		if (text == null || text.isDisposed()) {
+			return false;
+		}
+		return text.getSelectionCount() > 0;
+	}
+
+	/**
+	 * The <code>TextCellEditor</code> implementation of this
+	 * <code>CellEditor</code> method returns <code>true</code> if the current
+	 * selection is not empty.
+	 */
+	public boolean isCutEnabled() {
+		if (text == null || text.isDisposed()) {
+			return false;
+		}
+		return text.getSelectionCount() > 0;
+	}
+
+	/**
+	 * The <code>TextCellEditor</code> implementation of this
+	 * <code>CellEditor</code> method returns <code>true</code> if there is a
+	 * selection or if the caret is not positioned at the end of the text.
+	 */
+	public boolean isDeleteEnabled() {
+		if (text == null || text.isDisposed()) {
+			return false;
+		}
+		/*
+		 * TODO: check that semantics remains the same as original:
+		 * text.getCaretPosition()
+		 */
+		return text.getSelectionCount() > 0
+				|| text.getCaretOffset() < text.getCharCount();
+	}
+
+	/**
+	 * The <code>TextCellEditor</code> implementation of this
+	 * <code>CellEditor</code> method always returns <code>true</code>.
+	 */
+	public boolean isPasteEnabled() {
+		if (text == null || text.isDisposed()) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Check if save all is enabled
+	 *
+	 * @return true if it is
+	 */
+	public boolean isSaveAllEnabled() {
+		if (text == null || text.isDisposed()) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Returns <code>true</code> if this cell editor is able to perform the
+	 * select all action.
+	 * <p>
+	 * This default implementation always returns <code>false</code>.
+	 * </p>
+	 * <p>
+	 * Subclasses may override
+	 * </p>
+	 *
+	 * @return <code>true</code> if select all is possible, <code>false</code>
+	 *         otherwise
+	 */
+	public boolean isSelectAllEnabled() {
+		if (text == null || text.isDisposed()) {
+			return false;
+		}
+		return text.getCharCount() > 0;
+	}
+
+	/**
+	 * Processes a key release event that occurred in this cell editor.
+	 * <p>
+	 * The <code>TextCellEditor</code> implementation of this framework method
+	 * ignores when the RETURN key is pressed since this is handled in
+	 * <code>handleDefaultSelection</code>. An exception is made for Ctrl+Enter
+	 * for multi-line texts, since a default selection event is not sent in this
+	 * case.
+	 * </p>
+	 *
+	 * @param keyEvent
+	 *            the key event
+	 */
+	protected void keyReleaseOccured(KeyEvent keyEvent) {
+		if (keyEvent.character == '\r') { // Return key
+			// Enter is handled in handleDefaultSelection.
+			// Do not apply the editor value in response to an Enter key event
+			// since this can be received from the IME when the intent is -not-
+			// to apply the value.
+			// See bug 39074 [CellEditors] [DBCS] canna input mode fires bogus
+			// event from Text Control
+			//
+			// An exception is made for Ctrl+Enter for multi-line texts, since
+			// a default selection event is not sent in this case.
+			if (text != null && !text.isDisposed()
+					&& (text.getStyle() & SWT.MULTI) != 0) {
+				if ((keyEvent.stateMask & SWT.CTRL) != 0) {
+					super.keyReleaseOccured(keyEvent);
+				}
+			}
+			return;
+		}
+		super.keyReleaseOccured(keyEvent);
+	}
+
+	/**
+	 * The <code>TextCellEditor</code> implementation of this
+	 * <code>CellEditor</code> method copies the current selection to the
+	 * clipboard.
+	 */
+	public void performCopy() {
+		text.copy();
+	}
+
+	/**
+	 * The <code>TextCellEditor</code> implementation of this
+	 * <code>CellEditor</code> method cuts the current selection to the
+	 * clipboard.
+	 */
+	public void performCut() {
+		text.cut();
+		checkSelection();
+		checkDeleteable();
+		checkSelectable();
+	}
+
+	/**
+	 * The <code>TextCellEditor</code> implementation of this
+	 * <code>CellEditor</code> method deletes the current selection or, if there
+	 * is no selection, the character next character from the current position.
+	 */
+	public void performDelete() {
+		if (text.getSelectionCount() > 0) {
+			// remove the contents of the current selection
+			text.insert(""); //$NON-NLS-1$
+		} else {
+			// remove the next character
+			/*
+			 * TODO: check that semantics remains the same as original:
+			 * text.getCaretPosition()
+			 */
+			int pos = text.getCaretOffset();
+			if (pos < text.getCharCount()) {
+				text.setSelection(pos, pos + 1);
+				text.insert(""); //$NON-NLS-1$
+			}
+		}
+		checkSelection();
+		checkDeleteable();
+		checkSelectable();
+	}
+
+	/**
+	 * The <code>TextCellEditor</code> implementation of this
+	 * <code>CellEditor</code> method pastes the the clipboard contents over the
+	 * current selection.
+	 */
+	public void performPaste() {
+		text.paste();
+		checkSelection();
+		checkDeleteable();
+		checkSelectable();
+	}
+
+	/**
+	 * The <code>TextCellEditor</code> implementation of this
+	 * <code>CellEditor</code> method selects all of the current text.
+	 */
+	public void performSelectAll() {
+		text.selectAll();
+		checkSelection();
+		checkDeleteable();
+	}
+
+	/**
+	 * This implementation of
+	 * {@link CellEditor#dependsOnExternalFocusListener()} returns false if the
+	 * current instance's class is TextCellEditor, and true otherwise.
+	 * Subclasses that hook their own focus listener should override this method
+	 * and return false. See also bug 58777.
+	 *
+	 * @since 3.4
+	 */
+	protected boolean dependsOnExternalFocusListener() {
+		return getClass() != StyledTextCellEditor.class;
+	}
+}

--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/StyledTextXtextAdapter.java
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/StyledTextXtextAdapter.java
@@ -1,0 +1,450 @@
+/**
+ * Copyright (c) 2015 committers of YAKINDU and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * Contributors:
+ * committers of YAKINDU - initial API and implementation
+ *
+*/
+package org.osate.xtext.aadl2.ui.propertyview;
+
+import java.util.List;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jface.bindings.keys.KeyStroke;
+import org.eclipse.jface.fieldassist.ControlDecoration;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.text.IDocumentPartitioner;
+import org.eclipse.jface.text.contentassist.IContentAssistant;
+import org.eclipse.jface.text.source.AnnotationModel;
+import org.eclipse.jface.text.source.ICharacterPairMatcher;
+import org.eclipse.jface.text.source.ISharedTextColors;
+import org.eclipse.jface.viewers.ISelectionProvider;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.events.DisposeEvent;
+import org.eclipse.swt.events.DisposeListener;
+import org.eclipse.swt.events.FocusEvent;
+import org.eclipse.swt.events.FocusListener;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+import org.eclipse.ui.IWorkbenchPartSite;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.internal.editors.text.EditorsPlugin;
+import org.eclipse.ui.swt.IFocusService;
+import org.eclipse.ui.texteditor.AbstractDecoratedTextEditor;
+import org.eclipse.ui.texteditor.AnnotationPreference;
+import org.eclipse.ui.texteditor.DefaultMarkerAnnotationAccess;
+import org.eclipse.ui.texteditor.MarkerAnnotationPreferences;
+import org.eclipse.ui.texteditor.SourceViewerDecorationSupport;
+import org.eclipse.xtext.parser.IParseResult;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.ui.editor.XtextEditor;
+import org.eclipse.xtext.ui.editor.XtextSourceViewer;
+import org.eclipse.xtext.ui.editor.XtextSourceViewerConfiguration;
+import org.eclipse.xtext.ui.editor.bracketmatching.BracketMatchingPreferencesInitializer;
+import org.eclipse.xtext.ui.editor.model.XtextDocument;
+import org.eclipse.xtext.ui.editor.preferences.IPreferenceStoreAccess;
+import org.eclipse.xtext.ui.editor.quickfix.IssueResolutionProvider;
+import org.eclipse.xtext.ui.editor.validation.AnnotationIssueProcessor;
+import org.eclipse.xtext.ui.editor.validation.ValidationJob;
+import org.eclipse.xtext.util.concurrent.IUnitOfWork;
+import org.eclipse.xtext.validation.CheckMode;
+import org.eclipse.xtext.validation.IResourceValidator;
+import org.eclipse.xtext.validation.Issue;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+
+/**
+ *
+ * @author andreas.muelder@itemis.de
+ * @author alexander.nyssen@itemis.de
+ * @author patrick.koenemann@itemis.de
+ *
+ */
+@SuppressWarnings("restriction")
+public class StyledTextXtextAdapter {
+
+	@Inject
+	private IPreferenceStoreAccess preferenceStoreAccess;
+	@Inject
+	private ICharacterPairMatcher characterPairMatcher;
+	@Inject
+	private XtextSourceViewerConfiguration configuration;
+	@Inject
+	private XtextStyledTextHighlightingHelper xtextStyledTextHighlightingHelper;
+	@Inject
+	private IResourceValidator validator;
+	@Inject
+	private Provider<IDocumentPartitioner> documentPartitioner;
+	@Inject
+	private XtextDocument document;
+
+	private final IssueResolutionProvider resolutionProvider = new IssueResolutionProvider.NullImpl();
+	private final IXtextFakeContextResourcesProvider contextFakeResourceProvider;
+	private final XtextFakeResourceContext fakeResourceContext;
+
+	private XtextSourceViewer sourceviewer;
+
+	private ValidationJob validationJob;
+
+	private StyledText styledText;
+
+	private ControlDecoration decoration;
+
+	private SourceViewerDecorationSupport decorationSupport;
+	private IWorkbenchPartSite site;
+
+	public StyledTextXtextAdapter(Injector injector, IXtextFakeContextResourcesProvider contextFakeResourceProvider) {
+		this.contextFakeResourceProvider = contextFakeResourceProvider;
+		injector.injectMembers(this);
+
+		// create fake resource and containing resource set
+		this.fakeResourceContext = createFakeResourceContext(injector);
+	}
+
+	public StyledTextXtextAdapter(Injector injector) {
+		this(injector, IXtextFakeContextResourcesProvider.NULL_CONTEXT_PROVIDER);
+	}
+
+	public StyledTextXtextAdapter(Injector inject, IWorkbenchPartSite site) {
+		this(inject);
+		this.site = site;
+	}
+
+	public void adapt(StyledText styledText) {
+		adapt(styledText, true);
+	}
+
+	public void adapt(StyledText styledText, boolean decorate) {
+		this.styledText = styledText;
+
+		// perform initialization of fake resource context
+		updateFakeResourceContext();
+
+		// connect Xtext document to fake resource
+		initXtextDocument(getFakeResourceContext());
+
+		// connect xtext document to xtext source viewer
+		this.sourceviewer = createXtextSourceViewer();
+		this.decorationSupport = createSourceViewerDecorationSupport();
+		configureSourceViewerDecorationSupport(getDecorationSupport());
+
+		// install semantic highlighting support
+		installHighlightingHelper();
+
+		this.validationJob = createValidationJob();
+		getXtextDocument().setValidationJob(getValidationJob());
+
+		styledText.setData(StyledTextXtextAdapter.class.getCanonicalName(), this);
+
+		final IContentAssistant contentAssistant = getXtextSourceviewer().getContentAssistant();
+		final CompletionProposalAdapter completionProposalAdapter = new CompletionProposalAdapter(styledText,
+				contentAssistant, KeyStroke.getInstance(SWT.CTRL, SWT.SPACE), null);
+
+		if ((styledText.getStyle() & SWT.SINGLE) != 0) {
+			// The regular key down event is too late (after popup is closed).
+			// when using the StyledText.VerifyKey event (3005), we get the
+			// event early enough!
+			styledText.addListener(3005, new Listener() {
+				@Override
+				public void handleEvent(Event event) {
+					if (event.character == SWT.CR && !completionProposalAdapter.isProposalPopupOpen()) {
+						Event selectionEvent = new Event();
+						selectionEvent.type = SWT.DefaultSelection;
+						selectionEvent.widget = event.widget;
+						for (Listener l : event.widget.getListeners(SWT.DefaultSelection)) {
+							l.handleEvent(selectionEvent);
+						}
+					}
+				}
+			});
+		}
+
+		// Register focus tracker for evaluating the active focus control in
+		// core expression
+		IFocusService service = (IFocusService) PlatformUI.getWorkbench().getService(IFocusService.class);
+		service.addFocusTracker(styledText, StyledText.class.getCanonicalName());
+
+		if (decorate) {
+			// add JDT Style code completion hint decoration
+			this.decoration = createContentAssistDecoration(styledText);
+		}
+
+		initSelectionProvider();
+	}
+
+	protected void initSelectionProvider() {
+		// Overrides the editors selection provider to provide the text
+		// selection if opened within an editor context
+		try {
+			if (this.site == null) {
+				site = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActiveEditor().getSite();
+			}
+			XtextStyledTextSelectionProvider xtextStyledTextSelectionProvider = new XtextStyledTextSelectionProvider(
+					this.styledText, getFakeResourceContext().getFakeResource());
+			ChangeSelectionProviderOnFocusGain listener = new ChangeSelectionProviderOnFocusGain(site,
+					xtextStyledTextSelectionProvider, styledText);
+			getStyledText().addFocusListener(listener);
+			getStyledText().addDisposeListener(listener);
+		} catch (NullPointerException ex) {
+			// Do nothing, not opened within editor context
+		}
+	}
+
+	private ControlDecoration createContentAssistDecoration(StyledText styledText) {
+		final ControlDecoration result = new ControlDecoration(styledText, SWT.TOP | SWT.LEFT);
+		result.setShowHover(true);
+		result.setShowOnlyOnFocus(true);
+
+		final Image image = ImageDescriptor
+				.createFromFile(XtextStyledTextCellEditor.class, "images/content_assist_cue.gif").createImage();
+		result.setImage(image);
+		result.setDescriptionText("Content Assist Available (CTRL + Space)");
+		result.setMarginWidth(2);
+		styledText.addDisposeListener(new DisposeListener() {
+			@Override
+			public void widgetDisposed(DisposeEvent e) {
+				if (getDecoration() != null) {
+					getDecoration().dispose();
+				}
+				if (image != null) {
+					image.dispose();
+				}
+			}
+		});
+		return result;
+	}
+
+	protected ValidationJob createValidationJob() {
+		return new ValidationJob(getValidator(), getXtextDocument(), new AnnotationIssueProcessor(getXtextDocument(),
+				getXtextSourceviewer().getAnnotationModel(), getResolutionProvider()), CheckMode.FAST_ONLY);
+	}
+
+	protected XtextFakeResourceContext createFakeResourceContext(Injector injector) {
+		return new XtextFakeResourceContext(injector);
+	}
+
+	protected XtextSourceViewer createXtextSourceViewer() {
+		final XtextSourceViewer result = new XtextSourceViewerEx(getStyledText(),
+				getPreferenceStoreAccess().getPreferenceStore());
+		result.configure(getXtextSourceViewerConfiguration());
+		result.setDocument(getXtextDocument(), new AnnotationModel());
+		return result;
+	}
+
+	protected ISharedTextColors getSharedColors() {
+		return EditorsPlugin.getDefault().getSharedTextColors();
+	}
+
+	/**
+	 * Creates decoration support for the sourceViewer. code is entirely copied from
+	 * {@link XtextEditor} and its super class {@link AbstractDecoratedTextEditor}.
+	 *
+	 */
+	protected void configureSourceViewerDecorationSupport(SourceViewerDecorationSupport support) {
+		MarkerAnnotationPreferences annotationPreferences = new MarkerAnnotationPreferences();
+		List<AnnotationPreference> prefs = annotationPreferences.getAnnotationPreferences();
+		for (AnnotationPreference annotationPreference : prefs) {
+			support.setAnnotationPreference(annotationPreference);
+		}
+
+		support.setCharacterPairMatcher(getCharacterPairMatcher());
+		support.setMatchingCharacterPainterPreferenceKeys(BracketMatchingPreferencesInitializer.IS_ACTIVE_KEY,
+				BracketMatchingPreferencesInitializer.COLOR_KEY);
+
+		support.install(getPreferenceStoreAccess().getPreferenceStore());
+	}
+
+	protected void unconfigureSourceViewerDecorationSupport(SourceViewerDecorationSupport support) {
+		support.uninstall();
+	}
+
+	protected void initXtextDocument(XtextFakeResourceContext context) {
+		getXtextDocument().setInput(context.getFakeResource());
+		IDocumentPartitioner partitioner = getDocumentPartitioner().get();
+		partitioner.connect(getXtextDocument());
+		getXtextDocument().setDocumentPartitioner(partitioner);
+	}
+
+	public void setVisibleRegion(int start, int length) {
+		getXtextSourceviewer().setVisibleRegion(start, length);
+	}
+
+	public void resetVisibleRegion() {
+		getXtextSourceviewer().resetVisibleRegion();
+	}
+
+	private void installHighlightingHelper() {
+		if (getXtextStyledTextHighlightingHelper() != null) {
+			getXtextStyledTextHighlightingHelper().install(this, getXtextSourceviewer());
+		}
+	}
+
+	private void uninstallHighlightingHelper() {
+		if (getXtextStyledTextHighlightingHelper() != null) {
+			getXtextStyledTextHighlightingHelper().uninstall();
+		}
+	}
+
+	public void dispose() {
+		getXtextDocument().setOutdated(true);
+		if (getDecorationSupport() != null) {
+			unconfigureSourceViewerDecorationSupport(getDecorationSupport());
+		}
+		uninstallHighlightingHelper();
+	}
+
+	protected XtextSourceViewerConfiguration getXtextSourceViewerConfiguration() {
+		return this.configuration;
+	}
+
+	protected XtextDocument getXtextDocument() {
+		return this.document;
+	}
+
+	protected XtextSourceViewer getXtextSourceviewer() {
+		return this.sourceviewer;
+	}
+
+	public IParseResult getXtextParseResult() {
+		return getXtextDocument().readOnly(new IUnitOfWork<IParseResult, XtextResource>() {
+
+			@Override
+			public IParseResult exec(XtextResource state) throws Exception {
+				return state.getParseResult();
+			}
+		});
+	}
+
+	public IContentAssistant getContentAssistant() {
+		return getXtextSourceviewer().getContentAssistant();
+	}
+
+	public List<Issue> getXtextValidationIssues() {
+		return getValidationJob().createIssues(new NullProgressMonitor());
+	}
+
+	public void updateFakeResourceContext() {
+		getFakeResourceContext().updateFakeResourceContext(getFakeResourceContextProvider());
+	}
+
+	protected IXtextFakeContextResourcesProvider getFakeResourceContextProvider() {
+		return this.contextFakeResourceProvider;
+	}
+
+	public XtextFakeResourceContext getFakeResourceContext() {
+		return this.fakeResourceContext;
+	}
+
+	protected SourceViewerDecorationSupport createSourceViewerDecorationSupport() {
+		return new SourceViewerDecorationSupport(getXtextSourceviewer(), null, new DefaultMarkerAnnotationAccess(),
+				getSharedColors());
+	}
+
+	protected ValidationJob getValidationJob() {
+		return this.validationJob;
+	}
+
+	protected IssueResolutionProvider getResolutionProvider() {
+		return this.resolutionProvider;
+	}
+
+	protected StyledText getStyledText() {
+		return this.styledText;
+	}
+
+	protected ControlDecoration getDecoration() {
+		return this.decoration;
+	}
+
+	protected SourceViewerDecorationSupport getDecorationSupport() {
+		return this.decorationSupport;
+	}
+
+	protected IResourceValidator getValidator() {
+		return this.validator;
+	}
+
+	protected IPreferenceStoreAccess getPreferenceStoreAccess() {
+		return this.preferenceStoreAccess;
+	}
+
+	protected ICharacterPairMatcher getCharacterPairMatcher() {
+		return this.characterPairMatcher;
+	}
+
+	protected Provider<IDocumentPartitioner> getDocumentPartitioner() {
+		return this.documentPartitioner;
+	}
+
+	protected XtextStyledTextHighlightingHelper getXtextStyledTextHighlightingHelper() {
+		return this.xtextStyledTextHighlightingHelper;
+	}
+
+	public static class ChangeSelectionProviderOnFocusGain implements FocusListener, DisposeListener {
+
+		protected ISelectionProvider selectionProviderOnFocusGain;
+		protected ISelectionProvider selectionProviderOnFocusLost;
+		protected IWorkbenchPartSite site;
+		private boolean ignoreNextFocusLost = false;
+		private StyledText text;
+
+		public ChangeSelectionProviderOnFocusGain(IWorkbenchPartSite site,
+				ISelectionProvider selectionProviderOnFocusGain, StyledText text) {
+			this.selectionProviderOnFocusGain = selectionProviderOnFocusGain;
+			this.site = site;
+			this.text = text;
+		}
+
+		@Override
+		public void focusLost(FocusEvent e) {
+			if (SWT.getPlatform().equals("gtk")) {
+				if (isIgnoreNextFocusLost()) {
+					setIgnoreNextFocusLost(false);
+					return;
+				}
+				if (text.getMenu().isVisible()) {
+					setIgnoreNextFocusLost(true);
+					return;
+				}
+			}
+
+			if (this.selectionProviderOnFocusLost != null) {
+				this.site.setSelectionProvider(this.selectionProviderOnFocusLost);
+			}
+
+			text.setSelection(text.getCaretOffset());
+
+		}
+
+		protected void setIgnoreNextFocusLost(boolean b) {
+			this.ignoreNextFocusLost = b;
+
+		}
+
+		protected boolean isIgnoreNextFocusLost() {
+			return ignoreNextFocusLost;
+		}
+
+		@Override
+		public void focusGained(FocusEvent e) {
+			this.selectionProviderOnFocusLost = this.site.getSelectionProvider();
+			this.site.setSelectionProvider(this.selectionProviderOnFocusGain);
+		}
+
+		@Override
+		public void widgetDisposed(DisposeEvent e) {
+			if (this.selectionProviderOnFocusLost != null) {
+				this.site.setSelectionProvider(this.selectionProviderOnFocusLost);
+			}
+			((StyledText) e.getSource()).removeFocusListener(this);
+			((StyledText) e.getSource()).removeDisposeListener(this);
+		}
+
+	}
+}

--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/XtextFakeResourceContext.java
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/XtextFakeResourceContext.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2015 committers of YAKINDU and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * Contributors:
+ * committers of YAKINDU - initial API and implementation
+ *
+*/
+package org.osate.xtext.aadl2.ui.propertyview;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.xtext.Constants;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.resource.XtextResourceSet;
+import org.eclipse.xtext.util.StringInputStream;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import com.google.inject.name.Named;
+
+/**
+ * Context used by {@link XtextStyledTextAdapter} to handle the required
+ * underlying (fake) resources.
+ *
+ * @author alexander.nyssen@itemis.de
+ *
+ */
+public class XtextFakeResourceContext {
+
+	@Inject
+	private Provider<XtextResourceSet> resourceSetProvider;
+	private ResourceSet fakeResourceSet;
+	@Inject
+	private XtextResource fakeResource;
+	@Inject
+	private @Named(Constants.FILE_EXTENSIONS) String fakeResourceFileExtension;
+
+	private IProject activeProject;
+
+	public XtextFakeResourceContext(Injector injector) {
+		this(injector, ActiveEditorTracker.getLastActiveEditorProject());
+	}
+
+	public XtextFakeResourceContext(Injector injector, IProject activeProject) {
+		this.activeProject = activeProject;
+		injector.injectMembers(this);
+		// create resource set
+		createXtextFakeResourceSet();
+		// initialize fake resource (which was injected and thus does not has to
+		// be created)
+		initXtextFakeResource();
+		// initialize the resource set (the fake resource has to be added)
+		initXtextFakeResourceSet();
+	}
+
+	protected void initXtextFakeResourceSet() {
+		fakeResourceSet.getResources().add(fakeResource);
+		// fakeResourceSet.getLoadOptions().put(
+		// ResourceDescriptionsProvider.LIVE_SCOPE, Boolean.TRUE);
+	}
+
+	protected ResourceSet getFakeResourceSet() {
+		return fakeResourceSet;
+	}
+
+	protected void createXtextFakeResourceSet() {
+		fakeResourceSet = resourceSetProvider.get();
+	}
+
+	protected void initXtextFakeResource() {
+		// add the fake resource (add an uri to it, first)
+		IProject activeProject = getActiveProject();
+		// fallback to avoid dependency on open editor
+		String activeProjectName = activeProject != null ? activeProject.getName() : "fakeResource";
+		fakeResource.setURI(createFakeResourceUri(activeProjectName));
+		try {
+			fakeResource.load(new StringInputStream(""), Collections.EMPTY_MAP);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	public XtextResource getFakeResource() {
+		return fakeResource;
+	}
+
+	private URI createFakeResourceBaseFragment(String activeProject) {
+		return URI.createPlatformResourceURI(activeProject + "/embedded", true);
+	}
+
+	private URI createFakeResourceUri(String activeProject) {
+		return createFakeResourceBaseFragment(activeProject).appendFileExtension(fakeResourceFileExtension);
+	}
+
+	protected String getFileExtension() {
+		return fakeResourceFileExtension;
+	}
+
+	protected IProject getActiveProject() {
+		return activeProject;
+	}
+
+	public void updateFakeResourceContext(IXtextFakeContextResourcesProvider contextProvider) {
+
+		// remove any other resources that may have been created earlier
+		// unloading them (to remove all adapters)
+		List<Resource> staleResources = new ArrayList<Resource>();
+		for (Resource r : fakeResourceSet.getResources()) {
+			if (r != fakeResource) {
+				staleResources.add(r);
+				r.unload();
+			}
+		}
+		fakeResourceSet.getResources().removeAll(staleResources);
+
+		// when populating the fake resource set, the non-existing fake resource
+		// contained in the resource set may be problematic, so we temporarily
+		// remove it
+		fakeResourceSet.getResources().remove(fakeResource);
+		contextProvider.populateFakeResourceSet(fakeResourceSet, fakeResource);
+		fakeResourceSet.getResources().add(fakeResource);
+	}
+
+}

--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/XtextSourceViewerEx.java
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/XtextSourceViewerEx.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2015 committers of YAKINDU and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * Contributors:
+ * committers of YAKINDU - initial API and implementation
+ *
+*/
+package org.osate.xtext.aadl2.ui.propertyview;
+
+import java.lang.reflect.Field;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.projection.ProjectionDocument;
+import org.eclipse.jface.text.source.SourceViewerConfiguration;
+import org.eclipse.jface.text.source.projection.ProjectionViewer;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.editors.text.TextSourceViewerConfiguration;
+import org.eclipse.xtext.ui.editor.XtextSourceViewer;
+
+/**
+ * Source viewer replacement that implements a workaround for Eclipse bug
+ * #352847 to enable that offsets are respected.
+ *
+ * @author alexander.nyssen@itemis.de
+ *
+ */
+public class XtextSourceViewerEx extends XtextSourceViewer {
+
+	private final StyledText styledText;
+	private final IPreferenceStore preferenceStore;
+
+	public XtextSourceViewerEx(StyledText styledText,
+			IPreferenceStore preferenceStore) {
+		// super constructor will create a new text widget by calling
+		// createControl(). As we want to use the passed in styled text, we have
+		// to disable this mechanism.
+		super(null, null, null, false, styledText.getStyle());
+		this.styledText = styledText;
+		this.preferenceStore = preferenceStore;
+		super.createControl(styledText.getParent(), styledText.getStyle());
+	}
+
+	@Override
+	protected void createControl(Composite parent, int styles) {
+		// do nothing here (will be called by super constructor)
+	}
+
+	@Override
+	protected StyledText createTextWidget(Composite parent, int styles) {
+		return this.styledText;
+	}
+
+	/**
+	 * Overwritten to handle offset properly.
+	 */
+	@Override
+	protected boolean updateSlaveDocument(IDocument slaveDocument,
+			int modelRangeOffset, int modelRangeLength)
+			throws BadLocationException {
+		if (slaveDocument instanceof ProjectionDocument) {
+			ProjectionDocument projection = (ProjectionDocument) slaveDocument;
+
+			int offset = modelRangeOffset;
+			int length = modelRangeLength;
+
+			if (!isProjectionMode()) {
+				// mimic original TextViewer behavior
+				IDocument master = projection.getMasterDocument();
+				int line = master.getLineOfOffset(modelRangeOffset);
+				offset += master.getLineOffset(line);
+				length = (modelRangeOffset - offset) + modelRangeLength;
+			}
+
+			try {
+				// fHandleProjectionChanges= false;
+				setPrivateHandleProjectionChangesField(false);
+				projection.replaceMasterDocumentRanges(offset, length);
+			} finally {
+				// fHandleProjectionChanges= true;
+				setPrivateHandleProjectionChangesField(true);
+			}
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public void configure(SourceViewerConfiguration configuration) {
+		// We have to set the preference store via reflection here because Xtext
+		// uses package visibility for the setter
+		Field declaredField;
+		try {
+			declaredField = TextSourceViewerConfiguration.class
+					.getDeclaredField("fPreferenceStore");
+			declaredField.setAccessible(true);
+			declaredField.set(configuration, this.preferenceStore);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		super.configure(configuration);
+	}
+
+	/**
+	 * Set the private fHandleProjectionChanges field value.
+	 *
+	 * @param value
+	 *            the new value.
+	 */
+	protected void setPrivateHandleProjectionChangesField(boolean value) {
+		try {
+			Field declaredField = ProjectionViewer.class
+					.getDeclaredField("fHandleProjectionChanges");
+			declaredField.setAccessible(true);
+			declaredField.set(this, value);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+}

--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/XtextStyledTextCellEditor.java
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/XtextStyledTextCellEditor.java
@@ -1,0 +1,268 @@
+/**
+ * Copyright (c) 2011 itemis AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * 	itemis AG - initial API and implementation
+ *
+ */
+package org.osate.xtext.aadl2.ui.propertyview;
+
+import org.eclipse.jface.action.MenuManager;
+import org.eclipse.jface.bindings.keys.KeyStroke;
+import org.eclipse.jface.text.ITextListener;
+import org.eclipse.jface.text.TextEvent;
+import org.eclipse.jface.text.contentassist.IContentAssistant;
+import org.eclipse.jface.text.source.SourceViewer;
+import org.eclipse.jface.viewers.CellEditor;
+import org.eclipse.jface.viewers.StructuredViewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.events.FocusAdapter;
+import org.eclipse.swt.events.FocusEvent;
+import org.eclipse.swt.events.KeyEvent;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Menu;
+import org.eclipse.ui.IWorkbenchPartSite;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.xtext.ui.editor.XtextEditor;
+import com.google.inject.Injector;
+
+/**
+ * This class integrates Xtext features into a {@link CellEditor} and can be
+ * used e.g. in jFace {@link StructuredViewer}s or in GMF EditParts via
+ * DirectEditManager.
+ *
+ * The current implementation supports, code completion, syntax highlighting and
+ * validation
+ *
+ * @see XtextStyledTextProvider
+ *
+ * @author andreas.muelder@itemis.de
+ * @author alexander.nyssen@itemis.de
+ * @author patrick.koenemann@itemis.de
+ */
+public class XtextStyledTextCellEditor extends StyledTextCellEditor {
+
+	private final Injector injector;
+	private StyledTextXtextAdapter xtextAdapter;
+	private IXtextFakeContextResourcesProvider contextFakeResourceProvider;
+	private final static String CONTEXTMENUID = "org.osate.xtext.aadl2.ui.propertyview";
+
+	public XtextStyledTextCellEditor(int style, Injector injector,
+			IXtextFakeContextResourcesProvider contextFakeResourceProvider) {
+		this(style, injector);
+		this.contextFakeResourceProvider = contextFakeResourceProvider;
+	}
+
+	public XtextStyledTextCellEditor(int style, Injector injector) {
+		setStyle(style);
+		this.injector = injector;
+	}
+
+	/**
+	 * Creates an {@link SourceViewer} and returns the {@link StyledText} widget
+	 * of the viewer as the cell editors control. Some code is copied from
+	 * {@link XtextEditor}.
+	 */
+	@Override
+	protected Control createControl(Composite parent) {
+		StyledText styledText = (StyledText) super.createControl(parent);
+		styledText.addFocusListener(new FocusAdapter() {
+			@Override
+			public void focusLost(FocusEvent e) {
+				XtextStyledTextCellEditor.this.focusLost();
+			}
+		});
+
+		// adapt to xtext
+		this.xtextAdapter = createXtextAdapter();
+		getXtextAdapter().adapt(styledText);
+
+		// configure content assist
+		final IContentAssistant contentAssistant = getXtextAdapter().getContentAssistant();
+
+		this.completionProposalAdapter = createCompletionProposalAdapter(styledText, contentAssistant);
+
+		// This listener notifies the modification, when text is selected via
+		// proposal. A ModifyEvent is not thrown by the StyledText in this case.
+		getXtextAdapter().getXtextSourceviewer().addTextListener(new ITextListener() {
+			@Override
+			public void textChanged(TextEvent event) {
+				editOccured(null);
+			}
+		});
+
+		if ((styledText.getStyle() & SWT.SINGLE) != 0) {
+			// The regular key down event is too late (after popup is closed
+			// again).
+			// when using the StyledText.VerifyKey event (3005), we get the
+			// event early enough!
+			styledText.addListener(3005, new Listener() {
+				@Override
+				public void handleEvent(Event event) {
+					if (event.character == SWT.CR && !getCompletionProposalAdapter().isProposalPopupOpen()) {
+						focusLost();
+					}
+				}
+			});
+		}
+		styledText.addListener(3005, new Listener() {
+			@Override
+			public void handleEvent(Event event) {
+				if (event.character == '\u001b' // ESC
+						&& !getCompletionProposalAdapter().isProposalPopupOpen()) {
+					XtextStyledTextCellEditor.this.fireCancelEditor();
+				}
+			}
+		});
+
+		initContextMenu(styledText);
+
+		return styledText;
+	}
+
+	protected void initContextMenu(Control control) {
+		MenuManager menuManager = createMenuManager();
+		Menu contextMenu = menuManager.createContextMenu(control);
+		control.setMenu(contextMenu);
+		IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		IWorkbenchPartSite site = window.getActivePage().getActiveEditor().getSite();
+		site.registerContextMenu(CONTEXTMENUID, menuManager, site.getSelectionProvider());
+	}
+
+	protected MenuManager createMenuManager() {
+		return new FilteringMenuManager();
+	}
+
+	@Override
+	protected void keyReleaseOccured(KeyEvent keyEvent) {
+		if (keyEvent.character == '\u001b') { // ESC
+			return;
+		}
+		super.keyReleaseOccured(keyEvent);
+	}
+
+	@Override
+	protected void doSetValue(Object value) {
+		super.doSetValue(value);
+		// Reset the undo manager to prevent deletion of complete text if the
+		// user hits ctrl+z after cell editor opens
+		getXtextAdapter().getXtextSourceviewer().getUndoManager().reset();
+	}
+
+	@Override
+	public boolean isUndoEnabled() {
+		return true;
+	}
+
+	@Override
+	public void performUndo() {
+		getXtextAdapter().getXtextSourceviewer().getUndoManager().undo();
+	}
+
+	@Override
+	public boolean isRedoEnabled() {
+		return true;
+	}
+
+	@Override
+	public void performRedo() {
+		getXtextAdapter().getXtextSourceviewer().getUndoManager().redo();
+	}
+
+	@Override
+	public boolean isFindEnabled() {
+		return true;
+	}
+
+	// in gtk, we need this flag to let one focus lost event pass. See
+	// focusLost() for details.
+	private boolean ignoreNextFocusLost = false;
+	private CompletionProposalAdapter completionProposalAdapter;
+
+	/*
+	 * In gtk, the focus lost event is fired _after_ the CR event, so we need to
+	 * remember the state when the proposal popup window is open.
+	 */
+	@Override
+	protected void focusLost() {
+		if (SWT.getPlatform().equals("gtk")) {
+			if (isIgnoreNextFocusLost()) {
+				setIgnoreNextFocusLost(false);
+				return;
+			}
+			if (getCompletionProposalAdapter().isProposalPopupOpen() || text.getMenu().isVisible()) {
+				setIgnoreNextFocusLost(true);
+				return;
+			}
+		}
+
+		if (!getCompletionProposalAdapter().isProposalPopupOpen()) {
+			super.focusLost();
+		}
+	}
+
+	@Override
+	public void dispose() {
+		getXtextAdapter().dispose();
+		super.dispose();
+	}
+
+	/*
+	 * This is damn important! If we don't return false here, the
+	 * ColumnEditorViewer calls applyEditorValue on FocusLostEvents!
+	 */
+	@Override
+	protected boolean dependsOnExternalFocusListener() {
+		return false;
+	}
+
+	public void setVisibleRegion(int start, int length) {
+		getXtextAdapter().setVisibleRegion(start, length);
+	}
+
+	public StyledTextXtextAdapter getXtextAdapter() {
+		return this.xtextAdapter;
+	}
+
+	protected CompletionProposalAdapter getCompletionProposalAdapter() {
+		return this.completionProposalAdapter;
+	}
+
+	protected IXtextFakeContextResourcesProvider getContextFakeResourceProvider() {
+		return this.contextFakeResourceProvider;
+	}
+
+	protected CompletionProposalAdapter createCompletionProposalAdapter(StyledText styledText,
+			final IContentAssistant contentAssistant) {
+		return new CompletionProposalAdapter(styledText, contentAssistant, KeyStroke.getInstance(SWT.CTRL, SWT.SPACE),
+				null);
+	}
+
+	protected StyledTextXtextAdapter createXtextAdapter() {
+		return new StyledTextXtextAdapter(this.getInjector(),
+				getContextFakeResourceProvider() == null
+						? IXtextFakeContextResourcesProvider.NULL_CONTEXT_PROVIDER
+						: getContextFakeResourceProvider());
+	}
+
+	protected boolean isIgnoreNextFocusLost() {
+		return this.ignoreNextFocusLost;
+	}
+
+	protected void setIgnoreNextFocusLost(boolean ignoreNextFocusLost) {
+		this.ignoreNextFocusLost = ignoreNextFocusLost;
+	}
+
+	protected Injector getInjector() {
+		return this.injector;
+	}
+}

--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/XtextStyledTextHighlightingHelper.java
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/XtextStyledTextHighlightingHelper.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2015 committers of YAKINDU and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * Contributors:
+ * committers of YAKINDU - initial API and implementation
+ *
+*/
+package org.osate.xtext.aadl2.ui.propertyview;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.util.IPropertyChangeListener;
+import org.eclipse.jface.util.PropertyChangeEvent;
+import org.eclipse.xtext.ui.editor.XtextPresentationReconciler;
+import org.eclipse.xtext.ui.editor.XtextSourceViewer;
+import org.eclipse.xtext.ui.editor.XtextSourceViewerConfiguration;
+import org.eclipse.xtext.ui.editor.preferences.IPreferenceStoreAccess;
+import org.eclipse.xtext.ui.editor.syntaxcoloring.HighlightingPresenter;
+import org.eclipse.xtext.ui.editor.syntaxcoloring.TextAttributeProvider;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
+/**
+ * Modified copy of
+ * org.eclipse.xtext.ui.editor.syntaxcoloring.HighlightingHelper
+ */
+class XtextStyledTextHighlightingHelper implements IPropertyChangeListener {
+
+	@Inject
+	private Provider<XtextStyledTextHighlightingReconciler> reconcilerProvider;
+
+	@Inject
+	private Provider<HighlightingPresenter> presenterProvider;
+
+	@Inject
+	private IPreferenceStoreAccess preferenceStoreAccessor;
+
+	@Inject
+	private TextAttributeProvider textAttributeProvider;
+
+	/** Highlighting presenter */
+	private HighlightingPresenter fPresenter;
+	/** Highlighting reconciler */
+	private XtextStyledTextHighlightingReconciler fReconciler;
+
+	/** The editor */
+	private StyledTextXtextAdapter styledTextXtextAdapter;
+	/** The source viewer */
+	private XtextSourceViewer fSourceViewer;
+	/** The source viewer configuration */
+	private XtextSourceViewerConfiguration fConfiguration;
+	/** The presentation reconciler */
+	private XtextPresentationReconciler fPresentationReconciler;
+
+	private IPreferenceStore preferenceStore;
+
+	public void install(StyledTextXtextAdapter styledTextXtextAdapter,
+			XtextSourceViewer sourceViewer) {
+		this.styledTextXtextAdapter = styledTextXtextAdapter;
+		fSourceViewer = sourceViewer;
+		if (styledTextXtextAdapter != null) {
+			fConfiguration = styledTextXtextAdapter
+					.getXtextSourceViewerConfiguration();
+			fPresentationReconciler = (XtextPresentationReconciler) fConfiguration
+					.getPresentationReconciler(sourceViewer);
+		} else {
+			fConfiguration = null;
+			fPresentationReconciler = null;
+		}
+		preferenceStore = getPreferenceStoreAccessor().getPreferenceStore();
+		preferenceStore.addPropertyChangeListener(this);
+		enable();
+	}
+
+	/**
+	 * Enable advanced highlighting.
+	 */
+	private void enable() {
+		fPresenter = getPresenterProvider().get();
+		fPresenter.install(fSourceViewer, fPresentationReconciler);
+
+		if (styledTextXtextAdapter != null) {
+			fReconciler = reconcilerProvider.get();
+			fReconciler.install(styledTextXtextAdapter, fSourceViewer, fPresenter);
+		}
+	}
+
+	public void uninstall() {
+		disable();
+		if (preferenceStore != null) {
+			preferenceStore.removePropertyChangeListener(this);
+		}
+		styledTextXtextAdapter = null;
+		fSourceViewer = null;
+		fConfiguration = null;
+		fPresentationReconciler = null;
+	}
+
+	/**
+	 * Disable advanced highlighting.
+	 */
+	private void disable() {
+		if (fReconciler != null) {
+			fReconciler.uninstall();
+			fReconciler = null;
+		}
+
+		if (fPresenter != null) {
+			fPresenter.uninstall();
+			fPresenter = null;
+		}
+	}
+
+	/**
+	 * Returns this hightlighter's reconciler.
+	 *
+	 * @return the highlighter reconciler or <code>null</code> if none
+	 */
+	public XtextStyledTextHighlightingReconciler getReconciler() {
+		return fReconciler;
+	}
+
+	public void setReconcilerProvider(
+			Provider<XtextStyledTextHighlightingReconciler> reconcilerProvider) {
+		this.reconcilerProvider = reconcilerProvider;
+	}
+
+	public Provider<XtextStyledTextHighlightingReconciler> getReconcilerProvider() {
+		return reconcilerProvider;
+	}
+
+	public void setPresenterProvider(
+			Provider<HighlightingPresenter> presenterProvider) {
+		this.presenterProvider = presenterProvider;
+	}
+
+	public Provider<HighlightingPresenter> getPresenterProvider() {
+		return presenterProvider;
+	}
+
+	public void setPreferenceStoreAccessor(
+			IPreferenceStoreAccess preferenceStoreAccessor) {
+		this.preferenceStoreAccessor = preferenceStoreAccessor;
+	}
+
+	public IPreferenceStoreAccess getPreferenceStoreAccessor() {
+		return preferenceStoreAccessor;
+	}
+
+	public void propertyChange(PropertyChangeEvent event) {
+		if (fReconciler != null
+				&& event.getProperty().contains(".syntaxColorer.tokenStyles")) {
+			textAttributeProvider.propertyChange(event);
+			fReconciler.refresh();
+		}
+	}
+}

--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/XtextStyledTextHighlightingReconciler.java
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/XtextStyledTextHighlightingReconciler.java
@@ -1,0 +1,309 @@
+/**
+ * Copyright (c) 2015 committers of YAKINDU and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * Contributors:
+ * committers of YAKINDU - initial API and implementation
+ *
+*/
+package org.osate.xtext.aadl2.ui.propertyview;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.ITextInputListener;
+import org.eclipse.jface.text.TextAttribute;
+import org.eclipse.jface.text.TextPresentation;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.ui.editor.XtextSourceViewer;
+import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.ui.editor.model.IXtextModelListener;
+import org.eclipse.xtext.ui.editor.syntaxcoloring.AttributedPosition;
+import org.eclipse.xtext.ui.editor.syntaxcoloring.HighlightingPresenter;
+import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightedPositionAcceptor;
+import org.eclipse.xtext.ui.editor.syntaxcoloring.ISemanticHighlightingCalculator;
+import org.eclipse.xtext.ui.editor.syntaxcoloring.ITextAttributeProvider;
+import org.eclipse.xtext.ui.editor.syntaxcoloring.MergingHighlightedPositionAcceptor;
+import org.eclipse.xtext.util.concurrent.IUnitOfWork;
+
+import com.google.inject.Inject;
+
+
+/**
+ * Modified copy of org.eclipse.xtext.ui.editor.syntaxcoloring.HighlightingReconciler
+ */
+class XtextStyledTextHighlightingReconciler implements
+		ITextInputListener, IXtextModelListener, IHighlightedPositionAcceptor {
+
+	@Inject(optional = true)
+	private ISemanticHighlightingCalculator calculator;
+
+	@Inject
+	private ITextAttributeProvider attributeProvider;
+
+	/** The Xtext editor this highlighting reconciler is installed on */
+	private StyledTextXtextAdapter styledTextXtextAdapter;
+	/** The source viewer this highlighting reconciler is installed on */
+	private XtextSourceViewer sourceViewer;
+	/** The highlighting presenter */
+	private HighlightingPresenter presenter;
+
+	/** Background job's added highlighted positions */
+	private final List<AttributedPosition> addedPositions = new ArrayList<AttributedPosition>();
+	/** Background job's removed highlighted positions */
+	private List<AttributedPosition> removedPositions = new ArrayList<AttributedPosition>();
+	/** Number of removed positions */
+	private int removedPositionCount;
+
+	/**
+	 * Reconcile operation lock.
+	 *
+	 * @since 3.2
+	 */
+	private final Object fReconcileLock = new Object();
+	/**
+	 * <code>true</code> if any thread is executing <code>reconcile</code>,
+	 * <code>false</code> otherwise.
+	 *
+	 * @since 3.2
+	 */
+	private boolean reconciling = false;
+
+	/**
+	 * Start reconciling positions.
+	 */
+	private void startReconcilingPositions() {
+		presenter.addAllPositions(removedPositions);
+		removedPositionCount = removedPositions.size();
+	}
+
+	/**
+	 * Reconcile positions based on the AST subtrees
+	 *
+	 * @param subtrees
+	 *            the AST subtrees
+	 */
+	private void reconcilePositions(XtextResource resource) {
+		// for (int i= 0, n= subtrees.length; i < n; i++)
+		// subtrees[i].accept(fCollector);
+		MergingHighlightedPositionAcceptor acceptor = new MergingHighlightedPositionAcceptor(
+				calculator);
+		acceptor.provideHighlightingFor(resource, this);
+		// calculator.provideHighlightingFor(resource, this);
+		List<AttributedPosition> oldPositions = removedPositions;
+		List<AttributedPosition> newPositions = new ArrayList<AttributedPosition>(
+				removedPositionCount);
+		for (int i = 0, n = oldPositions.size(); i < n; i++) {
+			AttributedPosition current = oldPositions.get(i);
+			if (current != null)
+				newPositions.add(current);
+		}
+		removedPositions = newPositions;
+	}
+
+	/**
+	 * Add a position with the given range and highlighting if it does not exist
+	 * already.
+	 *
+	 * @param offset
+	 *            The range offset
+	 * @param length
+	 *            The range length
+	 * @param highlighting
+	 *            The highlighting
+	 */
+	public void addPosition(int offset, int length, String... ids) {
+		TextAttribute highlighting = ids.length == 1 ? attributeProvider
+				.getAttribute(ids[0]) : attributeProvider
+				.getMergedAttributes(ids);
+		boolean isExisting = false;
+		// TODO: use binary search
+		for (int i = 0, n = removedPositions.size(); i < n; i++) {
+			AttributedPosition position = removedPositions.get(i);
+			if (position == null)
+				continue;
+			if (position.isEqual(offset, length, highlighting)) {
+				isExisting = true;
+				removedPositions.set(i, null);
+				removedPositionCount--;
+				break;
+			}
+		}
+
+		if (!isExisting) {
+			AttributedPosition position = presenter.createHighlightedPosition(
+					offset, length, highlighting);
+			addedPositions.add(position);
+		}
+	}
+
+	/**
+	 * Update the presentation.
+	 *
+	 * @param textPresentation
+	 *            the text presentation
+	 * @param addedPositions
+	 *            the added positions
+	 * @param removedPositions
+	 *            the removed positions
+	 */
+	private void updatePresentation(TextPresentation textPresentation,
+			List<AttributedPosition> addedPositions,
+			List<AttributedPosition> removedPositions) {
+		Runnable runnable = presenter.createUpdateRunnable(textPresentation,
+				addedPositions, removedPositions);
+		if (runnable == null)
+			return;
+
+		Display display = Display.getDefault();
+		display.asyncExec(runnable);
+	}
+
+	/**
+	 * Stop reconciling positions.
+	 */
+	private void stopReconcilingPositions() {
+		removedPositions.clear();
+		removedPositionCount = 0;
+		addedPositions.clear();
+	}
+
+	/**
+	 * Install this reconciler on the given editor and presenter.
+	 *
+	 * @param editor
+	 *            the editor
+	 * @param sourceViewer
+	 *            the source viewer
+	 * @param presenter
+	 *            the highlighting presenter
+	 */
+	public void install(StyledTextXtextAdapter xtextStyledText, XtextSourceViewer sourceViewer,
+			HighlightingPresenter presenter) {
+		this.presenter = presenter;
+		this.styledTextXtextAdapter = xtextStyledText;
+		this.sourceViewer = sourceViewer;
+		if (calculator != null) {
+			if (styledTextXtextAdapter.getXtextDocument() != null)
+				styledTextXtextAdapter.getXtextDocument().addModelListener(this);
+
+			sourceViewer.addTextInputListener(this);
+		}
+		refresh();
+	}
+
+	/**
+	 * Uninstall this reconciler from the editor
+	 */
+	public void uninstall() {
+		if (presenter != null)
+			presenter.setCanceled(true);
+
+		if (styledTextXtextAdapter != null) {
+			if (calculator != null) {
+				if (styledTextXtextAdapter.getXtextDocument() != null)
+					styledTextXtextAdapter.getXtextDocument().removeModelListener(this);
+				sourceViewer.removeTextInputListener(this);
+			}
+			styledTextXtextAdapter = null;
+		}
+
+		sourceViewer = null;
+		presenter = null;
+	}
+
+	/*
+	 * @see
+	 * org.eclipse.jface.text.ITextInputListener#inputDocumentAboutToBeChanged
+	 * (org.eclipse.jface.text.IDocument, org.eclipse.jface.text.IDocument)
+	 */
+	public void inputDocumentAboutToBeChanged(IDocument oldInput,
+			IDocument newInput) {
+		if (oldInput != null)
+			((IXtextDocument) oldInput).removeModelListener(this);
+	}
+
+	/*
+	 * @see
+	 * org.eclipse.jface.text.ITextInputListener#inputDocumentChanged(org.eclipse
+	 * .jface.text.IDocument, org.eclipse.jface.text.IDocument)
+	 */
+	public void inputDocumentChanged(IDocument oldInput, IDocument newInput) {
+		if (newInput != null) {
+			refresh();
+			((IXtextDocument) newInput).addModelListener(this);
+		}
+	}
+
+	/**
+	 * Refreshes the highlighting.
+	 */
+	public void refresh() {
+		if (calculator != null) {
+			styledTextXtextAdapter.getXtextDocument().readOnly(
+					new IUnitOfWork.Void<XtextResource>() {
+						@Override
+						public void process(XtextResource state)
+								throws Exception {
+							modelChanged(state);
+						}
+					});
+		} else {
+			Display display = Display.getDefault();
+			display.asyncExec(presenter.createSimpleUpdateRunnable());
+		}
+	}
+
+	public void modelChanged(XtextResource resource) {
+		// ensure at most one thread can be reconciling at any time
+		synchronized (fReconcileLock) {
+			if (reconciling)
+				return;
+			reconciling = true;
+		}
+		final HighlightingPresenter highlightingPresenter = presenter;
+		try {
+			if (highlightingPresenter == null)
+				return;
+
+			highlightingPresenter.setCanceled(false);
+
+			if (highlightingPresenter.isCanceled())
+				return;
+
+			startReconcilingPositions();
+
+			if (!highlightingPresenter.isCanceled()) {
+				reconcilePositions(resource);
+			}
+
+			final TextPresentation[] textPresentation = new TextPresentation[1];
+			if (!highlightingPresenter.isCanceled()) {
+				textPresentation[0] = highlightingPresenter.createPresentation(
+						addedPositions, removedPositions);
+			}
+
+			if (!highlightingPresenter.isCanceled())
+				updatePresentation(textPresentation[0], addedPositions,
+						removedPositions);
+
+			stopReconcilingPositions();
+		} finally {
+			synchronized (fReconcileLock) {
+				reconciling = false;
+			}
+		}
+	}
+
+	public void setCalculator(ISemanticHighlightingCalculator calculator) {
+		this.calculator = calculator;
+	}
+
+	public ISemanticHighlightingCalculator getCalculator() {
+		return calculator;
+	}
+}

--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/XtextStyledTextSelectionProvider.java
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/propertyview/XtextStyledTextSelectionProvider.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2018 committers of YAKINDU and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * Contributors:
+ * committers of YAKINDU - initial API and implementation
+ *
+*/
+package org.osate.xtext.aadl2.ui.propertyview;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.ISelectionChangedListener;
+import org.eclipse.jface.viewers.ISelectionProvider;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.xtext.nodemodel.ICompositeNode;
+import org.eclipse.xtext.nodemodel.ILeafNode;
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.eclipse.xtext.parser.IParseResult;
+import org.eclipse.xtext.resource.XtextResource;
+
+
+public class XtextStyledTextSelectionProvider implements ISelectionProvider {
+
+	private StyledText styledText;
+	private XtextResource xtextResource;
+
+	public XtextStyledTextSelectionProvider(StyledText styledText, XtextResource xtextResource) {
+		this.styledText = styledText;
+		this.xtextResource = xtextResource;
+	}
+
+	public void setSelection(ISelection selection) {
+	}
+
+	public void removeSelectionChangedListener(ISelectionChangedListener listener) {
+	}
+
+	public void addSelectionChangedListener(ISelectionChangedListener listener) {
+	}
+
+	public ISelection getSelection() {
+		if (styledText.isDisposed())
+			return StructuredSelection.EMPTY;
+		int offset = Math.max(styledText.getCaretOffset() - 1, 0);
+		XtextResource fakeResource = xtextResource;
+		IParseResult parseResult = fakeResource.getParseResult();
+		if (parseResult == null)
+			return StructuredSelection.EMPTY;
+		ICompositeNode rootNode = parseResult.getRootNode();
+		ILeafNode selectedNode = NodeModelUtils.findLeafNodeAtOffset(rootNode, offset);
+		final EObject selectedObject = NodeModelUtils.findActualSemanticObjectFor(selectedNode);
+		if (selectedObject == null) {
+			return StructuredSelection.EMPTY;
+		}
+		return new StructuredSelection(selectedObject);
+	}
+}

--- a/ge/org.osate.ge.ba/META-INF/MANIFEST.MF
+++ b/ge/org.osate.ge.ba/META-INF/MANIFEST.MF
@@ -11,7 +11,6 @@ Require-Bundle: org.osate.ge;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.xtext.ui;bundle-version="[2.20.0,3.0.0)",
  org.eclipse.core.expressions;bundle-version="[3.6.0,4.0.0)",
  org.osate.xtext.aadl2.ui;bundle-version="[9.0.0,10.0.0)",
- org.yakindu.base.xtext.utils.jface;bundle-version="[3.5.9,4.0.0)",
  org.eclipse.emf.transaction;bundle-version="[1.4.0,2.0.0)",
  org.osate.ui;bundle-version="[6.5.0,7.0.0)"
 Automatic-Module-Name: org.osate.ge.ba

--- a/ge/org.osate.ge.ba/src/org/osate/ge/ba/ui/EmbeddedStyledTextXtextAdapter.java
+++ b/ge/org.osate.ge.ba/src/org/osate/ge/ba/ui/EmbeddedStyledTextXtextAdapter.java
@@ -37,8 +37,8 @@ import org.eclipse.xtext.ui.editor.model.XtextDocument;
 import org.osate.ge.ba.ui.properties.EditableEmbeddedTextValue;
 import org.osate.ge.ba.util.BehaviorAnnexXtextUtil;
 import org.osate.xtext.aadl2.ui.internal.Aadl2Activator;
+import org.osate.xtext.aadl2.ui.propertyview.IXtextFakeContextResourcesProvider;
 import org.osate.xtext.aadl2.ui.propertyview.OsateStyledTextXtextAdapter;
-import org.yakindu.base.xtext.utils.jface.viewers.context.IXtextFakeContextResourcesProvider;
 
 import com.google.inject.Injector;
 

--- a/releng/org.osate.build.repository/category.xml
+++ b/releng/org.osate.build.repository/category.xml
@@ -92,7 +92,6 @@ censes only apply to the Third Party Software and not any other portion of this 
    <repository-reference location="https://download.eclipse.org/xsemantics/milestones/1.24" name="" enabled="true" />
    <repository-reference location="https://download.eclipse.org/elk/updates/releases/0.9.1" name="" enabled="true" />
    <repository-reference location="https://osate-build.sei.cmu.edu/p2/py4j" name="" enabled="true" />
-   <repository-reference location="https://updates.yakindu.com/statecharts/releases/3.5.9" name="" enabled="true" />
    <repository-reference location="https://download.eclipse.org/ease/integration/nightly/" name="" enabled="true" />
    <repository-reference location="https://download.eclipse.org/justj/jres/21/updates/release/latest" name="" enabled="true" />
    <repository-reference location="https://downloads.efxclipse.bestsolution.at/p2-repos/openjfx-17.0.2" name="" enabled="true" />

--- a/releng/org.osate.build.target/osate2-platform.target
+++ b/releng/org.osate.build.target/osate2-platform.target
@@ -69,10 +69,6 @@
       <repository location="https://osate-build.sei.cmu.edu/p2/py4j"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-      <unit id="org.yakindu.base.xtext.utils.jface" version="0.0.0"/>
-      <repository location="https://updates.yakindu.com/statecharts/releases/3.5.9"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
     	<unit id="openjfx.standard.feature.feature.group" version="0.0.0"/>
     	<unit id="openjfx.swing.feature.feature.group" version="0.0.0"/>
     	<unit id="openjfx.swt.feature.feature.group" version="0.0.0"/>

--- a/releng/osate.releng/OSATE2 small fonts.launch
+++ b/releng/osate.releng/OSATE2 small fonts.launch
@@ -454,7 +454,6 @@
         <setEntry value="org.osgi.util.function@default:default"/>
         <setEntry value="org.osgi.util.promise@default:default"/>
         <setEntry value="org.tukaani.xz@default:default"/>
-        <setEntry value="org.yakindu.base.xtext.utils.jface@default:default"/>
         <setEntry value="slf4j.api@default:default"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">

--- a/releng/osate.releng/OSATE2.launch
+++ b/releng/osate.releng/OSATE2.launch
@@ -687,7 +687,6 @@
         <setEntry value="org.sat4j.core@default:default"/>
         <setEntry value="org.sat4j.pb@default:default"/>
         <setEntry value="org.tukaani.xz@default:default"/>
-        <setEntry value="org.yakindu.base.xtext.utils.jface@default:default"/>
         <setEntry value="py4j-java@default:default"/>
         <setEntry value="py4j-python@default:default"/>
         <setEntry value="slf4j.api@default:default"/>

--- a/releng/osate.releng/seisettings.xml
+++ b/releng/osate.releng/seisettings.xml
@@ -117,22 +117,6 @@ censes only apply to the Third Party Software and not any other portion of this 
     </mirror>
 
     <mirror>
-      <id>yakindu-mirror</id>
-      <mirrorOf>http://updates.yakindu.com/statecharts/releases/3.5.9</mirrorOf>
-      <url>file:/var/cache/p2mirror/current/yakindu</url>
-      <layout>p2</layout>
-      <mirrorOfLayouts>p2</mirrorOfLayouts>
-    </mirror>
-
-    <mirror>
-      <id>yakindu-mirror1</id>
-      <mirrorOf>https://updates.yakindu.com/statecharts/releases/3.5.9</mirrorOf>
-      <url>file:/var/cache/p2mirror/current/yakindu</url>
-      <layout>p2</layout>
-      <mirrorOfLayouts>p2</mirrorOfLayouts>
-    </mirror>
-
-    <mirror>
       <id>openjfx-17-mirror</id>
       <mirrorOf>https://downloads.efxclipse.bestsolution.at/p2-repos/openjfx-17.0.2</mirrorOf>
       <url>file:/var/cache/p2mirror/current/openjfx-17.0.2</url>

--- a/releng/scripts/p2mirror.ant.xml
+++ b/releng/scripts/p2mirror.ant.xml
@@ -181,11 +181,6 @@ Run with
             <iu id="com.rockwellcollins.atc.resolute.feature.feature.group"/>
         </p2.mirror-->
 
-        <p2.mirror source="http://updates.yakindu.com/statecharts/releases/3.5.13">
-            <destination location="${target.dir}/yakindu"/>
-            <iu id="org.yakindu.base.xtext.utils.jface"/>
-        </p2.mirror>
-
         <p2.mirror source="http://download.eclipse.org/technology/swtbot/releases/latest">
             <destination location="${target.dir}/technology/swtbot/releases/latest"/>
         </p2.mirror>

--- a/setup/osate2_2025-12.setup
+++ b/setup/osate2_2025-12.setup
@@ -934,8 +934,6 @@
       <requirement
           name="org.junit.jupiter.api"/>
       <requirement
-          name="org.yakindu.base.xtext.utils.jface"/>
-      <requirement
           name="*"/>
       <sourceLocator
           rootFolder="${git.clone.osate2.location}"/>
@@ -959,8 +957,6 @@
             url="https://xtexttools.libutzki.de/"/>
         <repository
             url="https://osate-build.sei.cmu.edu/p2/py4j"/>
-        <repository
-            url="https://updates.yakindu.com/statecharts/releases/3.5.9"/>
         <repository
             url="https://downloads.efxclipse.bestsolution.at/p2-repos/openjfx-17.0.2"/>
         <repository


### PR DESCRIPTION
Fixes #3064

## Cause and correction

OSATE depends on the small Yakindu JFace/Xtext editor integration bundle, but its upstream p2 repository is no longer available. This vendors the 13 classes used by the AADL property editor and graphical Behavior Annex editor into `org.osate.xtext.aadl2.ui`, while retaining the existing OSATE-specific wrappers.

The Yakindu bundle requirement and repository are removed from the current target platform, core feature, build repository metadata, p2 mirror configuration, launch configurations, SEI settings, and the `2025-12` Oomph setup. Historical Oomph setups are intentionally unchanged.

## Source provenance

The vendored implementation comes from `itemisCREATE/statecharts` release `3.5.9`, with the disposed-widget guard from release `3.5.13` in `StyledTextCellEditor`. The upstream EPL-1.0 copyright and license headers are preserved.

## Validation

- Targeted offline build without tests:
  `mvn -o -s releng/osate.releng/settings.xml -Plocal -pl :org.osate.xtext.aadl2.ui,:org.osate.core.feature,:org.osate.ge.ba,:org.osate.ge.ba.feature -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -DskipTests clean install`
- Clean full 137-module root reactor with existing tests:
  `mvn -s releng/osate.releng/settings.xml -Plocal -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -DfailIfNoTests=false clean install`
- Full reactor result: `BUILD SUCCESS` in 4:51.

## Residual risk

No new regression test was added per request. The editor integration is validated by compilation, the targeted bundle build, and the complete existing reactor test suite.

Dependencies: none.