### PR TITLE
Take the feature category from the prototype actual 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
@@ -53,8 +53,8 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.transaction.RollbackException;
+import org.osate.aadl2.AbstractFeature;
 import org.osate.aadl2.Access;
-import org.osate.aadl2.AccessCategory;
 import org.osate.aadl2.AccessSpecification;
 import org.osate.aadl2.AccessType;
 import org.osate.aadl2.ArrayDimension;
@@ -75,7 +75,6 @@ import org.osate.aadl2.Feature;
 import org.osate.aadl2.FeatureClassifier;
 import org.osate.aadl2.FeatureGroup;
 import org.osate.aadl2.FeatureGroupType;
-import org.osate.aadl2.FeaturePrototype;
 import org.osate.aadl2.FeaturePrototypeActual;
 import org.osate.aadl2.FeatureType;
 import org.osate.aadl2.FlowEnd;
@@ -89,7 +88,6 @@ import org.osate.aadl2.ModeTransition;
 import org.osate.aadl2.ModeTransitionTrigger;
 import org.osate.aadl2.NamedValue;
 import org.osate.aadl2.Port;
-import org.osate.aadl2.PortCategory;
 import org.osate.aadl2.PortSpecification;
 import org.osate.aadl2.Property;
 import org.osate.aadl2.PropertyAssociation;
@@ -1187,46 +1185,19 @@ public class InstantiateModel {
 			throws InterruptedException {
 		fi.setIndex(index);
 
-		// resolve feature prototype
-		if (feature.getPrototype() instanceof FeaturePrototype) {
-			FeaturePrototypeActual fpa = resolveFeaturePrototype(feature.getPrototype(), fi);
-
-			if (fpa instanceof AccessSpecification) {
-				AccessCategory ac = ((AccessSpecification) fpa).getCategory();
-
-				switch (ac) {
-				case BUS:
-					fi.setCategory(FeatureCategory.BUS_ACCESS);
-					break;
-				case DATA:
-					fi.setCategory(FeatureCategory.DATA_ACCESS);
-					break;
-				case SUBPROGRAM:
-					fi.setCategory(FeatureCategory.SUBPROGRAM_ACCESS);
-					break;
-				case SUBPROGRAM_GROUP:
-					fi.setCategory(FeatureCategory.SUBPROGRAM_GROUP_ACCESS);
-					break;
-				default:
-					;
-				}
-			} else if (fpa instanceof PortSpecification) {
-				PortCategory pc = ((PortSpecification) fpa).getCategory();
-
-				switch (pc) {
-				case DATA:
-					fi.setCategory(FeatureCategory.DATA_PORT);
-					break;
-				case EVENT:
-					fi.setCategory(FeatureCategory.EVENT_PORT);
-					break;
-				case EVENT_DATA:
-					fi.setCategory(FeatureCategory.EVENT_DATA_PORT);
-					break;
-				default:
-					;
-				}
-			}
+		/*
+		 * A feature that is declared with a feature prototype takes its category from the actual the
+		 * prototype is bound to. The prototype is reached through AbstractFeature. Feature.getPrototype()
+		 * is not the way there: it is declared to return a ComponentPrototype, which a FeaturePrototype
+		 * never is, and it is null for this shape.
+		 */
+		FeatureCategory prototypeCategory = null;
+		if (feature instanceof AbstractFeature af && af.getFeaturePrototype() != null) {
+			prototypeCategory = featureCategory(
+					InstanceUtil.resolveFeaturePrototype(af.getFeaturePrototype(), fi, classifierCache));
+		}
+		if (prototypeCategory != null) {
+			fi.setCategory(prototypeCategory);
 		} else {
 			fi.setCategory(feature);
 		}
@@ -1244,6 +1215,33 @@ public class InstantiateModel {
 				instantiateFeatureClassifier(fi, fc);
 			}
 		}
+	}
+
+	/**
+	 * The feature category determined by a feature prototype actual, or {@code null} if the actual does
+	 * not determine one. Null also covers a prototype that is not bound in this context, in which case
+	 * the category comes from the feature declaration.
+	 * <p>
+	 * A virtual bus access becomes a bus access, which is what a feature declared as a virtual bus
+	 * access instantiates to as well, because {@link FeatureCategory} has no separate literal for it.
+	 */
+	private static FeatureCategory featureCategory(FeaturePrototypeActual actual) {
+		if (actual instanceof AccessSpecification access) {
+			return switch (access.getCategory()) {
+			case BUS, VIRTUAL_BUS -> FeatureCategory.BUS_ACCESS;
+			case DATA -> FeatureCategory.DATA_ACCESS;
+			case SUBPROGRAM -> FeatureCategory.SUBPROGRAM_ACCESS;
+			case SUBPROGRAM_GROUP -> FeatureCategory.SUBPROGRAM_GROUP_ACCESS;
+			};
+		}
+		if (actual instanceof PortSpecification port) {
+			return switch (port.getCategory()) {
+			case DATA -> FeatureCategory.DATA_PORT;
+			case EVENT -> FeatureCategory.EVENT_PORT;
+			case EVENT_DATA -> FeatureCategory.EVENT_DATA_PORT;
+			};
+		}
+		return null;
 	}
 
 	/*

--- a/core/org.osate.core.tests/models/issue3067/.gitignore
+++ b/core/org.osate.core.tests/models/issue3067/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3067/.project
+++ b/core/org.osate.core.tests/models/issue3067/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3067</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3067/Issue3067.aadl
+++ b/core/org.osate.core.tests/models/issue3067/Issue3067.aadl
@@ -1,0 +1,20 @@
+package Issue3067
+public
+	-- The feature f is declared with a feature prototype rather than with a feature classifier. The
+	-- prototype binding on the subcomponent below says the feature is an incoming data port, so the
+	-- feature instance of f must have the category of a data port.
+	abstract A
+	prototypes
+		fp: in feature;
+	features
+		f: in prototype fp;
+	end A;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+	subcomponents
+		sub: abstract A (fp => in data port);
+	end Top.i;
+end Issue3067;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3067Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3067Test.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instance.FeatureCategory;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3067Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3067/Issue3067.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	/**
+	 * The feature is declared with a feature prototype, and the subcomponent binds that prototype to
+	 * {@code in data port}. The category of the feature instance therefore has to be that of a data port.
+	 * <p>
+	 * Instantiation instead reports the category of an abstract feature, because the branch of
+	 * {@code InstantiateModel.filloutFeatureInstance()} that resolves a feature prototype is guarded by
+	 * {@code feature.getPrototype() instanceof FeaturePrototype}. {@code Feature.getPrototype()} yields a
+	 * {@code ComponentPrototype}, which a {@code FeaturePrototype} never is, so the guard never holds and
+	 * the category falls back to the declarative metaclass of the feature. The feature prototype of an
+	 * abstract feature is reached through {@code AbstractFeature.getFeaturePrototype()} instead.
+	 */
+	@Test
+	public void featurePrototypeDeterminesFeatureInstanceCategory() throws Exception {
+		var pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+		var top = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+
+		var instance = InstantiateModel.instantiate(top);
+
+		var sub = instance.getComponentInstances()
+				.stream()
+				.filter(componentInstance -> componentInstance.getName().equals("sub"))
+				.findFirst()
+				.orElseThrow();
+		var feature = sub.getFeatureInstances()
+				.stream()
+				.filter(featureInstance -> featureInstance.getName().equals("f"))
+				.findFirst()
+				.orElseThrow();
+		assertEquals(FeatureCategory.DATA_PORT, feature.getCategory());
+	}
+}


### PR DESCRIPTION
Fixes #3067.

## Problem

A feature declared with a feature prototype was instantiated as an abstract feature no matter what the prototype was bound to. `filloutFeatureInstance()` has a branch that maps the resolved prototype actual to a feature category, guarded by

```java
if (feature.getPrototype() instanceof FeaturePrototype) {
```

`Feature.getPrototype()` is declared to return a `ComponentPrototype`, and no `FeaturePrototype` is one — `FeaturePrototype extends Prototype`, and `FeaturePrototypeImpl` is the only class implementing it. The guard could never hold, so ~40 lines were unreachable and the category always came from the declarative metaclass of the feature.

## Change

Two commits:

1. **`Add regression test for issue #3067`** — `Issue3067Test` plus the `issue3067` model project. On the first commit alone it fails with `expected:<dataPort> but was:<abstractFeature>`.
2. **`Take the feature category from the prototype actual`** — the fix.

The prototype is now reached through `AbstractFeature.getFeaturePrototype()`, the reference the grammar fills in for `f: in prototype fp`. `Feature.getPrototype()` answers the other shape, `f: feature dt` with a *component* prototype, whose classifier `instantiateFeatureClassifier()` already handles.

The actual-to-category mapping moved into one small method with two exhaustive switch expressions, so a new `AccessCategory` or `PortCategory` literal is a compile error instead of a silent no-op. The previous `default: ;` arms dropped `AccessCategory.VIRTUAL_BUS` on the floor; it now yields `BUS_ACCESS`, which is what a feature declared as a virtual bus access instantiates to as well, since `FeatureCategory` has no separate literal for it (a virtual bus access is a `BusAccess` with `virtual=true`, and `FeatureInstanceImpl.setCategory(Feature)` maps it that way).

## Deliberately not included

- **No diagnostic for an unbound prototype.** An actual that determines no category — including a prototype not bound in this context — keeps the category of the feature declaration, exactly as before. Reporting it would add diagnostics to existing models; #3067 raises it as a separate question.
- **`resolveFeaturePrototype()` left alone.** Both overloads take a `ComponentPrototype`, so they cannot carry a feature prototype, and widening the parameter would break API against the 2.18.0 baseline. The fix calls `InstanceUtil.resolveFeaturePrototype()` directly. Those wrappers have no reachable caller; #3066 covers the dead `protected` members of this class.
- **No refinement walk.** There is no `getAllFeaturePrototype()`; a refined abstract feature that inherits its prototype from the feature it refines is not handled, and nothing here tests that shape.

## Testing

```
mvn -o -s releng/osate.releng/settings.xml -Plocal -pl :org.osate.aadl2.instantiation,:org.osate.core.feature,:org.osate.core.tests \
  -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
  -DfailIfNoTests=false clean install
```

`Issue3067Test` passes with the fix and fails without it. The full `org.osate.core.tests` suite is green: **578 tests, 0 failures, 0 errors**.

One note on that number, in case it differs from a local run: a suite run without `clean` picked up stale compiled test classes from other branches in `target/classes` (17 `Issue3037*Test` classes and one `Issue3068Test`) whose fixtures do not exist on this branch, producing 55 bogus failures. The clean run above is the real result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
