### PR TITLE
Update Sirius to 7.6.0

### DIFF
--- a/releng/org.osate.build.target/osate2-platform.target
+++ b/releng/org.osate.build.target/osate2-platform.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target includeMode="feature" name="osate2-platform" sequenceNumber="29">
+<target includeMode="feature" name="osate2-platform" sequenceNumber="30">
   <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="org.eclipse.egit.feature.group" version="0.0.0"/>
@@ -13,12 +13,16 @@
       <unit id="org.eclipse.m2e.logback.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.mylyn.context.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.sirius.common.acceleo.aql" version="0.0.0"/>
-      <unit id="org.eclipse.sirius.runtime.ide.ui.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.uml2.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.zest.feature.group" version="0.0.0"/>
       <unit id="junit-jupiter-api" version="0.0.0"/>
       <repository location="https://download.eclipse.org/releases/2025-12"/>
+    </location>
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+      <unit id="org.eclipse.sirius.common.acceleo.aql" version="0.0.0"/>
+      <unit id="org.eclipse.sirius.runtime.ide.ui.feature.group" version="0.0.0"/>
+      <repository location="https://download.eclipse.org/sirius/updates/releases/7.6.0/2025-09"/>
+      <repository location="https://download.eclipse.org/acceleo/updates/releases/4.2/R202603201315"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="org.apache.commons.io" version="0.0.0"/>

--- a/releng/scripts/p2mirror.ant.xml
+++ b/releng/scripts/p2mirror.ant.xml
@@ -56,13 +56,30 @@ Run with
             <iu id="org.eclipse.platform.feature.group"/>
             <iu id="org.eclipse.rcp.feature.group"/>
             <iu id="org.eclipse.sdk.feature.group"/>
-            <iu id="org.eclipse.sirius.common.acceleo.aql"/>
-            <iu id="org.eclipse.sirius.runtime.ide.ui.feature.group"/>
             <iu id="org.eclipse.uml2.feature.group"/>
             <iu id="org.eclipse.zest.feature.group"/>
     		<iu id="org.hamcrest.library"/>
             <iu id="org.eclipse.mylyn.context.feature.feature.group"/>
     		<iu id="junit-jupiter-api"/>
+        </p2.mirror>
+
+        <p2.mirror>
+            <source>
+                <repository location="http://download.eclipse.org/sirius/updates/releases/7.6.0/2025-09"/>
+            </source>
+            <destination location="${target.dir}/sirius/updates/releases/7.6.0/2025-09"/>
+            <iu id="org.eclipse.sirius.common.acceleo.aql"/>
+            <iu id="org.eclipse.sirius.runtime.ide.ui.feature.group"/>
+        </p2.mirror>
+
+        <p2.mirror>
+            <source>
+                <repository location="http://download.eclipse.org/acceleo/updates/releases/4.2/R202603201315"/>
+            </source>
+            <destination location="${target.dir}/acceleo/updates/releases/4.2/R202603201315"/>
+            <iu id="org.eclipse.acceleo.query"/>
+            <iu id="org.eclipse.acceleo.annotations"/>
+            <iu id="org.antlr.antlr4-runtime"/>
         </p2.mirror>
 
     	<p2.mirror>

--- a/setup/osate2_2025-12.setup
+++ b/setup/osate2_2025-12.setup
@@ -480,8 +480,6 @@
     <requirement
         name="org.eclipse.sirius.runtime.feature.group"/>
     <requirement
-        name="org.eclipse.sirius.runtime.ide.ui.acceleo.feature.group"/>
-    <requirement
         name="org.eclipse.sirius.runtime.ide.xtext.feature.group"/>
     <requirement
         name="org.eclipse.sirius.properties.feature.feature.group"/>
@@ -492,23 +490,15 @@
     <requirement
         name="org.eclipse.sirius.runtime.ide.ui.feature.group"/>
     <requirement
-        name="org.eclipse.sirius.runtime.acceleo.feature.group"/>
-    <requirement
         name="org.eclipse.sirius.runtime.aql.feature.group"/>
     <requirement
-        name="org.eclipse.sirius.runtime.ocl.feature.group"/>
-    <requirement
         name="org.eclipse.sirius.samples.feature.group"/>
-    <requirement
-        name="org.eclipse.sirius.specifier.ide.ui.acceleo.feature.group"/>
     <requirement
         name="org.eclipse.sirius.specifier.ide.ui.aql.feature.group"/>
     <requirement
         name="org.eclipse.sirius.specifier.ide.ui.feature.group"/>
     <requirement
         name="org.eclipse.sirius.tests.support.feature.group"/>
-    <requirement
-        name="org.eclipse.acceleo.ui.interpreter.feature.group"/>
     <requirement
         name="org.eclipse.acceleo.query.feature.group"/>
     <requirement
@@ -518,7 +508,9 @@
     <repository
         url="https://download.eclipse.org/releases/${eclipse.target.platform}"/>
     <repository
-        url="https://download.eclipse.org/sirius/updates/releases/7.4.10/2023-03"/>
+        url="https://download.eclipse.org/sirius/updates/releases/7.6.0/2025-09"/>
+    <repository
+        url="https://download.eclipse.org/acceleo/updates/releases/4.2/R202603201315"/>
     <repository
         url="https://download.eclipse.org/emfstore/releases_19/190"/>
   </setupTask>
@@ -944,7 +936,9 @@
         <repository
             url="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.39.0"/>
         <repository
-            url="https://download.eclipse.org/sirius/updates/releases/7.4.10/2023-03"/>
+            url="https://download.eclipse.org/sirius/updates/releases/7.6.0/2025-09"/>
+        <repository
+            url="https://download.eclipse.org/acceleo/updates/releases/4.2/R202603201315"/>
         <repository
             url="https://download.eclipse.org/ease/integration/nightly"/>
         <repository


### PR DESCRIPTION
The target platform took Sirius from the 2025-12 simultaneous release, which ships 7.4.14. Move the two Sirius units into their own location pointing at the 7.6.0 release site.

Sirius 7.6.0 requires org.eclipse.acceleo.query 8.1.0 or later, while 2025-12 only provides 7.0.0. The Sirius site contains acceleo.query 8.1.0 but not the org.antlr.antlr4-runtime 4.13.2 it needs, so add the Acceleo 4.2 site as well. Resolution then picks acceleo.query 8.1.2, acceleo.annotations 8.1.2, and antlr4-runtime 4.13.2 from that site.

Update the Oomph setup for 2025-12 and the p2 mirror script for the same repositories. Sirius removed the Acceleo/MTL and OCL interpreter features in 7.5.0, and org.eclipse.acceleo.ui.interpreter is no longer published anywhere, so drop those requirements from the setup. Nothing in OSATE uses them; the fault tree bundles only need sirius, sirius.ui, sirius.common.ui, sirius.ext.base, and
sirius.common.acceleo.aql, all within their existing [6.3.0,8.0.0) version ranges.