### PR TITLE
Report an unsupported connection pattern 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
@@ -1766,6 +1766,15 @@ public class InstantiateModel {
 						dstIndices.remove(dstOffset);
 						srcIndices.remove(srcOffset);
 					}
+				} else {
+					/*
+					 * A pattern this method does not know expands into nothing. Report it and keep the
+					 * connection: returning the initial true would tell the caller that the connection was
+					 * expanded, and the caller would delete it without a replacement.
+					 */
+					errManager.error(conni, "Unsupported connection pattern '" + patternName + "' on connection "
+							+ conni.getFullName());
+					return false;
 				}
 			}
 		}

--- a/core/org.osate.core.tests/models/issue3068/.gitignore
+++ b/core/org.osate.core.tests/models/issue3068/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3068/.project
+++ b/core/org.osate.core.tests/models/issue3068/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3068</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3068/ExtraPatterns.aadl
+++ b/core/org.osate.core.tests/models/issue3068/ExtraPatterns.aadl
@@ -1,0 +1,8 @@
+-- Supplies an enumeration literal that is not one of the fourteen literals of
+-- AADL_Project::Supported_Connection_Patterns. A project may extend that enumeration, which is
+-- how a Connection_Pattern value with an unknown literal name reaches instantiation. The literal
+-- lives in its own property set here because the predeclared property sets that the test harness
+-- loads are the plugin-contributed ones, which a test project cannot override.
+property set ExtraPatterns is
+	Project_Specific_Patterns: type enumeration (Even_To_Odd);
+end ExtraPatterns;

--- a/core/org.osate.core.tests/models/issue3068/Issue3068.aadl
+++ b/core/org.osate.core.tests/models/issue3068/Issue3068.aadl
@@ -1,0 +1,28 @@
+package Issue3068
+public
+	thread Producer
+	features
+		outp: out data port;
+	end Producer;
+
+	thread Consumer
+	features
+		inp: in data port;
+	end Consumer;
+
+	process Top
+	end Top;
+
+	-- The connection carries a legal Connection_Pattern so that the model validates. The test replaces
+	-- the enumeration literal of that pattern with a literal the instantiator does not know, which is
+	-- what a project that extends AADL_Project::Supported_Connection_Patterns produces.
+	process implementation Top.i
+	subcomponents
+		producers: thread Producer[2];
+		consumers: thread Consumer[2];
+	connections
+		c: port producers.outp -> consumers.inp {
+			Communication_Properties::Connection_Pattern => ((One_To_One));
+		};
+	end Top.i;
+end Issue3068;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3068Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3068Test.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.EnumerationLiteral;
+import org.osate.aadl2.EnumerationType;
+import org.osate.aadl2.ListValue;
+import org.osate.aadl2.NamedValue;
+import org.osate.aadl2.PropertySet;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3068Test extends XtextTest {
+	private static final String PATH = "org.osate.core.tests/models/issue3068/";
+	private static final String MODEL = PATH + "Issue3068.aadl";
+	private static final String EXTRA_PATTERNS = PATH + "ExtraPatterns.aadl";
+
+	private static final String UNSUPPORTED_PATTERN = "Even_To_Odd";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	/**
+	 * A {@code Connection_Pattern} literal that the instantiator does not know must be reported. Today
+	 * {@code InstantiateModel.interpretConnectionPatterns()} compares the literal name against fourteen
+	 * hard-coded names; when none matches it falls off the end of the chain and returns its initial
+	 * {@code true}, which the caller reads as "the connection was expanded". The provisional connection
+	 * instance is then deleted while nothing was created in its place, and no diagnostic is produced.
+	 * <p>
+	 * The literal comes from a separate property set rather than from
+	 * {@code AADL_Project::Supported_Connection_Patterns}, and it is put in place after validation. Both
+	 * are deliberate. All fourteen predeclared literals are handled, so the only way to reach this path
+	 * is a project that extends that enumeration, and the test harness loads the plugin-contributed
+	 * predeclared property sets, which a test model project cannot override. Substituting the literal on
+	 * the parsed model reproduces exactly what such a project would hand to instantiation: a
+	 * {@code NamedValue} whose {@code EnumerationLiteral} has a name the chain does not match.
+	 */
+	@Test
+	public void unsupportedConnectionPatternIsReported() throws Exception {
+		var pkg = testHelper.parseFile(MODEL, EXTRA_PATTERNS);
+		validationHelper.assertNoIssues(pkg);
+		var top = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		substitutePatternLiteral(top, unsupportedLiteral(pkg));
+		var errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+
+		var instance = InstantiateModel.instantiate(top, errorManager);
+
+		var messages = ((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource())).getErrors()
+				.stream()
+				.map(message -> message.message)
+				.toList();
+		assertTrue("Instantiation reported nothing about the unsupported connection pattern: " + messages,
+				messages.stream().anyMatch(message -> message.contains(UNSUPPORTED_PATTERN)));
+	}
+
+	/**
+	 * Returns the literal of {@code ExtraPatterns}, which stands in for a literal added to
+	 * {@code AADL_Project::Supported_Connection_Patterns} by a project.
+	 */
+	private EnumerationLiteral unsupportedLiteral(AadlPackage pkg) {
+		var extraPatterns = pkg.eResource()
+				.getResourceSet()
+				.getResources()
+				.stream()
+				.flatMap(resource -> resource.getContents().stream())
+				.filter(PropertySet.class::isInstance)
+				.map(PropertySet.class::cast)
+				.filter(propertySet -> propertySet.getName().equals("ExtraPatterns"))
+				.findFirst()
+				.orElseThrow();
+		var literal = ((EnumerationType) extraPatterns.getOwnedPropertyTypes().get(0)).getOwnedLiterals().get(0);
+		assertEquals("The fixture no longer supplies the unsupported literal", UNSUPPORTED_PATTERN, literal.getName());
+		return literal;
+	}
+
+	/**
+	 * Replaces the enumeration literal of the connection's {@code Connection_Pattern} value, leaving the
+	 * property association, its value structure and its property reference as they were parsed.
+	 */
+	private void substitutePatternLiteral(ComponentImplementation top, EnumerationLiteral literal) {
+		var connection = top.getOwnedConnections()
+				.stream()
+				.filter(owned -> owned.getName().equals("c"))
+				.findFirst()
+				.orElseThrow();
+		var pattern = (ListValue) connection.getOwnedPropertyAssociations()
+				.get(0)
+				.getOwnedValues()
+				.get(0)
+				.getOwnedValue();
+		var dimension = (ListValue) pattern.getOwnedListElements().get(0);
+		((NamedValue) dimension.getOwnedListElements().get(0)).setNamedValue(literal);
+	}
+}


### PR DESCRIPTION
Fixes #3068.

## Problem

`interpretConnectionPatterns()` compares the name of the `Connection_Pattern` literal against fourteen hard-coded names through a chain of `equalsIgnoreCase`. A name matching none of them fell off the end of the chain and returned `result`, still its initial `true`, which `processConnections()` reads as "the connection was expanded":

```java
if (interpretConnectionPatterns(conni, isOpposite, pattern, ...)) {
    toRemove.add(conni);
}
...
for (ConnectionInstance conni : toRemove) {
    EcoreUtil.delete(conni);
}
```

So the provisional connection instance was deleted while nothing had been created in its place — the connection vanished from the instance model with no diagnostic. Every other failure path in that method reports through `errManager` and returns `false`, which keeps the connection. Only this one was silent, which is the worst available failure mode: downstream analyses see a model where the connection simply does not exist.

## Change

Two commits:

1. **`Add regression test for issue #3068`** — `Issue3068Test` plus the `issue3068` model project. On the first commit alone it fails with `Instantiation reported nothing about the unsupported connection pattern: []`.
2. **`Report an unsupported connection pattern`** — a trailing `else` that reports the literal and returns `false`.

## Scope

This is deliberately the *small* fix. The real one is step 5 of #3066, which replaces the whole chain with an exhaustive dispatch over an enum and subsumes this arm. Doing it here would mean doing that rewrite here.

The reason to land the small version first: that rewrite is the riskiest item in #3066 — fourteen arms of index arithmetic in a bundle with no unit tests of its own — and it is much better to start it with `Issue3068Test` green than red. A red test cannot distinguish "still broken" from "newly broken". The test asserts only that some diagnostic names the literal, not its wording, so it survives the rewrite rephrasing the message.

Two limits worth stating:

- An unknown pattern whose array sizes also disagree still reports the size mismatch first, since that check precedes the chain. Something is reported either way, which is the point.
- All fourteen literals of the predeclared `AADL_Project::Supported_Connection_Patterns` are handled, so only a project that extends that enumeration — legal AADL, since `AADL_Project` is the project-configurable property set — reaches this arm.

## How the test reaches the path

`Issue3068.aadl` connects two arrays of size 2 under a legal `Connection_Pattern => ((One_To_One))`, so the model validates. After validation the test swaps only the `EnumerationLiteral` that the value's `NamedValue` points at, for one declared in `ExtraPatterns.aadl`.

Both details are deliberate, and the test's Javadoc says so. The literal cannot come from `Supported_Connection_Patterns`, because every predeclared literal is handled. And it cannot come from a project-local override of the predeclared property sets, because `TestResourceSetHelper` loads the plugin-contributed ones into a resource set that is `static` and shared across the suite — mutating the contributed enumeration there would leak into every other test. Everything else (the property association, its nested list values, the reference to `Communication_Properties::Connection_Pattern`) is as parsed, so the only difference from a project-extended enumeration is where the literal is declared. `interpretConnectionPatterns` and `processConnections` are both `private`, so there is no overridable boundary closer to the defect.

## Testing

```
mvn -o -s releng/osate.releng/settings.xml -Plocal -pl :org.osate.aadl2.instantiation,:org.osate.core.feature,:org.osate.core.tests \
  -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
  -DfailIfNoTests=false clean install
```

`Issue3068Test` passes with the fix and fails without it. The full `org.osate.core.tests` suite is green: **578 tests, 0 failures, 0 errors**.

## Related

`CommunicationProperties.getConnectionPattern()` in `org.osate.aadl2.contrib` resolves values through `SupportedConnectionPatterns.valueOf(...)`, a generated Java enum of the same fourteen literals, so it would throw on the same input. Untouched here — different code path, and worth its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
