### PR TITLE
Modernize InstantiateModel and characterize component instantiation 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
@@ -34,7 +34,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Stack;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -231,18 +230,29 @@ public class InstantiateModel {
 	 * @param errMgr
 	 */
 	public InstantiateModel(final IProgressMonitor pm) {
-		classifierCache = new HashMap<InstanceObject, InstantiatedClassifier>();
-		mode2som = new HashMap<ModeInstance, List<SystemOperationMode>>();
+		classifierCache = new HashMap<>();
+		mode2som = new HashMap<>();
 		errManager = new AnalysisErrorReporterManager(
 				new MarkerAnalysisErrorReporter.Factory(AadlConstants.INSTANTIATION_OBJECT_MARKER));
 		monitor = pm;
 	}
 
 	public InstantiateModel(final IProgressMonitor pm, final AnalysisErrorReporterManager errMgr) {
-		classifierCache = new HashMap<InstanceObject, InstantiatedClassifier>();
-		mode2som = new HashMap<ModeInstance, List<SystemOperationMode>>();
+		classifierCache = new HashMap<>();
+		mode2som = new HashMap<>();
 		errManager = errMgr;
 		monitor = pm;
+	}
+
+	/**
+	 * Stop the current instantiation if the user canceled it.
+	 *
+	 * @throws InterruptedException if the progress monitor reports cancellation
+	 */
+	private void checkCanceled() throws InterruptedException {
+		if (monitor.isCanceled()) {
+			throw new InterruptedException();
+		}
 	}
 
 	// Methods
@@ -372,8 +382,8 @@ public class InstantiateModel {
 	 */
 	public static void rebuildAllInstanceModelFiles(final IProgressMonitor monitor) throws Exception {
 		HashSet<IFile> files = TraverseWorkspace.getInstanceModelFilesInWorkspace();
-		List<URI> instanceRoots = new ArrayList<URI>();
-		List<IResource> instanceIResources = new ArrayList<IResource>();
+		List<URI> instanceRoots = new ArrayList<>();
+		List<IResource> instanceIResources = new ArrayList<>();
 		ResourceSet rset = new ResourceSetImpl();
 		for (IFile iFile : files) {
 			IResource ires = iFile;
@@ -411,9 +421,7 @@ public class InstantiateModel {
 			throws Exception {
 		SystemInstance result = createSystemInstanceInt(ci, aadlResource, true);
 
-		if (monitor.isCanceled()) {
-			throw new InterruptedException();
-		}
+		checkCanceled();
 
 		// We're done: Save the model.
 		// We don't respond to a cancel at this point
@@ -463,15 +471,15 @@ public class InstantiateModel {
 				if (msg.where.eResource() != null) {
 					// keep only errors referring to elements that are still in the instance model
 					switch (msg.kind) {
-					case QueuingAnalysisErrorReporter.ERROR:
-						errManager.error(msg.where, msg.message, msg.attributes, msg.values);
-						break;
-					case QueuingAnalysisErrorReporter.WARNING:
-						errManager.warning(msg.where, msg.message, msg.attributes, msg.values);
-						break;
-					case QueuingAnalysisErrorReporter.INFO:
-						errManager.info(msg.where, msg.message, msg.attributes, msg.values);
-						break;
+					case QueuingAnalysisErrorReporter.ERROR -> errManager.error(msg.where, msg.message, msg.attributes,
+							msg.values);
+					case QueuingAnalysisErrorReporter.WARNING -> errManager.warning(msg.where, msg.message,
+							msg.attributes, msg.values);
+					case QueuingAnalysisErrorReporter.INFO -> errManager.info(msg.where, msg.message, msg.attributes,
+							msg.values);
+					default -> {
+						// a message of any other kind is dropped, as it was before
+					}
 					}
 				}
 			}
@@ -521,9 +529,7 @@ public class InstantiateModel {
 				InstantiationRoot pending = roots.get(annexed++);
 				aic.instantiateAllAnnexes(pending.root);
 				pending.phase = InstantiationRoot.Phase.DONE;
-				if (monitor.isCanceled()) {
-					throw new InterruptedException();
-				}
+				checkCanceled();
 			}
 		}
 
@@ -559,9 +565,7 @@ public class InstantiateModel {
 		final ComponentInstance root = pending.root;
 
 		new CreateConnectionsSwitch(monitor, errManager, classifierCache).processPreOrderAll(root);
-		if (monitor.isCanceled()) {
-			throw new InterruptedException();
-		}
+		checkCanceled();
 
 		/*
 		 * The expansion needs Connection_Pattern and Connection_Set on the provisional connections, but
@@ -583,21 +587,15 @@ public class InstantiateModel {
 		cacheStructuralConnectionProperties(root, structuralProperties);
 		// handle arrays, connection patterns, and connection sets
 		processConnections(root);
-		if (monitor.isCanceled()) {
-			throw new InterruptedException();
-		}
+		checkCanceled();
 
 		final ValidateConnectionsSwitch vcs = new ValidateConnectionsSwitch(monitor, errManager, classifierCache);
 		vcs.processPreOrderAll(root);
 		vcs.postProcess();
-		if (monitor.isCanceled()) {
-			throw new InterruptedException();
-		}
+		checkCanceled();
 
 		new CreateEndToEndFlowsSwitch(monitor, errManager, classifierCache).processPreOrderAll(root);
-		if (monitor.isCanceled()) {
-			throw new InterruptedException();
-		}
+		checkCanceled();
 
 		cacheProperties(root, remainingProperties);
 	}
@@ -642,16 +640,12 @@ public class InstantiateModel {
 		CacheContainedPropertyAssociationsSwitch ccpas = new CacheContainedPropertyAssociationsSwitch(classifierCache,
 				scProps, monitor, errManager);
 		ccpas.processPostOrderAll(root);
-		if (monitor.isCanceled()) {
-			throw new InterruptedException();
-		}
+		checkCanceled();
 
 		final CachePropertyAssociationsSwitch cpas = new CachePropertyAssociationsSwitch(monitor, errManager,
 				propertyDefinitionList, classifierCache, scProps, mode2som);
 		cpas.processPreOrderAll(root);
-		if (monitor.isCanceled()) {
-			throw new InterruptedException();
-		}
+		checkCanceled();
 	}
 
 	/**
@@ -672,15 +666,11 @@ public class InstantiateModel {
 		SCProperties structuralScProps = new SCProperties();
 		new CacheContainedPropertyAssociationsSwitch(classifierCache, structuralScProps, monitor, errManager,
 				structuralProperties).processPostOrderAll(root);
-		if (monitor.isCanceled()) {
-			throw new InterruptedException();
-		}
+		checkCanceled();
 
 		new CachePropertyAssociationsSwitch(monitor, errManager, structuralProperties, classifierCache,
 				structuralScProps, mode2som).processPreOrderAll(root);
-		if (monitor.isCanceled()) {
-			throw new InterruptedException();
-		}
+		checkCanceled();
 	}
 
 	/**
@@ -757,9 +747,7 @@ public class InstantiateModel {
 
 	private void fillModes(ComponentInstance ci, List<Mode> modes) throws InterruptedException {
 		for (Mode m : modes) {
-			if (monitor.isCanceled()) {
-				throw new InterruptedException();
-			}
+			checkCanceled();
 			ModeInstance mi = InstanceFactory.eINSTANCE.createModeInstance();
 			/*
 			 * Used to add the mode instance to the component instance at the end of the loop,
@@ -783,23 +771,15 @@ public class InstantiateModel {
 				final EList<ModeBinding> ownedModeBindings = sub.getOwnedModeBindings();
 				if (ownedModeBindings == null || ownedModeBindings.isEmpty()) {
 					// Implicit mode map, must find modes of the same name in the containing component
-					ModeInstance foundParentMode = null;
-					for (ModeInstance pmi : parentci.getModeInstances()) {
-						if (pmi.getName().equalsIgnoreCase(m.getName())) {
-							foundParentMode = pmi;
-							break;
-						}
-					}
-					if (foundParentMode == null) {
-						errManager.error(mi, "Required mode '" + m.getName() + "' not found in containing component");
-					} else {
-						mi.getParents().add(foundParentMode);
-					}
+					parentci.getModeInstances()
+							.stream()
+							.filter(pmi -> pmi.getName().equalsIgnoreCase(m.getName()))
+							.findFirst()
+							.ifPresentOrElse(mi.getParents()::add, () -> errManager.error(mi,
+									"Required mode '" + m.getName() + "' not found in containing component"));
 				} else {
 					for (ModeBinding mb : ownedModeBindings) {
-						if (monitor.isCanceled()) {
-							throw new InterruptedException();
-						}
+						checkCanceled();
 						if (mb.getDerivedMode() == m || mb.getDerivedMode() == null
 								&& mb.getParentMode().getName().equalsIgnoreCase(m.getName())) {
 							mi.getParents().add(parentci.findModeInstance(mb.getParentMode()));
@@ -818,9 +798,7 @@ public class InstantiateModel {
 	protected void fillModeTransitions(ComponentInstance ci, List<ModeTransition> transitions)
 			throws InterruptedException {
 		for (ModeTransition mt : transitions) {
-			if (monitor.isCanceled()) {
-				throw new InterruptedException();
-			}
+			checkCanceled();
 			ModeTransitionInstance mti = InstanceFactory.eINSTANCE.createModeTransitionInstance();
 			Mode srcmode = mt.getSource();
 			Mode dstmode = mt.getDestination();
@@ -840,12 +818,8 @@ public class InstantiateModel {
 				if (!triggers.isEmpty()) {
 					TriggerPort tp = triggers.get(0).getTriggerPort();
 
-					if (tp instanceof Port) {
-						Context ctx = triggers.get(0).getContext();
-
-						if (ctx instanceof Subcomponent) {
-							eventName = ((Subcomponent) ctx).getName() + "_";
-						}
+					if (tp instanceof Port && triggers.get(0).getContext() instanceof Subcomponent subcomponent) {
+						eventName = subcomponent.getName() + "_";
 					}
 					eventName += tp.getName();
 				}
@@ -857,16 +831,15 @@ public class InstantiateModel {
 			for (ModeTransitionTrigger t : triggers) {
 				TriggerPort tp = t.getTriggerPort();
 
-				if (tp instanceof Port) {
-					Port port = (Port) tp;
+				if (tp instanceof Port port) {
 					FeatureInstance porti = null;
 					Context ctx = t.getContext();
 
-					if (ctx instanceof Subcomponent) {
-						ComponentInstance subi = ci.findSubcomponentInstance((Subcomponent) ctx);
+					if (ctx instanceof Subcomponent subcomponent) {
+						ComponentInstance subi = ci.findSubcomponentInstance(subcomponent);
 						porti = subi.findFeatureInstance(port);
-					} else if (ctx instanceof FeatureGroup) {
-						FeatureInstance fgi = ci.findFeatureInstance((FeatureGroup) ctx);
+					} else if (ctx instanceof FeatureGroup featureGroup) {
+						FeatureInstance fgi = ci.findFeatureInstance(featureGroup);
 						porti = fgi.findFeatureInstance(port);
 					} else if (ctx == null) {
 						porti = ci.findFeatureInstance(port);
@@ -888,34 +861,30 @@ public class InstantiateModel {
 	protected void instantiateSubcomponents(final ComponentInstance ci, ComponentImplementation impl)
 			throws InterruptedException {
 		for (final Subcomponent sub : impl.getAllSubcomponents()) {
-			if (monitor.isCanceled()) {
-				throw new InterruptedException();
-			}
+			checkCanceled();
 			if (hasSubcomponentInstance(ci, sub)) {
 				errManager.error(ci, "Cyclic containment dependency: Subcomponent '" + sub.getName()
 						+ "' has already been instantiated as enclosing component.");
 			} else {
 				final EList<ArrayDimension> dims = sub.getArrayDimensions();
-				Stack<Long> indexStack = new Stack<Long>();
+				List<Long> indexStack = new ArrayList<>();
 
 				if (dims.isEmpty()) {
 					instantiateSubcomponent(ci, sub, sub, indexStack, 0);
 				} else {
 					final int dimensions = dims.size();
 					class ArrayInstantiator {
-						void process(int dim, Stack<Long> indexStack) throws InterruptedException {
+						void process(int dim, List<Long> indexStack) throws InterruptedException {
 							// index starts with one
 							ArraySize arraySize = dims.get(dim).getSize();
 							long count = getElementCount(arraySize, ci);
 
 							for (int i = 1; i <= count; i++) {
-								if (monitor.isCanceled()) {
-									throw new InterruptedException();
-								}
+								checkCanceled();
 								if (dim + 1 < dimensions) {
-									indexStack.push(Long.valueOf(i));
+									indexStack.add(Long.valueOf(i));
 									process(dim + 1, indexStack);
-									indexStack.pop();
+									indexStack.removeLast();
 								} else {
 									instantiateSubcomponent(ci, sub, sub, indexStack, i);
 								}
@@ -944,7 +913,7 @@ public class InstantiateModel {
 		return false;
 	}
 
-	protected String indexStackToString(Stack<Long> indexStack) {
+	protected String indexStackToString(List<Long> indexStack) {
 		String result = "";
 		for (int i = 0; i < indexStack.size(); i++) {
 			result = result + "_" + indexStack.get(i);
@@ -953,7 +922,7 @@ public class InstantiateModel {
 	}
 
 	protected void instantiateSubcomponent(final ComponentInstance parent, final ModalElement mm,
-			final Subcomponent sub, Stack<Long> indexStack, int index) throws InterruptedException {
+			final Subcomponent sub, List<Long> indexStack, int index) throws InterruptedException {
 		final ComponentInstance newInstance = InstanceFactory.eINSTANCE.createComponentInstance();
 		final ComponentClassifier cc;
 		final InstantiatedClassifier ic;
@@ -1009,9 +978,7 @@ public class InstantiateModel {
 		}
 
 		for (Mode mode : mm.getAllInModes()) {
-			if (monitor.isCanceled()) {
-				throw new InterruptedException();
-			}
+			checkCanceled();
 			ModeInstance mi = parent.findModeInstance(mode);
 
 			if (mi != null) {
@@ -1028,9 +995,7 @@ public class InstantiateModel {
 	 */
 	private void instantiateFlowSpecs(ComponentInstance ci) throws InterruptedException {
 		for (FlowSpecification spec : getComponentType(ci).getAllFlowSpecifications()) {
-			if (monitor.isCanceled()) {
-				throw new InterruptedException();
-			}
+			checkCanceled();
 			FlowSpecificationInstance speci = ci.createFlowSpecification();
 			speci.setName(spec.getName());
 			speci.setFlowSpecification(spec);
@@ -1049,9 +1014,7 @@ public class InstantiateModel {
 				}
 			}
 			for (Mode mode : spec.getAllInModes()) {
-				if (monitor.isCanceled()) {
-					throw new InterruptedException();
-				}
+				checkCanceled();
 				ModeInstance mi = ci.findModeInstance(mode);
 				if (mi != null) {
 					speci.getInModes().add(mi);
@@ -1059,9 +1022,7 @@ public class InstantiateModel {
 			}
 
 			for (ModeTransition mt : spec.getInModeTransitions()) {
-				if (monitor.isCanceled()) {
-					throw new InterruptedException();
-				}
+				checkCanceled();
 				ModeTransitionInstance ti = ci.findModeTransitionInstance(mt);
 
 				if (ti != null) {
@@ -1085,9 +1046,7 @@ public class InstantiateModel {
 	 */
 	protected void instantiateFeatures(final ComponentInstance ci) throws InterruptedException {
 		for (final Feature feature : getInstantiatedClassifier(ci).getClassifier().getAllFeatures()) {
-			if (monitor.isCanceled()) {
-				throw new InterruptedException();
-			}
+			checkCanceled();
 			final EList<ArrayDimension> dims = feature.getArrayDimensions();
 			boolean arrayAllowed = canBeArray(feature);
 			if (dims.isEmpty() || !arrayAllowed) {
@@ -1160,8 +1119,8 @@ public class InstantiateModel {
 
 	private DirectionType getDirection(Feature feature, boolean inverse) {
 		DirectionType dir;
-		if (feature instanceof DirectedFeature) {
-			dir = ((DirectedFeature) feature).getDirection();
+		if (feature instanceof DirectedFeature directedFeature) {
+			dir = directedFeature.getDirection();
 		} else {
 			Access access = (Access) feature;
 			dir = access.getKind() == AccessType.PROVIDES ? DirectionType.OUT : DirectionType.IN;
@@ -1251,9 +1210,8 @@ public class InstantiateModel {
 	 */
 	protected void expandFeatureGroupInstance(Feature feature, FeatureInstance fi, boolean inverse)
 			throws InterruptedException {
-		if (feature instanceof FeatureGroup) {
-			final FeatureGroup fg = (FeatureGroup) feature;
-			FeatureType ft = ((FeatureGroup) feature).getFeatureType();
+		if (feature instanceof FeatureGroup fg) {
+			FeatureType ft = fg.getFeatureType();
 			if (Aadl2Util.isNull(ft)) {
 				return;
 			}
@@ -1333,10 +1291,14 @@ public class InstantiateModel {
 		if (f.getOwner() instanceof Feature) {
 			return false;
 		} else if (f.getOwner() instanceof ComponentType ct) {
-			var cat = ct.getCategory();
-			return (cat == ComponentCategory.THREAD || cat == ComponentCategory.DEVICE
-					|| cat == ComponentCategory.PROCESSOR || cat == ComponentCategory.MEMORY
-					|| cat == ComponentCategory.SYSTEM || cat == ComponentCategory.ABSTRACT);
+			/*
+			 * Exhaustive on purpose: this list has to agree with the one the validator enforces, so a new
+			 * component category should not compile until it has been decided for here as well.
+			 */
+			return switch (ct.getCategory()) {
+			case ABSTRACT, DEVICE, MEMORY, PROCESSOR, SYSTEM, THREAD -> true;
+			case BUS, DATA, PROCESS, SUBPROGRAM, SUBPROGRAM_GROUP, THREAD_GROUP, VIRTUAL_BUS, VIRTUAL_PROCESSOR -> false;
+			};
 		}
 		return false;
 	}
@@ -1347,9 +1309,8 @@ public class InstantiateModel {
 	 */
 	private boolean hasFeatureInstance(FeatureInstance fi, Feature f) {
 		EObject parent = fi;
-		while (parent instanceof FeatureInstance) {
-			Feature df = ((FeatureInstance) parent).getFeature();
-			if (df == f) {
+		while (parent instanceof FeatureInstance featureInstance) {
+			if (featureInstance.getFeature() == f) {
 				return true;
 			}
 			parent = parent.eContainer();
@@ -1417,11 +1378,9 @@ public class InstantiateModel {
 	// --------------------------------------------------------------------------------------------
 
 	private void processConnections(ComponentInstance root) throws InterruptedException {
-		if (monitor.isCanceled()) {
-			throw new InterruptedException();
-		}
-		EList<ComponentInstance> replicateConns = new UniqueEList<ComponentInstance>();
-		List<ConnectionInstance> toRemove = new ArrayList<ConnectionInstance>();
+		checkCanceled();
+		EList<ComponentInstance> replicateConns = new UniqueEList<>();
+		List<ConnectionInstance> toRemove = new ArrayList<>();
 		EList<ConnectionInstance> connilist = root.getAllConnectionInstances();
 		for (ConnectionInstance conni : connilist) {
 			// track all component instances that contain connection instances
@@ -1433,10 +1392,10 @@ public class InstantiateModel {
 			if (setPA == null && patternPA == null) {
 				// OsateDebug.osateDebug("[InstantiateModel] processConnections");
 
-				LinkedList<Integer> srcDims = new LinkedList<Integer>();
-				LinkedList<Integer> dstDims = new LinkedList<Integer>();
-				LinkedList<Integer> srcSizes = new LinkedList<Integer>();
-				LinkedList<Integer> dstSizes = new LinkedList<Integer>();
+				LinkedList<Integer> srcDims = new LinkedList<>();
+				LinkedList<Integer> dstDims = new LinkedList<>();
+				LinkedList<Integer> srcSizes = new LinkedList<>();
+				LinkedList<Integer> dstSizes = new LinkedList<>();
 				boolean done = false;
 
 				analyzePath(conni.getContainingComponentInstance(), conni.getSource(), null, srcDims, srcSizes);
@@ -1445,7 +1404,7 @@ public class InstantiateModel {
 					if (d != 0) {
 						done = true;
 						if (interpretConnectionPatterns(conni, false, null, 0, srcSizes, 0, dstSizes, 0,
-								new ArrayList<Long>(), new ArrayList<Long>())) {
+								new ArrayList<>(), new ArrayList<>())) {
 							toRemove.add(conni);
 						}
 						break;
@@ -1456,7 +1415,7 @@ public class InstantiateModel {
 						if (d != 0) {
 							done = true;
 							if (interpretConnectionPatterns(conni, false, null, 0, srcSizes, 0, dstSizes, 0,
-									new ArrayList<Long>(), new ArrayList<Long>())) {
+									new ArrayList<>(), new ArrayList<>())) {
 								toRemove.add(conni);
 							}
 							break;
@@ -1470,8 +1429,8 @@ public class InstantiateModel {
 						.getOwnedListElements();
 				for (PropertyExpression pe : patterns) {
 					List<PropertyExpression> pattern = ((ListValue) pe).getOwnedListElements();
-					LinkedList<Integer> srcSizes = new LinkedList<Integer>();
-					LinkedList<Integer> dstSizes = new LinkedList<Integer>();
+					LinkedList<Integer> srcSizes = new LinkedList<>();
+					LinkedList<Integer> dstSizes = new LinkedList<>();
 
 					analyzePath(conni.getContainingComponentInstance(), conni.getSource(), null, null, srcSizes);
 					analyzePath(conni.getContainingComponentInstance(), conni.getDestination(), null, null, dstSizes);
@@ -1480,7 +1439,7 @@ public class InstantiateModel {
 								"Connection pattern specified for connection that does not connect array elements.");
 					} else {
 						if (interpretConnectionPatterns(conni, isOpposite, pattern, 0, srcSizes, 0, dstSizes, 0,
-								new ArrayList<Long>(), new ArrayList<Long>())) {
+								new ArrayList<>(), new ArrayList<>())) {
 							toRemove.add(conni);
 						}
 					}
@@ -1780,7 +1739,7 @@ public class InstantiateModel {
 	}
 
 	private List<Long> getIndices(RecordValue rv, String field) {
-		List<Long> indices = new ArrayList<Long>();
+		List<Long> indices = new ArrayList<>();
 		for (BasicPropertyAssociation fv : rv.getOwnedFieldValues()) {
 			if (fv.getProperty().getName().equalsIgnoreCase(field)) {
 				ListValue lv = (ListValue) fv.getOwnedValue();
@@ -1816,17 +1775,17 @@ public class InstantiateModel {
 				names.add(current.getName());
 			}
 
-			if (current instanceof ComponentInstance) {
-				d = ((ComponentInstance) current).getSubcomponent().getArrayDimensions().size();
-			} else if (current instanceof FeatureInstance && ((FeatureInstance) current).getIndex() != 0) {
+			if (current instanceof ComponentInstance componentInstance) {
+				d = componentInstance.getSubcomponent().getArrayDimensions().size();
+			} else if (current instanceof FeatureInstance featureInstance && featureInstance.getIndex() != 0) {
 				d = 1;
 			}
 			if (dims != null) {
 				dims.add(d);
 			}
 			if (sizes != null && d != 0) {
-				if (current instanceof ComponentInstance) {
-					Subcomponent s = ((ComponentInstance) current).getSubcomponent();
+				if (current instanceof ComponentInstance componentInstance) {
+					Subcomponent s = componentInstance.getSubcomponent();
 
 					for (ArrayDimension ad : s.getArrayDimensions()) {
 						ArraySize as = ad.getSize();
@@ -1834,8 +1793,8 @@ public class InstantiateModel {
 						sizes.add((int) getElementCount(as, current.getContainingComponentInstance()));
 					}
 
-				} else if (current instanceof FeatureInstance && ((FeatureInstance) current).getIndex() != 0) {
-					Feature f = ((FeatureInstance) current).getFeature();
+				} else if (current instanceof FeatureInstance featureInstance && featureInstance.getIndex() != 0) {
+					Feature f = featureInstance.getFeature();
 					ArraySize as = f.getArrayDimensions().get(0).getSize();
 
 					sizes.add((int) getElementCount(as, current.getContainingComponentInstance()));
@@ -1854,28 +1813,28 @@ public class InstantiateModel {
 			if (names != null) {
 				names.add(current.getName());
 			}
-			if (current instanceof ComponentInstance) {
-				EList<Long> idx = ((ComponentInstance) current).getIndices();
+			if (current instanceof ComponentInstance componentInstance) {
+				EList<Long> idx = componentInstance.getIndices();
 				if (!idx.isEmpty()) {
-					indices.addAll(((ComponentInstance) current).getIndices());
+					indices.addAll(idx);
 				}
-			} else if (current instanceof FeatureInstance) {
-				long idx = ((FeatureInstance) current).getIndex();
+			} else if (current instanceof FeatureInstance featureInstance) {
+				long idx = featureInstance.getIndex();
 				if (idx != 0) {
 					indices.add(idx);
 				}
 			}
-			if (current instanceof ComponentInstance) {
-				d = ((ComponentInstance) current).getSubcomponent().getArrayDimensions().size();
-			} else if (current instanceof FeatureInstance && ((FeatureInstance) current).getIndex() != 0) {
+			if (current instanceof ComponentInstance componentInstance) {
+				d = componentInstance.getSubcomponent().getArrayDimensions().size();
+			} else if (current instanceof FeatureInstance featureInstance && featureInstance.getIndex() != 0) {
 				d = 1;
 			}
 			if (dims != null) {
 				dims.add(d);
 			}
 			if (sizes != null && d != 0) {
-				if (current instanceof ComponentInstance) {
-					Subcomponent s = ((ComponentInstance) current).getSubcomponent();
+				if (current instanceof ComponentInstance componentInstance) {
+					Subcomponent s = componentInstance.getSubcomponent();
 
 					for (ArrayDimension ad : s.getArrayDimensions()) {
 						ArraySize as = ad.getSize();
@@ -1883,8 +1842,8 @@ public class InstantiateModel {
 						sizes.add((int) getElementCount(as, current.getContainingComponentInstance()));
 					}
 
-				} else if (current instanceof FeatureInstance && ((FeatureInstance) current).getIndex() != 0) {
-					Feature f = ((FeatureInstance) current).getFeature();
+				} else if (current instanceof FeatureInstance featureInstance && featureInstance.getIndex() != 0) {
+					Feature f = featureInstance.getFeature();
 					ArraySize as = f.getArrayDimensions().get(0).getSize();
 
 					sizes.add((int) getElementCount(as, current.getContainingComponentInstance()));
@@ -1902,9 +1861,9 @@ public class InstantiateModel {
 	 */
 	private void createNewConnection(ConnectionInstance conni, List<Long> srcIndices, List<Long> dstIndices) {
 		ComponentInstance container = conni.getContainingComponentInstance();
-		LinkedList<String> names = new LinkedList<String>();
-		LinkedList<Integer> dims = new LinkedList<Integer>();
-		LinkedList<Integer> sizes = new LinkedList<Integer>();
+		LinkedList<String> names = new LinkedList<>();
+		LinkedList<Integer> dims = new LinkedList<>();
+		LinkedList<Integer> sizes = new LinkedList<>();
 		ConnectionInstance newConn = EcoreUtil.copy(conni);
 		newConn.setSource(null);
 		newConn.setDestination(null);
@@ -1945,7 +1904,7 @@ public class InstantiateModel {
 		String containerPath = container.getInstanceObjectPath();
 		int len = containerPath.length() + 1;
 		String srcPath = (src != null) ? src.getInstanceObjectPath() : "Source end not found";
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		int i = (srcPath.startsWith(containerPath)) ? len : 0;
 		sb.append(srcPath.substring(i));
 		sb.append(" --> ");
@@ -1973,10 +1932,10 @@ public class InstantiateModel {
 	 * @return
 	 */
 	private void createNewConnection(ConnectionInstance conni, ComponentInstance targetComponent) {
-		LinkedList<Long> indices = new LinkedList<Long>();
-		LinkedList<String> names = new LinkedList<String>();
-		LinkedList<Integer> dims = new LinkedList<Integer>();
-		LinkedList<Integer> sizes = new LinkedList<Integer>();
+		LinkedList<Long> indices = new LinkedList<>();
+		LinkedList<String> names = new LinkedList<>();
+		LinkedList<Integer> dims = new LinkedList<>();
+		LinkedList<Integer> sizes = new LinkedList<>();
 		ConnectionInstance newConn = EcoreUtil.copy(conni);
 		newConn.setSource(null);
 		newConn.setDestination(null);
@@ -2004,7 +1963,7 @@ public class InstantiateModel {
 		String containerPath = targetComponent.getInstanceObjectPath();
 		int len = containerPath.length() + 1;
 		String srcPath = (src != null) ? src.getInstanceObjectPath() : "Source end not found";
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		int i = (srcPath.startsWith(containerPath)) ? len : 0;
 		sb.append(srcPath.substring(i));
 		sb.append(" --> ");
@@ -2094,12 +2053,9 @@ public class InstantiateModel {
 				// re-resolve the source feature
 				ConnectionInstanceEnd found = (ConnectionInstanceEnd) AadlUtil
 						.findNamedElementInList(target.getFeatureInstances(), src.getName(), idx);
-				if (found == null) {
-					Element parent = src.getOwner();
-					if (parent instanceof FeatureInstance) {
-						found = (ConnectionInstanceEnd) AadlUtil.findNamedElementInList(target.getFeatureInstances(),
-								((FeatureInstance) parent).getName(), fgidx);
-					}
+				if (found == null && src.getOwner() instanceof FeatureInstance parent) {
+					found = (ConnectionInstanceEnd) AadlUtil.findNamedElementInList(target.getFeatureInstances(),
+							parent.getName(), fgidx);
 				}
 				if (found != null) {
 					targetConnRef.setSource(found);
@@ -2119,12 +2075,9 @@ public class InstantiateModel {
 					// the outer source points to the enclosing feature group. reresolve the feature in this feature group
 					ConnectionInstanceEnd found = (ConnectionInstanceEnd) AadlUtil.findNamedElementInList(
 							((FeatureInstance) outerSrc).getFeatureInstances(), dst.getName(), idx);
-					if (found == null) {
-						Element parent = dst.getOwner();
-						if (parent instanceof FeatureInstance) {
-							found = (ConnectionInstanceEnd) AadlUtil.findNamedElementInList(
-									target.getFeatureInstances(), ((FeatureInstance) parent).getName(), fgidx);
-						}
+					if (found == null && dst.getOwner() instanceof FeatureInstance parent) {
+						found = (ConnectionInstanceEnd) AadlUtil.findNamedElementInList(target.getFeatureInstances(),
+								parent.getName(), fgidx);
 					}
 					if (found != null) {
 						targetConnRef.setDestination(found);
@@ -2140,12 +2093,9 @@ public class InstantiateModel {
 				// re-resolve the source feature
 				ConnectionInstanceEnd found = (ConnectionInstanceEnd) AadlUtil
 						.findNamedElementInList(target.getFeatureInstances(), dst.getName(), idx);
-				if (found == null) {
-					Element parent = dst.getOwner();
-					if (parent instanceof FeatureInstance) {
-						found = (ConnectionInstanceEnd) AadlUtil.findNamedElementInList(target.getFeatureInstances(),
-								((FeatureInstance) parent).getName(), fgidx);
-					}
+				if (found == null && dst.getOwner() instanceof FeatureInstance parent) {
+					found = (ConnectionInstanceEnd) AadlUtil.findNamedElementInList(target.getFeatureInstances(),
+							parent.getName(), fgidx);
 				}
 				if (found != null) {
 					targetConnRef.setDestination(found);
@@ -2164,12 +2114,9 @@ public class InstantiateModel {
 					// the outer source points to the enclosing feature group. reresolve the feature in this feature group
 					ConnectionInstanceEnd found = (ConnectionInstanceEnd) AadlUtil.findNamedElementInList(
 							((FeatureInstance) outerDst).getFeatureInstances(), src.getName(), idx);
-					if (found == null) {
-						Element parent = src.getOwner();
-						if (parent instanceof FeatureInstance) {
-							found = (ConnectionInstanceEnd) AadlUtil.findNamedElementInList(
-									target.getFeatureInstances(), ((FeatureInstance) parent).getName(), fgidx);
-						}
+					if (found == null && src.getOwner() instanceof FeatureInstance parent) {
+						found = (ConnectionInstanceEnd) AadlUtil.findNamedElementInList(target.getFeatureInstances(),
+								parent.getName(), fgidx);
 					}
 					if (found != null) {
 						targetConnRef.setSource(found);
@@ -2207,14 +2154,14 @@ public class InstantiateModel {
 		ConnectionInstanceEnd result = null;
 		for (int nameidx = names.size() - 1; nameidx >= 0; nameidx--) {
 			String name = names.get(nameidx);
-			List<InstanceObject> owned = new ArrayList<InstanceObject>();
+			List<InstanceObject> owned = new ArrayList<>();
 			int dim = dims.get(count);
-			if (resolutionContext instanceof ComponentInstance) {
+			if (resolutionContext instanceof ComponentInstance componentContext) {
 				// if nextConnRef is null it is because we are going to look up feature instances inside the last component instance
-				owned.addAll(((ComponentInstance) resolutionContext).getComponentInstances());
-				owned.addAll(((ComponentInstance) resolutionContext).getFeatureInstances());
-			} else if (resolutionContext instanceof FeatureInstance) {
-				owned.addAll(((FeatureInstance) resolutionContext).getFeatureInstances());
+				owned.addAll(componentContext.getComponentInstances());
+				owned.addAll(componentContext.getFeatureInstances());
+			} else if (resolutionContext instanceof FeatureInstance featureContext) {
+				owned.addAll(featureContext.getFeatureInstances());
 			}
 
 			if (dim == 0) {
@@ -2231,10 +2178,10 @@ public class InstantiateModel {
 				outer: for (InstanceObject io : owned) {
 					if (io.getName().equalsIgnoreCase(name)) {
 						try {
-							if (io instanceof ComponentInstance) {
+							if (io instanceof ComponentInstance componentInstance) {
 								// we need to deal with possibly more than one index
 								int d = dim - 1;
-								for (long i : ((ComponentInstance) io).getIndices()) {
+								for (long i : componentInstance.getIndices()) {
 									if (i != indices.get(offset - d)) {
 										continue outer;
 									}
@@ -2357,10 +2304,8 @@ public class InstantiateModel {
 	 * @since 3.0
 	 */
 	public EList<Property> getAllUsedPropertyDefinitions(ComponentInstance root) throws InterruptedException {
-		if (monitor.isCanceled()) {
-			throw new InterruptedException();
-		}
-		EList<Property> result = new UniqueEList<Property>();
+		checkCanceled();
+		EList<Property> result = new UniqueEList<>();
 
 		addUsedProperties(root, root.getClassifier(), result);
 		TreeIterator<Element> it = EcoreUtil.getAllContents(Collections.singleton(root));
@@ -2368,8 +2313,8 @@ public class InstantiateModel {
 		while (it.hasNext()) {
 			Element elem = it.next();
 
-			if (elem instanceof ComponentInstance) {
-				InstantiatedClassifier ic = getInstantiatedClassifier((ComponentInstance) elem);
+			if (elem instanceof ComponentInstance componentInstance) {
+				InstantiatedClassifier ic = getInstantiatedClassifier(componentInstance);
 				if (ic != null && ic.getClassifier() != null) {
 					if (ic.getClassifier().equals(root.getClassifier())) {
 						addUsedProperties(root, ic.getClassifier(), result, false);
@@ -2377,8 +2322,7 @@ public class InstantiateModel {
 						addUsedProperties(root, ic.getClassifier(), result);
 					}
 				}
-			} else if (elem instanceof FeatureInstance) {
-				FeatureInstance fi = (FeatureInstance) elem;
+			} else if (elem instanceof FeatureInstance fi) {
 				if (fi.getFeature() instanceof FeatureGroup) {
 					FeatureGroupType fgt = getFeatureGroupType(fi);
 					addUsedProperties(root, fgt, result);
@@ -2386,8 +2330,7 @@ public class InstantiateModel {
 					Classifier c = fi.getFeature().getClassifier();
 					addUsedProperties(root, c, result);
 				}
-			} else if (elem instanceof ConnectionInstance) {
-				ConnectionInstance ci = (ConnectionInstance) elem;
+			} else if (elem instanceof ConnectionInstance ci) {
 				addUsedPropertyDefinitions(ci.getContainingClassifier(), result);
 
 				for (ConnectionReference cr : ci.getConnectionReferences()) {
@@ -2404,9 +2347,9 @@ public class InstantiateModel {
 
 	private void addUsedProperties(InstanceObject root, Classifier cc, EList<Property> result, boolean showError) {
 
-		if (cc instanceof ComponentImplementation) {
-			ComponentImplementation impl = (ComponentImplementation) cc;
-			List<ComponentImplementation> extendedComponentImpls = new ArrayList<ComponentImplementation>();
+		if (cc instanceof ComponentImplementation implementation) {
+			ComponentImplementation impl = implementation;
+			List<ComponentImplementation> extendedComponentImpls = new ArrayList<>();
 			while (impl != null) {
 				extendedComponentImpls.add(impl);
 				addUsedPropertyDefinitions(impl, result);
@@ -2419,9 +2362,9 @@ public class InstantiateModel {
 					break;
 				}
 			}
-			cc = ((ComponentImplementation) cc).getType();
+			cc = implementation.getType();
 		}
-		List<Classifier> extendedClassifiers = new ArrayList<Classifier>();
+		List<Classifier> extendedClassifiers = new ArrayList<>();
 		while (cc != null) {
 			extendedClassifiers.add(cc);
 			addUsedPropertyDefinitions(cc, result);
@@ -2453,10 +2396,10 @@ public class InstantiateModel {
 			EObject ao = it.next();
 			// OsateDebug.osateDebug ("[InstantiateModel] ao=" + ao);
 
-			if (ao instanceof PropertyAssociation) {
+			if (ao instanceof PropertyAssociation propertyAssociation) {
 				// OsateDebug.osateDebug ("[InstantiateModel] ao=" + ao);
 
-				Property pd = ((PropertyAssociation) ao).getProperty();
+				Property pd = propertyAssociation.getProperty();
 				// OsateDebug.osateDebug ("[InstantiateModel] pd=" + pd);
 
 				if (pd != null) {
@@ -2523,9 +2466,7 @@ public class InstantiateModel {
 
 			protected int enumerateSoms(int depth, int index) throws InterruptedException {
 
-				if (monitor.isCanceled()) {
-					throw new InterruptedException();
-				}
+				checkCanceled();
 
 				Node node = workState.get(depth);
 				State parentState = node.parentNode.state;
@@ -2540,9 +2481,7 @@ public class InstantiateModel {
 					// here we add one or more SOMs
 					if (active) {
 						while (modes.hasNext()) {
-							if (monitor.isCanceled()) {
-								throw new InterruptedException();
-							}
+							checkCanceled();
 							state.mode = modes.next();
 							root.getSystemOperationModes().add(createSOM(index + 1));
 							if (index < 0 || ++index >= limit) {
@@ -2582,16 +2521,14 @@ public class InstantiateModel {
 					return Collections.emptyIterator();
 				} else {
 					// limit derived modes to mapping
-					return modes.stream().filter(mi -> {
-						return !mi.isDerived() || mi.getParents().contains(parentMode);
-					}).iterator();
+					return modes.stream()
+							.filter(mi -> !mi.isDerived() || mi.getParents().contains(parentMode))
+							.iterator();
 				}
 			}
 
 			protected void initWorkState(ComponentInstance ci, Node parentNode) throws InterruptedException {
-				if (monitor.isCanceled()) {
-					throw new InterruptedException();
-				}
+				checkCanceled();
 				if (!ci.getModeInstances().isEmpty()) {
 					parentNode = new Node(ci, parentNode);
 					workState.add(parentNode);
@@ -2606,19 +2543,12 @@ public class InstantiateModel {
 
 				som = InstanceFactory.eINSTANCE.createSystemOperationMode();
 				for (Node node : workState) {
-					if (monitor.isCanceled()) {
-						throw new InterruptedException();
-					}
+					checkCanceled();
 					if (!node.state.active) {
 						continue;
 					}
 					ModeInstance mi = node.state.mode;
-					List<SystemOperationMode> soms = mode2som.get(mi);
-					if (soms == null) {
-						soms = new ArrayList<SystemOperationMode>();
-						mode2som.put(mi, soms);
-					}
-					soms.add(som);
+					mode2som.computeIfAbsent(mi, key -> new ArrayList<>()).add(som);
 					som.getCurrentModes().add(mi);
 				}
 				som.setName("som_" + somNo);

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
@@ -127,11 +127,14 @@ import org.osgi.service.prefs.Preferences;
 import com.google.common.base.Strings;
 
 /**
- * This class implements the instantiation of models from a root system impl.
- * The class also contains a switch for performing checks on semantic
- * constraints that must be satisfied for certain analyes on instance models.
- * Although there is a method that invokes these checks, it is best for each
- * analysis method to invoke those checks that are relevant for its processing.
+ * This class implements the instantiation of an instance model from a root component implementation:
+ * the component hierarchy with its features, modes and flow specifications, the system operation
+ * modes, and the phases that turn the hierarchy into a complete instance model, which are the
+ * connection instances, the end to end flows, the cached properties and the annex instances.
+ * <p>
+ * One instantiator serves one instantiation at a time. The classifier cache, the mode to SOM map and
+ * the list of instance model roots are all per instantiation, so an instance of this class must not be
+ * shared between concurrent instantiations.
  *
  * @author phf
  */
@@ -139,7 +142,7 @@ public class InstantiateModel {
 	// Project properties that are set via a PropertyPage
 	public static final String PREFS_QUALIFIER = "org.osate.aadl2.instantiation";
 	public static final String PREF_SOM_LIMIT = "org.osate.aadl2.instantiation.som_limit";
-	public static final String PREF_SOM_USE_WORKSPACE = "org.osage.aadl2.instantiation.som_use_workspace";
+	public static final String PREF_SOM_USE_WORKSPACE = "org.osate.aadl2.instantiation.som_use_workspace";
 
 	/* The name for the single mode of a non-modal system */
 	public static final String NORMAL_SOM_NAME = "No Modes";
@@ -174,60 +177,37 @@ public class InstantiateModel {
 	 * {@link #instantiateFeatureClassifier(FeatureInstance, FeatureClassifier)}, which is the only place
 	 * that adds a root to the instance resource. All of them go through the same phases, see
 	 * {@link #fillSystemInstance(SystemInstance)}.
+	 * <p>
+	 * The list is emptied at the start of every {@link #fillSystemInstance(SystemInstance)} call. It has
+	 * to be a field rather than a local because
+	 * {@link #instantiateFeatureClassifier(FeatureInstance, FeatureClassifier)} appends to it from deep
+	 * inside the recursion. That, and the classifier cache, is why one {@code InstantiateModel} must not
+	 * be used for more than one instantiation at a time.
 	 */
 	private final List<InstantiationRoot> roots = new ArrayList<>();
 
 	/**
-	 * A root of the instance model together with the next phase it has to go through. A root is
-	 * populated as soon as it is discovered, because that is what discovers further roots, but the
-	 * remaining phases run from the queue. Tracking the phase per root keeps a root that is discovered
-	 * late from being processed twice.
+	 * A root of the instance model, and whether it still has to be brought to its final connections. A
+	 * root is populated as soon as it is discovered, because that is what discovers further roots, but
+	 * the remaining phases run from the queue, and the flag keeps a root that is discovered late from
+	 * being processed twice. Which roots still need their annexes is tracked by the index into
+	 * {@link #roots} in {@link #fillSystemInstance(SystemInstance)}.
 	 */
 	private static final class InstantiationRoot {
-		private enum Phase {
-			FINALIZE_CONNECTIONS, INSTANTIATE_ANNEXES, DONE
-		}
-
 		private final ComponentInstance root;
-		private Phase phase;
+		private boolean connectionsFinalized;
 
 		private InstantiationRoot(ComponentInstance root) {
 			this.root = root;
-			phase = Phase.FINALIZE_CONNECTIONS;
 		}
-	}
-
-	/*
-	 * An error message that is filled by potential methods that
-	 * instantiate the system and raises an error. This message
-	 * is then show in the error dialog when an instantiation error
-	 * is raised.
-	 */
-	private static String errorMessage = null;
-
-	/*
-	 * To keep under control the error messages and ease
-	 * debug, we encapsulate the error message string
-	 * and access it only through methods (setters and getters).
-	 */
-	public static void setErrorMessage(String s) {
-		errorMessage = s;
-	}
-
-	public static String getErrorMessage() {
-		return errorMessage;
 	}
 
 	// Constructors
 
-	/*
-	 * Create an instantiate object. Tracks who to report errors to - the
-	 * resource that contains si. It also holds on to the property definition
-	 * filter to be used for caching properties in the instance model
+	/**
+	 * Create an instantiator that reports to the workspace markers of the instance model file.
 	 *
-	 * @param pm
-	 *
-	 * @param errMgr
+	 * @param pm the progress monitor
 	 */
 	public InstantiateModel(final IProgressMonitor pm) {
 		classifierCache = new HashMap<>();
@@ -237,6 +217,12 @@ public class InstantiateModel {
 		monitor = pm;
 	}
 
+	/**
+	 * Create an instantiator that reports to the given error manager.
+	 *
+	 * @param pm the progress monitor
+	 * @param errMgr the error manager to report to
+	 */
 	public InstantiateModel(final IProgressMonitor pm, final AnalysisErrorReporterManager errMgr) {
 		classifierCache = new HashMap<>();
 		mode2som = new HashMap<>();
@@ -256,16 +242,13 @@ public class InstantiateModel {
 	}
 
 	// Methods
-	/*
-	 * This method will construct an instance model, save it on disk and return
-	 * its root object The method makes sure that the system implementation is
-	 * in the OSATE resource set and will create the instance model there as
-	 * well. The Osate resource set is the shared resource set maintained by
-	 * OsateResourceUtil.
+	/**
+	 * Construct an instance model, save it on disk and return its root object. The instance model is
+	 * created in a resource set of its own that also holds the component implementation.
 	 *
-	 * @param si system implementation
-	 *
-	 * @return SystemInstance or <code>null</code> if cancelled.
+	 * @param ci the component implementation to instantiate
+	 * @param monitor the progress monitor
+	 * @return the system instance
 	 */
 	public static SystemInstance buildInstanceModelFile(final ComponentImplementation ci, IProgressMonitor monitor)
 			throws Exception {
@@ -331,14 +314,12 @@ public class InstantiateModel {
 		return instantiate(ci, AnalysisErrorReporterManager.NULL_ERROR_MANANGER);
 	}
 
-	/*
-	 * This method will construct an instance model, save it on disk and return
-	 * its root object The method will make sure the declarative models are up
-	 * to date.
+	/**
+	 * Construct an instance model from an existing instance model file, save it on disk and return its
+	 * root object.
 	 *
-	 * @param si system implementation
-	 *
-	 * @return SystemInstance or <code>null</code> if cancelled.
+	 * @param ires the instance model file to rebuild
+	 * @return the system instance
 	 */
 	public static SystemInstance rebuildInstanceModelFile(final IResource ires) throws Exception {
 		return rebuildInstanceModelFile(ires, new NullProgressMonitor());
@@ -349,9 +330,9 @@ public class InstantiateModel {
 	 * its root object The method will make sure the declarative models are up
 	 * to date.
 	 *
-	 * @param si system implementation
-	 *
-	 * @return SystemInstance or <code>null</code> if cancelled.
+	 * @param ires the instance model file to rebuild
+	 * @param monitor the progress monitor
+	 * @return the system instance
 	 * @since 1.1
 	 */
 	public static SystemInstance rebuildInstanceModelFile(final IResource ires, final IProgressMonitor monitor)
@@ -372,9 +353,7 @@ public class InstantiateModel {
 		}
 		final InstantiateModel instantiateModel = new InstantiateModel(monitor, new AnalysisErrorReporterManager(
 				new MarkerAnalysisErrorReporter.Factory(AadlConstants.INSTANTIATION_OBJECT_MARKER)));
-		SystemInstance root = instantiateModel.createSystemInstance(ci, res);
-
-		return root;
+		return instantiateModel.createSystemInstance(ci, res);
 	}
 
 	/*
@@ -410,12 +389,13 @@ public class InstantiateModel {
 	}
 
 	/**
-	 * create a system instance into the provided (empty) resource and save it
-	 * @param ci
-	 * @param aadlResource
-	 * @return
-	 * @throws RollbackException
-	 * @throws InterruptedException
+	 * Create a system instance in the provided (empty) resource and save it.
+	 *
+	 * @param ci the component implementation to instantiate
+	 * @param aadlResource the resource to create the instance model in
+	 * @return the system instance
+	 * @throws Exception if instantiation is canceled, which is an {@link InterruptedException}, or the
+	 *             resource cannot be saved
 	 */
 	public SystemInstance createSystemInstance(final ComponentImplementation ci, final Resource aadlResource)
 			throws Exception {
@@ -431,16 +411,15 @@ public class InstantiateModel {
 		return result;
 	}
 
-	/*
-	 * instantiate SystemImpl as root of instance tree and save the model
+	/**
+	 * Instantiate a component implementation as the root of an instance tree.
 	 *
-	 * @param si SystemImpl the root of the system instance
-	 *
-	 * @param aadlResource the Resource to store the instance model in
-	 *
-	 * @return SystemInstance or <code>null</code> if canceled.
+	 * @param ci the component implementation to instantiate
+	 * @param aadlResource the resource to store the instance model in
+	 * @param save whether to save the resource before filling in the instance model
+	 * @return the system instance
 	 * @throws InterruptedException if instantiation is canceled
-	 * @throws RuntimeException if instantiation fails
+	 * @throws UncheckedIOException if the initial instance model cannot be saved
 	 */
 	public SystemInstance createSystemInstanceInt(ComponentImplementation ci, Resource aadlResource, boolean save)
 			throws InterruptedException {
@@ -466,6 +445,7 @@ public class InstantiateModel {
 			errManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
 			fillSystemInstance(root);
 			var errors = ((QueuingAnalysisErrorReporter) errManager.getReporter(aadlResource)).getErrors();
+			// the finally block restores errManager, the messages below go to the original one
 			errManager = origErrManager;
 			for (var msg : errors) {
 				if (msg.where.eResource() != null) {
@@ -492,8 +472,10 @@ public class InstantiateModel {
 	}
 
 	/**
-	 * Will in fill instance model under system instance but not save it
-	 * @param root
+	 * Fill in the instance model under a system instance, but do not save it.
+	 *
+	 * @param root the system instance to fill in
+	 * @throws InterruptedException if instantiation is canceled
 	 */
 	public void fillSystemInstance(SystemInstance root) throws InterruptedException {
 		roots.clear();
@@ -526,24 +508,10 @@ public class InstantiateModel {
 			final int fixedPoint = roots.size();
 			monitor.subTask("Instantiating annexes");
 			while (annexed < fixedPoint) {
-				InstantiationRoot pending = roots.get(annexed++);
-				aic.instantiateAllAnnexes(pending.root);
-				pending.phase = InstantiationRoot.Phase.DONE;
+				aic.instantiateAllAnnexes(roots.get(annexed++).root);
 				checkCanceled();
 			}
 		}
-
-//		OsateResourceManager.save(aadlResource);
-//		OsateResourceManager.getResourceSet().setPropagateNameChange(oldProp);
-		// Run some checks over the model.
-//		final SOMIterator soms = new SOMIterator(root);
-//		while (soms.hasNext()) {
-//			final SystemOperationMode som = soms.nextSOM();
-//			monitor.subTask("Checking model semantics for mode " + som.getName());
-//			final CheckInstanceSemanticsSwitch semanticsSwitch = new CheckInstanceSemanticsSwitch(som, soms
-//					.getSOMasModeBindings(), cpas.getSemanticConnectionProperties(), errManager);
-//			semanticsSwitch.processPostOrderAll(root);
-//		}
 	}
 
 	/**
@@ -558,10 +526,10 @@ public class InstantiateModel {
 	 * Does nothing if the root already went through this phase.
 	 */
 	private void finalizeConnections(InstantiationRoot pending) throws InterruptedException {
-		if (pending.phase != InstantiationRoot.Phase.FINALIZE_CONNECTIONS) {
+		if (pending.connectionsFinalized) {
 			return;
 		}
-		pending.phase = InstantiationRoot.Phase.INSTANTIATE_ANNEXES;
+		pending.connectionsFinalized = true;
 		final ComponentInstance root = pending.root;
 
 		new CreateConnectionsSwitch(monitor, errManager, classifierCache).processPreOrderAll(root);
@@ -600,12 +568,11 @@ public class InstantiateModel {
 		cacheProperties(root, remainingProperties);
 	}
 
-	/*
-	 * returns the instance model URI for a given system implementation
+	/**
+	 * The URI of the instance model file of a component implementation.
 	 *
-	 * @param si
-	 *
-	 * @return URI for instance model file
+	 * @param ci the component implementation
+	 * @return the URI of its instance model file
 	 */
 	public static URI getInstanceModelURI(ComponentImplementation ci) {
 		Resource res = ci.eResource();
@@ -713,18 +680,7 @@ public class InstantiateModel {
 			// Recursively add subcomponents
 			instantiateSubcomponents(ci, impl);
 
-			// TODO now add subprogram calls
-			// EList callseqlist = compimpl.getXAllCallSequence();
-			// for (Iterator it = callseqlist.iterator(); it.hasNext();) {
-			// CallSequence cseq = (CallSequence) it.next();
-			//
-			// EList calllist = cseq.getCall();
-			// for (Iterator iit = calllist.iterator(); iit.hasNext();) {
-			// final SubprogramSubcomponent call =
-			// (SubprogramSubcomponent) iit.next();
-			// instantiateSubcomponent(ci, cseq, call);
-			// }
-			// }
+			// TODO subprogram calls are not instantiated
 		}
 
 		// do it only if subcomponent has type
@@ -791,9 +747,11 @@ public class InstantiateModel {
 	}
 
 	/**
-	 * @param ci
-	 * @param transitions
-	 * @throws InterruptedException
+	 * Add a mode transition instance for every mode transition, with its triggers resolved.
+	 *
+	 * @param ci the component instance to add the mode transition instances to
+	 * @param transitions the mode transitions of its classifier
+	 * @throws InterruptedException if instantiation is canceled
 	 */
 	protected void fillModeTransitions(ComponentInstance ci, List<ModeTransition> transitions)
 			throws InterruptedException {
@@ -853,10 +811,13 @@ public class InstantiateModel {
 		}
 	}
 
-	/*
-	 * @param ci
+	/**
+	 * Add a component instance for every subcomponent, one per array element for a subcomponent that is
+	 * an array.
 	 *
-	 * @param impl
+	 * @param ci the component instance to add the subcomponent instances to
+	 * @param impl the implementation the subcomponents are declared in
+	 * @throws InterruptedException if instantiation is canceled
 	 */
 	protected void instantiateSubcomponents(final ComponentInstance ci, ComponentImplementation impl)
 			throws InterruptedException {
@@ -943,13 +904,6 @@ public class InstantiateModel {
 		if (cc == null) {
 			errManager.warning(newInstance, "Instantiated subcomponent doesn't have a component classifier");
 		} else {
-//			if (cc instanceof ComponentType) {
-//				if (sub instanceof SystemSubcomponent || sub instanceof ProcessSubcomponent
-//						|| sub instanceof ThreadGroupSubcomponent) {
-//					errManager.warning(newInstance, "Instantiated subcomponent has a component type only");
-//				}
-//			}
-
 			newInstance.setClassifier(cc);
 
 			/*
@@ -989,9 +943,13 @@ public class InstantiateModel {
 	}
 
 	/**
-	 * same method but with different name exists in createEndToEndFlowSwitch.
-	 * It adds the flow instances on demand when ETEF is created
-	 * @param ci
+	 * Add a flow specification instance for every flow specification of the component type.
+	 * <p>
+	 * {@code CreateEndToEndFlowsSwitch} has a method of its own for this, which adds flow specification
+	 * instances on demand while an end to end flow is created.
+	 *
+	 * @param ci the component instance to add the flow specification instances to
+	 * @throws InterruptedException if instantiation is canceled
 	 */
 	private void instantiateFlowSpecs(ComponentInstance ci) throws InterruptedException {
 		for (FlowSpecification spec : getComponentType(ci).getAllFlowSpecifications()) {
@@ -1095,11 +1053,12 @@ public class InstantiateModel {
 	/**
 	 * fill in a feature within a feature group
 	 * Take into account the inverse setting on enclosing feature group(s) in setting feature direction
-	 * @param fgi
-	 * @param feature
-	 * @param inverse
-	 * @param index
-	 * @throws InterruptedException
+	 * @param fgi the feature group instance to add the feature instance to
+	 * @param feature the feature to instantiate
+	 * @param inverse whether the enclosing feature group(s) invert the direction of the feature
+	 * @param index the index of the feature instance, zero if the feature is not an array
+	 * @return the new feature instance
+	 * @throws InterruptedException if instantiation is canceled
 	 * @since 3.0
 	 */
 	protected FeatureInstance fillFeatureInstance(FeatureInstance fgi, Feature feature, boolean inverse, int index)
@@ -1132,13 +1091,13 @@ public class InstantiateModel {
 	}
 
 	/**
-	 * fill out the rest of the feature instance
-	 * resolve any prototype first
-	 * @param feature
-	 * @param fi is feature instance of feature
-	 * @param inverse
-	 * @param index
-	 * @throws InterruptedException
+	 * Fill out the rest of a feature instance, resolving a feature prototype first.
+	 *
+	 * @param fi the feature instance of {@code feature}
+	 * @param feature the feature that was instantiated
+	 * @param inverse whether the enclosing feature group(s) invert the direction of the feature
+	 * @param index the index of the feature instance, zero if the feature is not an array
+	 * @throws InterruptedException if instantiation is canceled
 	 */
 	protected void filloutFeatureInstance(FeatureInstance fi, Feature feature, boolean inverse, int index)
 			throws InterruptedException {
@@ -1225,7 +1184,7 @@ public class InstantiateModel {
 				return;
 			} else if (ic.getBindings() != null && ic.getBindings().isEmpty()) {
 				// prototype has not been bound yet
-				errManager.warning(fi, "Feature group prototype  of " + fi.getInstanceObjectPath()
+				errManager.warning(fi, "Feature group prototype of " + fi.getInstanceObjectPath()
 						+ " is not bound yet to feature group type");
 			}
 			FeatureGroupType fgt = (FeatureGroupType) ic.getClassifier();
@@ -1268,8 +1227,14 @@ public class InstantiateModel {
 	}
 
 	/**
-	 * instantiate features in feature group take into account that they can be declared as arrays
-	 * @throws InterruptedException
+	 * Add a feature instance for every feature of a feature group type. A feature declared inside a
+	 * feature group type cannot be an array, so an array declaration is reported and the feature is
+	 * instantiated as a single feature.
+	 *
+	 * @param fgi the feature group instance to add the feature instances to
+	 * @param flist the features of its feature group type
+	 * @param inverse whether the enclosing feature group(s) invert the direction of the features
+	 * @throws InterruptedException if instantiation is canceled
 	 */
 	protected void instantiateFGFeatures(final FeatureInstance fgi, List<Feature> flist, final boolean inverse)
 			throws InterruptedException {
@@ -1319,10 +1284,12 @@ public class InstantiateModel {
 	}
 
 	/**
+	 * Give a feature instance the component instance of its classifier, as a root of its own in the
+	 * instance resource. Features that name the same classifier share one root.
 	 *
-	 * @param classifier
-	 * @return
-	 * @throws InterruptedException
+	 * @param fi the feature instance
+	 * @param fc the classifier of its feature
+	 * @throws InterruptedException if instantiation is canceled
 	 * @since 3.0
 	 */
 	protected void instantiateFeatureClassifier(FeatureInstance fi, FeatureClassifier fc) throws InterruptedException {
@@ -1359,7 +1326,6 @@ public class InstantiateModel {
 				newInstance.setCategory(cc.getCategory());
 				classifierCache.put(newInstance, ic);
 				contents.add(newInstance);
-				// root.getReferencedComponents().add(newInstance);
 				fi.setType(newInstance);
 				/*
 				 * Only establish the hierarchy, which is what discovers further referenced classifiers, and
@@ -1390,8 +1356,6 @@ public class InstantiateModel {
 			PropertyAssociation patternPA = getPA(conni, CONNECTION_PATTERN);
 
 			if (setPA == null && patternPA == null) {
-				// OsateDebug.osateDebug("[InstantiateModel] processConnections");
-
 				LinkedList<Integer> srcDims = new LinkedList<>();
 				LinkedList<Integer> dstDims = new LinkedList<>();
 				LinkedList<Integer> srcSizes = new LinkedList<>();
@@ -1576,7 +1540,6 @@ public class InstantiateModel {
 			return false;
 		}
 		if (isOpposite && !patternName.equalsIgnoreCase("One_To_All") && (dstOffset >= dstSizes.size())) {
-			// verbose exception message
 			errManager.error(conni, "Too few indices for connection source for " + conni.getFullName());
 			return false;
 		}
@@ -1613,13 +1576,10 @@ public class InstantiateModel {
 			}
 		} else {
 			if (!srcSizes.get(srcOffset).equals(dstSizes.get(dstOffset))) {
-//verbose exception message
 				errManager.error(conni,
 						"Array size mismatch (" + patternName + ") on connection " + conni.getFullName() + " in "
 								+ conni.getContainingComponentInstance().getFullName() + ": " + srcSizes.get(srcOffset)
-								+ " at source " + // ("+conni.getSource().getFullName()+")
-								"and " + dstSizes.get(dstOffset) + " at destination." // ("+conni.getSource().getFullName()+")."
-				);
+								+ " at source and " + dstSizes.get(dstOffset) + " at destination.");
 				return false;
 			} else {
 				if (patternName.equalsIgnoreCase("One_To_One")) {
@@ -1744,8 +1704,6 @@ public class InstantiateModel {
 			if (fv.getProperty().getName().equalsIgnoreCase(field)) {
 				ListValue lv = (ListValue) fv.getOwnedValue();
 				EList<PropertyExpression> vlist = lv.getOwnedListElements();
-//				for (int i = vlist.size()-1; i >=0; i--){
-//				PropertyExpression elem = vlist.get(i);
 				for (PropertyExpression elem : vlist) {
 					indices.add(((IntegerLiteral) elem).getValue());
 				}
@@ -1854,10 +1812,12 @@ public class InstantiateModel {
 	}
 
 	/**
-	 * create a copy of the connection instance with the specified indices for the source and the destination
-	 * @param conni
-	 * @param srcIndices
-	 * @param dstIndices
+	 * Create a copy of the connection instance with the specified indices for the source and the
+	 * destination.
+	 *
+	 * @param conni the connection instance to copy
+	 * @param srcIndices the indices of the source end
+	 * @param dstIndices the indices of the destination end
 	 */
 	private void createNewConnection(ConnectionInstance conni, List<Long> srcIndices, List<Long> dstIndices) {
 		ComponentInstance container = conni.getContainingComponentInstance();
@@ -1903,12 +1863,12 @@ public class InstantiateModel {
 
 		String containerPath = container.getInstanceObjectPath();
 		int len = containerPath.length() + 1;
-		String srcPath = (src != null) ? src.getInstanceObjectPath() : "Source end not found";
+		String srcPath = src.getInstanceObjectPath();
 		StringBuilder sb = new StringBuilder();
 		int i = (srcPath.startsWith(containerPath)) ? len : 0;
 		sb.append(srcPath.substring(i));
 		sb.append(" --> ");
-		String dstPath = (dst != null) ? dst.getInstanceObjectPath() : "Destination end not found";
+		String dstPath = dst.getInstanceObjectPath();
 		i = (dstPath.startsWith(containerPath)) ? len : 0;
 		sb.append(dstPath.substring(i));
 
@@ -1925,11 +1885,11 @@ public class InstantiateModel {
 	}
 
 	/**
-	 * create a copy of the connection instance with the specified indices for the source and the destination
-	 * @param conni
-	 * @param srcIndices
-	 * @param dstIndices
-	 * @return
+	 * Create a copy of the connection instance in another element of the array the connection instance
+	 * belongs to.
+	 *
+	 * @param conni the connection instance to copy
+	 * @param targetComponent the component instance the copy belongs to
 	 */
 	private void createNewConnection(ConnectionInstance conni, ComponentInstance targetComponent) {
 		LinkedList<Long> indices = new LinkedList<>();
@@ -1962,12 +1922,12 @@ public class InstantiateModel {
 
 		String containerPath = targetComponent.getInstanceObjectPath();
 		int len = containerPath.length() + 1;
-		String srcPath = (src != null) ? src.getInstanceObjectPath() : "Source end not found";
+		String srcPath = src.getInstanceObjectPath();
 		StringBuilder sb = new StringBuilder();
 		int i = (srcPath.startsWith(containerPath)) ? len : 0;
 		sb.append(srcPath.substring(i));
 		sb.append(" --> ");
-		String dstPath = (dst != null) ? dst.getInstanceObjectPath() : "Destination end not found";
+		String dstPath = dst.getInstanceObjectPath();
 		i = (dstPath.startsWith(containerPath)) ? len : 0;
 		sb.append(dstPath.substring(i));
 
@@ -2036,10 +1996,13 @@ public class InstantiateModel {
 	 * resolve downgoing source or destination of the connection reference.
 	 * we do so by re-retrieving the feature instance based on the existing connection instance end name.
 	 * If the connection reference is up or down going we also fill in the other end.
-	 * @param targetConnRef
-	 * @param result
-	 * @param name
-	 * @param doSource
+	 * @param targetConnRef the connection reference to resolve
+	 * @param outerConnRef the connection reference one level up
+	 * @param target the component instance to resolve the end in
+	 * @param doSource whether to resolve the source end or the destination end
+	 * @param idx the index of the feature instance to resolve to
+	 * @param fgidx the index of the enclosing feature group instance to resolve to
+	 * @return the resolved end
 	 */
 	private ConnectionInstanceEnd resolveConnectionReference(ConnectionReference targetConnRef,
 			ConnectionReference outerConnRef, ComponentInstance target, boolean doSource, long idx, long fgidx) {
@@ -2195,7 +2158,7 @@ public class InstantiateModel {
 							}
 						} catch (IndexOutOfBoundsException e) {
 							errManager.warning(diagnosticTarget,
-									"Too few indices for connection end, using fist array element");
+									"Too few indices for connection end, using first array element");
 						}
 						resolutionContext = (ConnectionInstanceEnd) io;
 						break;
@@ -2299,8 +2262,9 @@ public class InstantiateModel {
 	 * includes the predeclared properties and any property definitions in user
 	 * declared property sets.
 	 *
-	 * @param si System Implementation
-	 * @return property definitions
+	 * @param root the root of the instance model to collect from
+	 * @return the used property definitions
+	 * @throws InterruptedException if instantiation is canceled
 	 * @since 3.0
 	 */
 	public EList<Property> getAllUsedPropertyDefinitions(ComponentInstance root) throws InterruptedException {
@@ -2389,21 +2353,12 @@ public class InstantiateModel {
 	 * @return List holding the used property definitions
 	 */
 	protected void addUsedPropertyDefinitions(Element root, List<Property> result) {
-//		OsateDebug.osateDebug ("[InstantiateModel] addUsedPropertyDefinitions=" + root);
-
 		TreeIterator<Element> it = EcoreUtil.getAllContents(Collections.singleton(root));
 		while (it.hasNext()) {
 			EObject ao = it.next();
-			// OsateDebug.osateDebug ("[InstantiateModel] ao=" + ao);
-
 			if (ao instanceof PropertyAssociation propertyAssociation) {
-				// OsateDebug.osateDebug ("[InstantiateModel] ao=" + ao);
-
 				Property pd = propertyAssociation.getProperty();
-				// OsateDebug.osateDebug ("[InstantiateModel] pd=" + pd);
-
 				if (pd != null) {
-//					OsateDebug.osateDebug ("[InstanceModel] AddUsedProperty " + pd + " to " + root);
 					result.add(pd);
 				}
 			}
@@ -2441,7 +2396,7 @@ public class InstantiateModel {
 				}
 			}
 
-			ArrayList<Node> workState = new ArrayList<>();;
+			ArrayList<Node> workState = new ArrayList<>();
 
 			int modalCount;
 

--- a/core/org.osate.core.tests/models/componentInstantiation/.gitignore
+++ b/core/org.osate.core.tests/models/componentInstantiation/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/componentInstantiation/.project
+++ b/core/org.osate.core.tests/models/componentInstantiation/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>componentInstantiation</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/componentInstantiation/ArrayConstants.aadl
+++ b/core/org.osate.core.tests/models/componentInstantiation/ArrayConstants.aadl
@@ -1,0 +1,28 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- A property constant used as an array size, so that the array size does not come from a literal.
+property set ArrayConstants is
+	Count: constant aadlinteger => 2;
+end ArrayConstants;

--- a/core/org.osate.core.tests/models/componentInstantiation/Arrays.aadl
+++ b/core/org.osate.core.tests/models/componentInstantiation/Arrays.aadl
@@ -1,0 +1,53 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- Subcomponent arrays: one dimension, two dimensions, an empty array, a size taken from a property
+-- constant, and an array nested inside an array element.
+package Arrays
+public
+	with ArrayConstants;
+
+	device Dev
+	end Dev;
+
+	system Mid
+	end Mid;
+
+	system implementation Mid.i
+		subcomponents
+			inner: device Dev [2];
+	end Mid.i;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			one: device Dev [3];
+			grid: device Dev [2][3];
+			empty: device Dev [0];
+			sized: device Dev [ArrayConstants::Count];
+			nested: system Mid.i [2];
+	end Top.i;
+end Arrays;

--- a/core/org.osate.core.tests/models/componentInstantiation/Categories.aadl
+++ b/core/org.osate.core.tests/models/componentInstantiation/Categories.aadl
@@ -1,0 +1,68 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- Where the category of a component instance comes from: the classifier when that is not abstract,
+-- the subcomponent otherwise, and a subcomponent that has no classifier at all.
+package Categories
+public
+	bus B
+	end B;
+
+	bus implementation B.i
+	end B.i;
+
+	process P
+	end P;
+
+	process implementation P.i
+	end P.i;
+
+	abstract Abs
+	end Abs;
+
+	abstract implementation Abs.i
+	end Abs.i;
+
+	system Holder
+		prototypes
+			X: abstract;
+	end Holder;
+
+	system implementation Holder.i
+		subcomponents
+			s: abstract X;
+	end Holder.i;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			bus_bound: system Holder.i (X => bus B.i);
+			process_bound: system Holder.i (X => process P.i);
+			unbound: system Holder.i;
+			plain_abstract: abstract Abs.i;
+			no_classifier: abstract;
+	end Top.i;
+end Categories;

--- a/core/org.osate.core.tests/models/componentInstantiation/CyclicContainment.aadl
+++ b/core/org.osate.core.tests/models/componentInstantiation/CyclicContainment.aadl
@@ -1,0 +1,52 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+-- Deliberately invalid: the validator rejects circular containment, but nothing stops
+-- InstantiateModel from being run on a model that has errors, so the guard against instantiating a
+-- subcomponent that is already in its own ancestry is reachable. A.i contains B.i and B.i contains A.i.
+package CyclicContainment
+public
+	system A
+	end A;
+
+	system implementation A.i
+		subcomponents
+			b: system B.i;
+	end A.i;
+
+	system B
+	end B;
+
+	system implementation B.i
+		subcomponents
+			a: system A.i;
+	end B.i;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			a: system A.i;
+	end Top.i;
+end CyclicContainment;

--- a/core/org.osate.core.tests/models/componentInstantiation/CyclicFeatureGroup.aadl
+++ b/core/org.osate.core.tests/models/componentInstantiation/CyclicFeatureGroup.aadl
@@ -1,0 +1,41 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+-- Deliberately invalid: the validator rejects a feature group type that contains itself, but
+-- instantiation can still be run on it, so the guard against expanding a feature that is already in
+-- its own ancestry is reachable.
+package CyclicFeatureGroup
+public
+	feature group Loop
+		features
+			self_ref: feature group Loop;
+	end Loop;
+
+	system Top
+		features
+			fg: feature group Loop;
+	end Top;
+
+	system implementation Top.i
+	end Top.i;
+end CyclicFeatureGroup;

--- a/core/org.osate.core.tests/models/componentInstantiation/FeatureArrays.aadl
+++ b/core/org.osate.core.tests/models/componentInstantiation/FeatureArrays.aadl
@@ -1,0 +1,57 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- Feature arrays on the classifier categories that are allowed to declare them.
+package FeatureArrays
+public
+	data D
+	end D;
+
+	thread ThreadPorts
+		features
+			ports: in data port D [3];
+	end ThreadPorts;
+
+	system SystemPorts
+		features
+			ports: out event port [2];
+	end SystemPorts;
+
+	process Pr
+	end Pr;
+
+	process implementation Pr.i
+		subcomponents
+			t: thread ThreadPorts;
+	end Pr.i;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			p: process Pr.i;
+			s: system SystemPorts;
+	end Top.i;
+end FeatureArrays;

--- a/core/org.osate.core.tests/models/componentInstantiation/FeatureGroups.aadl
+++ b/core/org.osate.core.tests/models/componentInstantiation/FeatureGroups.aadl
@@ -1,0 +1,75 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- Feature group expansion: nesting, the two ways of inverting, a feature group type that only has
+-- an inverse, extension with a refinement, an empty feature group type, and a feature group with no
+-- type at all.
+package FeatureGroups
+public
+	data D
+	end D;
+
+	feature group Inner
+		features
+			a: in data port D;
+			b: out event port;
+	end Inner;
+
+	feature group Outer
+		features
+			nested: feature group Inner;
+			c: in data port D;
+	end Outer;
+
+	feature group InverseOfInner
+		inverse of Inner
+	end InverseOfInner;
+
+	feature group Base
+		features
+			x: in data port D;
+	end Base;
+
+	feature group Extended extends Base
+		features
+			y: out data port D;
+			x: refined to in data port D;
+	end Extended;
+
+	feature group Empty
+	end Empty;
+
+	system Top
+		features
+			outer: feature group Outer;
+			inverse_type: feature group InverseOfInner;
+			inverse_feature: feature group inverse of Inner;
+			extended: feature group Extended;
+			empty: feature group Empty;
+			no_type: feature group;
+	end Top;
+
+	system implementation Top.i
+	end Top.i;
+end FeatureGroups;

--- a/core/org.osate.core.tests/models/componentInstantiation/FeatureKinds.aadl
+++ b/core/org.osate.core.tests/models/componentInstantiation/FeatureKinds.aadl
@@ -1,0 +1,96 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- One feature of every kind, each on a classifier that is allowed to declare it, so that the feature
+-- category and the direction of a feature instance are pinned down for all of them.
+package FeatureKinds
+public
+	data D
+	end D;
+
+	subprogram Sub
+		features
+			param_in: in parameter D;
+			param_out: out parameter D;
+	end Sub;
+
+	subprogram group SG
+	end SG;
+
+	virtual bus VB
+	end VB;
+
+	bus Bus1
+	end Bus1;
+
+	feature group FG
+		features
+			member: in data port D;
+	end FG;
+
+	thread Th
+		features
+			data_in: in data port D;
+			data_out: out data port D;
+			event_out: out event port;
+			event_data_inout: in out event data port D;
+			data_access_req: requires data access D;
+			data_access_prov: provides data access D;
+			subprogram_access: provides subprogram access Sub;
+			subprogram_group_access: requires subprogram group access SG;
+			fgroup: feature group FG;
+			abstract_plain: feature;
+			abstract_in: in feature;
+			abstract_out: out feature;
+	end Th;
+
+	thread implementation Th.i
+		subcomponents
+			called: subprogram Sub;
+	end Th.i;
+
+	process Pr
+	end Pr;
+
+	process implementation Pr.i
+		subcomponents
+			t: thread Th.i;
+	end Pr.i;
+
+	device Dev
+		features
+			bus_access_req: requires bus access Bus1;
+			bus_access_prov: provides bus access Bus1;
+			virtual_bus_access: requires virtual bus access VB;
+	end Dev;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			p: process Pr.i;
+			d: device Dev;
+	end Top.i;
+end FeatureKinds;

--- a/core/org.osate.core.tests/models/componentInstantiation/FlowSpecs.aadl
+++ b/core/org.osate.core.tests/models/componentInstantiation/FlowSpecs.aadl
@@ -1,0 +1,71 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- Flow specification instances: source, sink, path, a flow end reached through a feature group, and a
+-- flow specification restricted to a mode and to a mode transition.
+package FlowSpecs
+public
+	data D
+	end D;
+
+	feature group FG
+		features
+			a: in data port D;
+	end FG;
+
+	device Dev
+		features
+			in_p: in data port D;
+			out_p: out data port D;
+			fg: feature group FG;
+		flows
+			src: flow source out_p;
+			snk: flow sink in_p;
+			thru: flow path in_p -> out_p;
+			fg_thru: flow path fg.a -> out_p;
+	end Dev;
+
+	device Modal
+		features
+			in_p: in data port D;
+			out_p: out data port D;
+			trigger: in event port;
+		flows
+			modal_path: flow path in_p -> out_p in modes (m1);
+			transition_path: flow path in_p -> out_p in modes (t12);
+		modes
+			m1: initial mode;
+			m2: mode;
+			t12: m1 -[ trigger ]-> m2;
+	end Modal;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			d: device Dev;
+			m: device Modal;
+	end Top.i;
+end FlowSpecs;

--- a/core/org.osate.core.tests/models/componentInstantiation/Hierarchy.aadl
+++ b/core/org.osate.core.tests/models/componentInstantiation/Hierarchy.aadl
@@ -1,0 +1,67 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- Component hierarchy shapes: nesting, declaration order, a subcomponent without a classifier,
+-- a subcomponent with a component type only, and a root that is not a system.
+package Hierarchy
+public
+	data Dat
+	end Dat;
+
+	bus Bus1
+	end Bus1;
+
+	thread Th
+	end Th;
+
+	thread implementation Th.i
+		subcomponents
+			d: data Dat;
+	end Th.i;
+
+	process Proc
+	end Proc;
+
+	process implementation Proc.i
+		subcomponents
+			t1: thread Th.i;
+			t2: thread Th.i;
+	end Proc.i;
+
+	system WithFeatures
+		features
+			p: in data port Dat;
+	end WithFeatures;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			p: process Proc.i;
+			b: bus Bus1;
+			untyped: system;
+			typeonly: system WithFeatures;
+	end Top.i;
+end Hierarchy;

--- a/core/org.osate.core.tests/models/componentInstantiation/InvalidFeatureArrays.aadl
+++ b/core/org.osate.core.tests/models/componentInstantiation/InvalidFeatureArrays.aadl
@@ -1,0 +1,56 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+-- Deliberately invalid: the validator allows feature arrays only in abstract, thread, device, memory,
+-- system and processor classifiers, but instantiation can still be run on a model that declares them
+-- elsewhere, so the "no array allowed here" paths are reachable. A multi dimensional feature array is
+-- not written here because the grammar accepts only one dimension on a feature.
+package InvalidFeatureArrays
+public
+	data D
+	end D;
+
+	process NotAllowed
+		features
+			ports: in data port D [3];
+	end NotAllowed;
+
+	feature group FG
+		features
+			inner: in data port D [2];
+	end FG;
+
+	system WithFeatureGroup
+		features
+			fg: feature group FG;
+	end WithFeatureGroup;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			p: process NotAllowed;
+			g: system WithFeatureGroup;
+	end Top.i;
+end InvalidFeatureArrays;

--- a/core/org.osate.core.tests/models/componentInstantiation/MissingParentMode.aadl
+++ b/core/org.osate.core.tests/models/componentInstantiation/MissingParentMode.aadl
@@ -1,0 +1,47 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- A subcomponent with a required mode that the containing component does not have, so the implicit
+-- mode map cannot be established.
+package MissingParentMode
+public
+	system Child
+		requires modes
+			nomatch: mode;
+	end Child;
+
+	system implementation Child.i
+	end Child.i;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			child: system Child.i;
+		modes
+			m1: initial mode;
+			m2: mode;
+	end Top.i;
+end MissingParentMode;

--- a/core/org.osate.core.tests/models/componentInstantiation/ModeInstantiation.aadl
+++ b/core/org.osate.core.tests/models/componentInstantiation/ModeInstantiation.aadl
@@ -1,0 +1,76 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- Mode instances: own modes, a modal subcomponent, required modes mapped explicitly and by name, and
+-- required modes of a root, which are not derived because there is no containing component.
+package ModeInstantiation
+public
+	system Plain
+	end Plain;
+
+	system implementation Plain.i
+	end Plain.i;
+
+	system OwnModes
+	end OwnModes;
+
+	system implementation OwnModes.i
+		modes
+			o1: initial mode;
+			o2: mode;
+	end OwnModes.i;
+
+	system Derived
+		requires modes
+			d1: mode;
+			d2: mode;
+	end Derived;
+
+	system implementation Derived.i
+	end Derived.i;
+
+	system DerivedByName
+		requires modes
+			m1: mode;
+			m2: mode;
+	end DerivedByName;
+
+	system implementation DerivedByName.i
+	end DerivedByName.i;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			always: system Plain.i;
+			only_m1: system Plain.i in modes (m1);
+			own: system OwnModes.i;
+			derived_explicit: system Derived.i in modes (m1 => d1, m2 => d2);
+			derived_implicit: system DerivedByName.i;
+		modes
+			m1: initial mode;
+			m2: mode;
+	end Top.i;
+end ModeInstantiation;

--- a/core/org.osate.core.tests/models/componentInstantiation/ModeTransitions.aadl
+++ b/core/org.osate.core.tests/models/componentInstantiation/ModeTransitions.aadl
@@ -1,0 +1,61 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- Mode transition instances: a named transition, generated names for unnamed ones, triggers reached
+-- through a subcomponent, through a feature group and directly, several triggers on one transition,
+-- and a trigger that is an internal event rather than a port.
+package ModeTransitions
+public
+	device Sensor
+		features
+			trigger: out event port;
+	end Sensor;
+
+	feature group FG
+		features
+			fg_trigger: in event port;
+	end FG;
+
+	system Top
+		features
+			top_trigger: in event port;
+			fg: feature group FG;
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			s: device Sensor;
+		internal features
+			ie: event;
+		modes
+			m1: initial mode;
+			m2: mode;
+			m3: mode;
+			named: m1 -[ s.trigger ]-> m2;
+			m2 -[ top_trigger ]-> m3;
+			m3 -[ fg.fg_trigger ]-> m1;
+			m3 -[ s.trigger, top_trigger ]-> m2;
+			m1 -[ self.ie ]-> m3;
+	end Top.i;
+end ModeTransitions;

--- a/core/org.osate.core.tests/models/componentInstantiation/PropertyCaching.aadl
+++ b/core/org.osate.core.tests/models/componentInstantiation/PropertyCaching.aadl
@@ -1,0 +1,52 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- A property declared on a classifier and a contained property association that applies to one of two
+-- identical subcomponents, so that property caching over the finished hierarchy is visible.
+package PropertyCaching
+public
+	thread Worker
+		properties
+			Period => 10 ms;
+	end Worker;
+
+	process Pr
+	end Pr;
+
+	process implementation Pr.i
+		subcomponents
+			t: thread Worker;
+			u: thread Worker;
+		properties
+			Period => 20 ms applies to u;
+	end Pr.i;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			p: process Pr.i;
+	end Top.i;
+end PropertyCaching;

--- a/core/org.osate.core.tests/models/componentInstantiation/PrototypeResolution.aadl
+++ b/core/org.osate.core.tests/models/componentInstantiation/PrototypeResolution.aadl
@@ -1,0 +1,82 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- Prototypes as seen by instantiation: a component prototype with and without a binding and with a
+-- constraining classifier, a feature prototype bound to a port and to an access, and a feature group
+-- prototype with and without a binding.
+package PrototypeResolution
+public
+	data D
+	end D;
+
+	bus B
+	end B;
+
+	bus implementation B.i
+	end B.i;
+
+	feature group FGT
+		features
+			p: in data port D;
+	end FGT;
+
+	system ComponentProto
+		prototypes
+			unconstrained: bus;
+			constrained: bus B;
+	end ComponentProto;
+
+	system implementation ComponentProto.i
+		subcomponents
+			u: bus unconstrained;
+			c: bus constrained;
+	end ComponentProto.i;
+
+	abstract FeatureProto
+		prototypes
+			fp: in feature;
+		features
+			f: in prototype fp;
+	end FeatureProto;
+
+	abstract FeatureGroupProto
+		prototypes
+			fgp: feature group;
+		features
+			fg: feature group fgp;
+	end FeatureGroupProto;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			component_unbound: system ComponentProto.i;
+			component_bound: system ComponentProto.i (unconstrained => bus B.i, constrained => bus B.i);
+			feature_port: abstract FeatureProto (fp => in data port D);
+			feature_access: abstract FeatureProto (fp => requires data access D);
+			feature_unbound: abstract FeatureProto;
+			group_bound: abstract FeatureGroupProto (fgp => feature group FGT);
+	end Top.i;
+end PrototypeResolution;

--- a/core/org.osate.core.tests/models/componentInstantiation/ReferencedClassifiers.aadl
+++ b/core/org.osate.core.tests/models/componentInstantiation/ReferencedClassifiers.aadl
@@ -1,0 +1,65 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- A feature that has a component classifier makes instantiation create a root of its own for that
+-- classifier, next to the system instance in the same resource. Two features with the same
+-- classifier share one root.
+package ReferencedClassifiers
+public
+	data Field
+	end Field;
+
+	data D
+	end D;
+
+	data implementation D.i
+		subcomponents
+			field: data Field;
+	end D.i;
+
+	thread Th
+		features
+			p1: in data port D.i;
+			p2: out data port D.i;
+			p3: in data port D;
+			shared: requires data access D.i;
+			event_no_classifier: out event port;
+	end Th;
+
+	process Pr
+	end Pr;
+
+	process implementation Pr.i
+		subcomponents
+			t: thread Th;
+	end Pr.i;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			p: process Pr.i;
+	end Top.i;
+end ReferencedClassifiers;

--- a/core/org.osate.core.tests/models/componentInstantiation/SystemOperationModes.aadl
+++ b/core/org.osate.core.tests/models/componentInstantiation/SystemOperationModes.aadl
@@ -1,0 +1,102 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- System operation modes: a model with no modes at all, the product of two modal components, a
+-- modal component that is inactive in one of its parent's modes, and required modes that restrict the
+-- product to the mapped combinations.
+package SystemOperationModes
+public
+	system Plain
+	end Plain;
+
+	system implementation Plain.i
+	end Plain.i;
+
+	system TwoModes
+	end TwoModes;
+
+	system implementation TwoModes.i
+		modes
+			a1: initial mode;
+			a2: mode;
+	end TwoModes.i;
+
+	system ThreeModes
+	end ThreeModes;
+
+	system implementation ThreeModes.i
+		modes
+			b1: initial mode;
+			b2: mode;
+			b3: mode;
+	end ThreeModes.i;
+
+	system NonModal
+	end NonModal;
+
+	system implementation NonModal.i
+		subcomponents
+			s: system Plain.i;
+	end NonModal.i;
+
+	system Product
+	end Product;
+
+	system implementation Product.i
+		subcomponents
+			a: system TwoModes.i;
+			b: system ThreeModes.i;
+	end Product.i;
+
+	system Nested
+	end Nested;
+
+	system implementation Nested.i
+		subcomponents
+			inner: system TwoModes.i in modes (n1);
+		modes
+			n1: initial mode;
+			n2: mode;
+	end Nested.i;
+
+	system DerivedChild
+		requires modes
+			n1: mode;
+			n2: mode;
+	end DerivedChild;
+
+	system implementation DerivedChild.i
+	end DerivedChild.i;
+
+	system DerivedParent
+	end DerivedParent;
+
+	system implementation DerivedParent.i
+		subcomponents
+			child: system DerivedChild.i;
+		modes
+			n1: initial mode;
+			n2: mode;
+	end DerivedParent.i;
+end SystemOperationModes;

--- a/core/org.osate.core.tests/models/componentInstantiation/UnboundFeatureGroupPrototype.aadl
+++ b/core/org.osate.core.tests/models/componentInstantiation/UnboundFeatureGroupPrototype.aadl
@@ -1,0 +1,43 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- A feature group typed with a feature group prototype that is not bound and has no constraining
+-- feature group type.
+package UnboundFeatureGroupPrototype
+public
+	abstract FeatureGroupProto
+		prototypes
+			fgp: feature group;
+		features
+			fg: feature group fgp;
+	end FeatureGroupProto;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			unbound: abstract FeatureGroupProto;
+	end Top.i;
+end UnboundFeatureGroupPrototype;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/AbstractComponentInstantiationTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/AbstractComponentInstantiationTest.java
@@ -1,0 +1,263 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.instantiation.components;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.Element;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.aadl2.instance.FeatureInstance;
+import org.osate.aadl2.instance.FlowSpecificationInstance;
+import org.osate.aadl2.instance.InstanceObject;
+import org.osate.aadl2.instance.ModeInstance;
+import org.osate.aadl2.instance.ModeTransitionInstance;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instance.SystemOperationMode;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter.Message;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * Shared plumbing for the tests that characterize what {@code InstantiateModel} makes of the
+ * component hierarchy: the fixture project, one instantiation per test, and readers that turn the
+ * instance model into values a test can compare against.
+ *
+ * <p>
+ * Diagnostics are collected with an in-memory queuing reporter instead of workspace markers, so a
+ * test reads what a run reported without touching the workspace.
+ * </p>
+ */
+abstract class AbstractComponentInstantiationTest extends XtextTest {
+	private static final String PROJECT = "org.osate.core.tests/models/componentInstantiation/";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	/**
+	 * Parse {@code fileName}, insist that it has no AADL issues, and instantiate the named component
+	 * implementation from it.
+	 *
+	 * @param fileName the fixture file, relative to the fixture project
+	 * @param implementationName the component implementation to instantiate
+	 * @param referenced further fixture files the fixture needs in the resource set
+	 */
+	protected InstantiationResult instantiate(String fileName, String implementationName, String... referenced)
+			throws Exception {
+		return instantiate(fileName, implementationName, true, referenced);
+	}
+
+	/**
+	 * Parse {@code fileName} and instantiate the named component implementation from it without insisting
+	 * that the model is valid.
+	 *
+	 * <p>
+	 * Nothing keeps instantiation from running on a model the validator rejects, so the guards
+	 * {@code InstantiateModel} has against ill-formed models are reachable and worth pinning. A test that
+	 * uses this reads {@link InstantiationResult#aadlIssues()} as well, so that the fixture cannot drift
+	 * into a different kind of invalid without the test noticing.
+	 * </p>
+	 */
+	protected InstantiationResult instantiateIgnoringAadlIssues(String fileName, String implementationName,
+			String... referenced) throws Exception {
+		return instantiate(fileName, implementationName, false, referenced);
+	}
+
+	private InstantiationResult instantiate(String fileName, String implementationName, boolean requireValid,
+			String... referenced) throws Exception {
+		String[] referencedPaths = new String[referenced.length];
+		for (int i = 0; i < referenced.length; i++) {
+			referencedPaths[i] = PROJECT + referenced[i];
+		}
+		AadlPackage pkg = testHelper.parseFile(PROJECT + fileName, referencedPaths);
+		List<String> aadlIssues = validationHelper.validate(pkg)
+				.stream()
+				.map(issue -> issue.getSeverity() + ": " + issue.getMessage())
+				.toList();
+		if (requireValid) {
+			assertEquals(fileName + " must be a valid AADL model", List.of(), aadlIssues);
+		}
+		ComponentImplementation impl = findImplementation(pkg, implementationName);
+		var errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+		SystemInstance instance = InstantiateModel.instantiate(impl, errorManager);
+		var reporter = (QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource());
+		return new InstantiationResult(impl, instance, reporter.getErrors(), aadlIssues);
+	}
+
+	/**
+	 * Parse {@code fileName} and hand back the named component implementation without instantiating it,
+	 * for the few tests that drive instantiation themselves.
+	 */
+	protected ComponentImplementation implementation(String fileName, String implementationName) throws Exception {
+		AadlPackage pkg = testHelper.parseFile(PROJECT + fileName);
+		validationHelper.assertNoIssues(pkg);
+		return findImplementation(pkg, implementationName);
+	}
+
+	private static ComponentImplementation findImplementation(AadlPackage pkg, String name) {
+		return (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals(name))
+				.findFirst()
+				.orElseThrow(() -> new IllegalStateException("No component implementation named " + name));
+	}
+
+	/**
+	 * One instantiation: what it was made from, what it produced, what it reported, and what the AADL
+	 * validator had to say about the fixture.
+	 */
+	protected record InstantiationResult(ComponentImplementation implementation, SystemInstance instance,
+			List<Message> messages, List<String> aadlIssues) {
+	}
+
+	// Readers over the component hierarchy
+
+	protected static ComponentInstance component(ComponentInstance parent, String name) {
+		return parent.getComponentInstances()
+				.stream()
+				.filter(component -> component.getName().equals(name))
+				.findFirst()
+				.orElseThrow(() -> new IllegalStateException("No component instance " + name + " in " + path(parent)));
+	}
+
+	/** All instances of one subcomponent declaration, in the order they were created. */
+	protected static List<ComponentInstance> components(ComponentInstance parent, String name) {
+		return parent.getComponentInstances().stream().filter(component -> component.getName().equals(name)).toList();
+	}
+
+	protected static List<String> componentNames(ComponentInstance parent) {
+		return parent.getComponentInstances().stream().map(ComponentInstance::getName).toList();
+	}
+
+	// Readers over features
+
+	protected static FeatureInstance feature(ComponentInstance owner, String name) {
+		return owner.getFeatureInstances()
+				.stream()
+				.filter(feature -> feature.getName().equals(name))
+				.findFirst()
+				.orElseThrow(() -> new IllegalStateException("No feature instance " + name + " in " + path(owner)));
+	}
+
+	protected static FeatureInstance feature(FeatureInstance owner, String name) {
+		return owner.getFeatureInstances()
+				.stream()
+				.filter(feature -> feature.getName().equals(name))
+				.findFirst()
+				.orElseThrow(() -> new IllegalStateException("No feature instance " + name + " in " + path(owner)));
+	}
+
+	protected static List<FeatureInstance> features(ComponentInstance owner, String name) {
+		return owner.getFeatureInstances().stream().filter(feature -> feature.getName().equals(name)).toList();
+	}
+
+	protected static List<String> featureNames(ComponentInstance owner) {
+		return owner.getFeatureInstances().stream().map(FeatureInstance::getName).toList();
+	}
+
+	protected static List<String> featureNames(FeatureInstance owner) {
+		return owner.getFeatureInstances().stream().map(FeatureInstance::getName).toList();
+	}
+
+	// Readers over modes, flows and diagnostics
+
+	protected static List<String> modeNames(ComponentInstance owner) {
+		return owner.getModeInstances().stream().map(ModeInstance::getName).toList();
+	}
+
+	protected static ModeInstance mode(ComponentInstance owner, String name) {
+		return owner.getModeInstances()
+				.stream()
+				.filter(modeInstance -> modeInstance.getName().equals(name))
+				.findFirst()
+				.orElseThrow(() -> new IllegalStateException("No mode instance " + name + " in " + path(owner)));
+	}
+
+	protected static ModeTransitionInstance transition(ComponentInstance owner, String name) {
+		return owner.getModeTransitionInstances()
+				.stream()
+				.filter(transitionInstance -> transitionInstance.getName().equals(name))
+				.findFirst()
+				.orElseThrow(() -> new IllegalStateException("No mode transition instance " + name));
+	}
+
+	protected static List<String> transitionNames(ComponentInstance owner) {
+		return owner.getModeTransitionInstances().stream().map(ModeTransitionInstance::getName).toList();
+	}
+
+	protected static FlowSpecificationInstance flowSpecification(ComponentInstance owner, String name) {
+		return owner.getFlowSpecifications()
+				.stream()
+				.filter(flow -> flow.getName().equals(name))
+				.findFirst()
+				.orElseThrow(() -> new IllegalStateException("No flow specification instance " + name));
+	}
+
+	protected static List<String> flowSpecificationNames(ComponentInstance owner) {
+		return owner.getFlowSpecifications().stream().map(FlowSpecificationInstance::getName).toList();
+	}
+
+	protected static List<String> somNames(SystemInstance instance) {
+		return instance.getSystemOperationModes().stream().map(SystemOperationMode::getName).toList();
+	}
+
+	/** The current modes of every system operation mode, by instance object path. */
+	protected static List<List<String>> somModes(SystemInstance instance) {
+		return instance.getSystemOperationModes()
+				.stream()
+				.map(som -> som.getCurrentModes().stream().map(AbstractComponentInstantiationTest::path).toList())
+				.toList();
+	}
+
+	protected static List<String> paths(List<? extends InstanceObject> objects) {
+		return objects.stream().map(AbstractComponentInstantiationTest::path).toList();
+	}
+
+	protected static String path(InstanceObject object) {
+		return object.getInstanceObjectPath();
+	}
+
+	/** Every reported diagnostic as {@code kind path: message}, in the order it was reported. */
+	protected static List<String> diagnostics(InstantiationResult result) {
+		return result.messages().stream().map(message -> message.kind + " " + where(message.where) + ": "
+				+ message.message).toList();
+	}
+
+	private static String where(Element element) {
+		return element instanceof InstanceObject instanceObject ? path(instanceObject) : String.valueOf(element);
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/ComponentCategoryInstantiationTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/ComponentCategoryInstantiationTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.instantiation.components;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.ComponentCategory;
+import org.osate.testsupport.Aadl2InjectorProvider;
+
+/**
+ * Where the category of a component instance comes from. A subcomponent declared abstract takes the
+ * category of the classifier it ends up with, which for a prototype is only known once the prototype
+ * is resolved; a subcomponent with no classifier keeps the category it was declared with.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class ComponentCategoryInstantiationTest extends AbstractComponentInstantiationTest {
+	private static final String FILE = "Categories.aadl";
+
+	/** An abstract subcomponent bound to a bus classifier becomes a bus. */
+	@Test
+	public void categoryComesFromTheClassifierWhenThatIsNotAbstract() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+
+		var bus = component(component(result.instance(), "bus_bound"), "s");
+		assertEquals(ComponentCategory.BUS, bus.getCategory());
+		assertEquals("Categories::B.i", bus.getClassifier().getQualifiedName());
+
+		var process = component(component(result.instance(), "process_bound"), "s");
+		assertEquals(ComponentCategory.PROCESS, process.getCategory());
+		assertEquals("Categories::P.i", process.getClassifier().getQualifiedName());
+	}
+
+	/** Two abstract ends stay abstract. */
+	@Test
+	public void categoryStaysAbstractWhenBothEndsAreAbstract() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+		var abstractInstance = component(result.instance(), "plain_abstract");
+
+		assertEquals(ComponentCategory.ABSTRACT, abstractInstance.getCategory());
+		assertEquals("Categories::Abs.i", abstractInstance.getClassifier().getQualifiedName());
+	}
+
+	/**
+	 * A subcomponent that never gets a classifier - declared without one, or typed with a prototype that
+	 * is neither bound nor constrained - keeps the declared category and is reported.
+	 */
+	@Test
+	public void subcomponentWithoutClassifierKeepsItsDeclaredCategory() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+
+		var declaredWithout = component(result.instance(), "no_classifier");
+		assertEquals(ComponentCategory.ABSTRACT, declaredWithout.getCategory());
+		assertNull(declaredWithout.getClassifier());
+
+		var unresolvedPrototype = component(component(result.instance(), "unbound"), "s");
+		assertEquals(ComponentCategory.ABSTRACT, unresolvedPrototype.getCategory());
+		assertNull(unresolvedPrototype.getClassifier());
+
+		assertEquals(List.of(
+				"Warning Top_i_Instance.no_classifier: Instantiated subcomponent doesn't have a component classifier",
+				"Warning Top_i_Instance.unbound.s: Instantiated subcomponent doesn't have a component classifier"),
+				diagnostics(result));
+	}
+
+	/** The same implementation instantiated twice with different bindings produces different categories. */
+	@Test
+	public void prototypeBindingIsResolvedPerSubcomponentInstance() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+
+		assertEquals(List.of("plain_abstract", "no_classifier", "bus_bound", "process_bound", "unbound"),
+				componentNames(result.instance()));
+		assertEquals("Categories::Holder.i",
+				component(result.instance(), "bus_bound").getClassifier().getQualifiedName());
+		assertEquals("Categories::Holder.i",
+				component(result.instance(), "process_bound").getClassifier().getQualifiedName());
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/ComponentHierarchyInstantiationTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/ComponentHierarchyInstantiationTest.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.instantiation.components;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.ComponentCategory;
+import org.osate.testsupport.Aadl2InjectorProvider;
+
+/**
+ * What instantiation makes of the component hierarchy: the root, the shape of the tree below it, the
+ * order the subcomponent instances appear in, and the two subcomponents that carry less than a full
+ * classifier.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class ComponentHierarchyInstantiationTest extends AbstractComponentInstantiationTest {
+	private static final String FILE = "Hierarchy.aadl";
+
+	/**
+	 * The root is named after the type and implementation name of what was instantiated, carries both
+	 * the implementation and the classifier, and is the first object in the instance resource.
+	 */
+	@Test
+	public void rootIsNamedAfterTheImplementation() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+		var root = result.instance();
+
+		assertEquals("Top_i_Instance", root.getName());
+		assertEquals("Top_i_Instance", path(root));
+		assertEquals(ComponentCategory.SYSTEM, root.getCategory());
+		assertSame(result.implementation(), root.getComponentImplementation());
+		assertSame(result.implementation(), root.getClassifier());
+		assertTrue(root.getIndices().isEmpty());
+		assertNull(root.eContainer());
+		assertSame(root, root.eResource().getContents().get(0));
+	}
+
+	/**
+	 * Subcomponent instances are grouped by the kind of subcomponent they come from, not created in
+	 * declaration order. {@code Top.i} declares p, b, untyped, typeonly.
+	 */
+	@Test
+	public void subcomponentInstancesAreGroupedByKind() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+
+		assertEquals(List.of("b", "p", "untyped", "typeonly"), componentNames(result.instance()));
+	}
+
+	/**
+	 * Every level of the declarative hierarchy becomes a level of component instances, once per
+	 * subcomponent, and a subcomponent that is not an array is indexed with a single zero.
+	 */
+	@Test
+	public void hierarchyIsInstantiatedOncePerSubcomponent() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+		var root = result.instance();
+
+		var process = component(root, "p");
+		assertEquals(List.of("t1", "t2"), componentNames(process));
+		assertSame(root, process.getContainingComponentInstance());
+		assertEquals(List.of(0L), process.getIndices());
+
+		var thread = component(process, "t1");
+		assertEquals(ComponentCategory.THREAD, thread.getCategory());
+		assertEquals("Top_i_Instance.p.t1", path(thread));
+
+		var data = component(thread, "d");
+		assertEquals(ComponentCategory.DATA, data.getCategory());
+		assertEquals("Top_i_Instance.p.t1.d", path(data));
+		assertTrue(data.getComponentInstances().isEmpty());
+	}
+
+	/**
+	 * A subcomponent instance refers back to the subcomponent it was created from, which is what tells
+	 * the two instances of the same classifier apart.
+	 */
+	@Test
+	public void subcomponentInstanceRefersToItsDeclaration() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+		var process = component(result.instance(), "p");
+
+		var t1 = component(process, "t1");
+		var t2 = component(process, "t2");
+		assertEquals("t1", t1.getSubcomponent().getName());
+		assertEquals("t2", t2.getSubcomponent().getName());
+		assertSame(t1.getClassifier(), t2.getClassifier());
+	}
+
+	/**
+	 * A subcomponent without a classifier is reported as a warning, keeps the category it was declared
+	 * with, and gets no classifier and no contents.
+	 */
+	@Test
+	public void subcomponentWithoutClassifierIsReported() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+		var untyped = component(result.instance(), "untyped");
+
+		assertEquals(ComponentCategory.SYSTEM, untyped.getCategory());
+		assertNull(untyped.getClassifier());
+		assertTrue(untyped.getComponentInstances().isEmpty());
+		assertTrue(untyped.getFeatureInstances().isEmpty());
+		assertEquals(List.of("Warning Top_i_Instance.untyped: "
+				+ "Instantiated subcomponent doesn't have a component classifier"), diagnostics(result));
+	}
+
+	/**
+	 * A subcomponent whose classifier is a component type gets that type's features but nothing below
+	 * it, because there is no implementation to take subcomponents from.
+	 */
+	@Test
+	public void subcomponentWithComponentTypeOnlyGetsFeaturesOnly() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+		var typeOnly = component(result.instance(), "typeonly");
+
+		assertEquals("Hierarchy::WithFeatures", typeOnly.getClassifier().getQualifiedName());
+		assertEquals(List.of("p"), featureNames(typeOnly));
+		assertTrue(typeOnly.getComponentInstances().isEmpty());
+	}
+
+	/**
+	 * The root does not have to be a system. Instantiating a process implementation produces a system
+	 * instance object whose category is the category of that implementation.
+	 */
+	@Test
+	public void rootCanBeANonSystemImplementation() throws Exception {
+		var result = instantiate(FILE, "Proc.i");
+		var root = result.instance();
+
+		assertEquals("Proc_i_Instance", root.getName());
+		assertEquals(ComponentCategory.PROCESS, root.getCategory());
+		assertEquals(List.of("t1", "t2"), componentNames(root));
+		assertEquals(List.of(), diagnostics(result));
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/CyclicContainmentInstantiationTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/CyclicContainmentInstantiationTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.instantiation.components;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.testsupport.Aadl2InjectorProvider;
+
+/**
+ * The two guards that keep instantiation from recursing forever on a model that contains itself. The
+ * AADL validator rejects both shapes, but nothing keeps {@code InstantiateModel} from being run on a
+ * model that has errors, so both guards are reachable and both are what stands between such a model and
+ * a stack overflow.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class CyclicContainmentInstantiationTest extends AbstractComponentInstantiationTest {
+
+	/**
+	 * Two implementations that contain each other. The hierarchy is built until a subcomponent turns up
+	 * that is already in its own ancestry, and that subcomponent is reported instead of instantiated.
+	 */
+	@Test
+	public void subcomponentThatContainsItselfIsReportedOnce() throws Exception {
+		var result = instantiateIgnoringAadlIssues("CyclicContainment.aadl", "Top.i");
+		var root = result.instance();
+
+		assertEquals(List.of("ERROR: Invalid circular dependency. Subcomponent 'b' directly or indirectly contains "
+				+ "'A.i'.",
+				"ERROR: Invalid circular dependency. Subcomponent 'a' directly or indirectly contains 'B.i'.",
+				"ERROR: Invalid circular dependency. Subcomponent 'a' directly or indirectly contains 'Top.i'."),
+				result.aadlIssues());
+
+		var outer = component(root, "a");
+		var middle = component(outer, "b");
+		var inner = component(middle, "a");
+		assertEquals("Top_i_Instance.a.b.a", path(inner));
+		assertTrue(inner.getComponentInstances().isEmpty());
+		assertEquals(List.of("Error Top_i_Instance.a.b.a: Cyclic containment dependency: Subcomponent 'b' has "
+				+ "already been instantiated as enclosing component."), diagnostics(result));
+	}
+
+	/**
+	 * A feature group type that contains itself. One level of the member is created, and the expansion of
+	 * that member stops with the feature reported on the feature instance being expanded.
+	 */
+	@Test
+	public void featureGroupThatContainsItselfIsReportedOnce() throws Exception {
+		var result = instantiateIgnoringAadlIssues("CyclicFeatureGroup.aadl", "Top.i");
+
+		assertEquals(List.of("ERROR: Feature group directly or indirectly contains itself"), result.aadlIssues());
+
+		var group = feature(result.instance(), "fg");
+		assertEquals(List.of("self_ref"), featureNames(group));
+		var member = feature(group, "self_ref");
+		assertTrue(member.getFeatureInstances().isEmpty());
+		assertEquals(List.of("Error Top_i_Instance.fg.self_ref: Cyclic containment dependency: Feature 'self_ref' "
+				+ "has already been instantiated as enclosing feature group."), diagnostics(result));
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/FeatureArrayInstantiationTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/FeatureArrayInstantiationTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.instantiation.components;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.instance.FeatureInstance;
+import org.osate.testsupport.Aadl2InjectorProvider;
+
+/**
+ * What instantiation makes of feature arrays. Like subcomponent array elements, the feature instances
+ * all carry the name of the feature; unlike them, a feature instance is indexed with a single number
+ * rather than a list, and that number starts at one for an array and is zero for a feature that is not
+ * one.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class FeatureArrayInstantiationTest extends AbstractComponentInstantiationTest {
+	private static final String FILE = "FeatureArrays.aadl";
+
+	@Test
+	public void featureArrayIsIndexedFromOne() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+		var thread = component(component(result.instance(), "p"), "t");
+
+		var ports = features(thread, "ports");
+		assertEquals(3, ports.size());
+		assertEquals(List.of(1L, 2L, 3L), ports.stream().map(FeatureInstance::getIndex).toList());
+		assertEquals(List.of("Top_i_Instance.p.t.ports[1]", "Top_i_Instance.p.t.ports[2]",
+				"Top_i_Instance.p.t.ports[3]"), paths(ports));
+		assertSame(ports.get(0).getFeature(), ports.get(2).getFeature());
+		assertEquals(List.of("ports", "ports", "ports"), featureNames(thread));
+	}
+
+	@Test
+	public void featureArrayOnASystemIsInstantiatedTheSameWay() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+		var system = component(result.instance(), "s");
+
+		var ports = features(system, "ports");
+		assertEquals(2, ports.size());
+		assertEquals(List.of(1L, 2L), ports.stream().map(FeatureInstance::getIndex).toList());
+		assertEquals(List.of(), diagnostics(result));
+	}
+
+	/**
+	 * A feature array on a classifier that may not have one, and a feature array declared inside a
+	 * feature group type, are both instantiated as a single feature with a warning. The AADL validator
+	 * rejects both, but instantiation can be run on a model that has errors, so both paths are reachable.
+	 *
+	 * <p>
+	 * The neighbouring warning about a feature array with more than one dimension has no test, because
+	 * the grammar accepts only one dimension on a feature, so no model can reach it.
+	 * </p>
+	 */
+	@Test
+	public void arrayWhereNoArrayIsAllowedBecomesASingleFeature() throws Exception {
+		var result = instantiateIgnoringAadlIssues("InvalidFeatureArrays.aadl", "Top.i");
+		var root = result.instance();
+
+		String notAllowed = "Feature arrays are allowed only in abstract, thread, device, memory, system, and "
+				+ "processor classifiers.";
+		assertEquals(List.of("ERROR: " + notAllowed, "ERROR: " + notAllowed), result.aadlIssues());
+
+		var onProcess = features(component(root, "p"), "ports");
+		assertEquals(1, onProcess.size());
+		assertEquals(0, onProcess.get(0).getIndex());
+		assertEquals("Top_i_Instance.p.ports", path(onProcess.get(0)));
+
+		var group = feature(component(root, "g"), "fg");
+		assertEquals(List.of("inner"), featureNames(group));
+		assertEquals(0, feature(group, "inner").getIndex());
+
+		assertEquals(List.of("Warning Top_i_Instance.p.ports: No array allowed here, instantiated as a single feature",
+				"Warning Top_i_Instance.g.fg.inner: No array allowed here, instantiated as a single feature"),
+				diagnostics(result));
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/FeatureGroupInstantiationTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/FeatureGroupInstantiationTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.instantiation.components;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.DirectionType;
+import org.osate.aadl2.instance.FeatureCategory;
+import org.osate.testsupport.Aadl2InjectorProvider;
+
+/**
+ * How a feature group is expanded into feature instances: nested groups, the two ways a group can be
+ * inverted, extension with a refinement, and the two groups that expand into nothing.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class FeatureGroupInstantiationTest extends AbstractComponentInstantiationTest {
+	private static final String FILE = "FeatureGroups.aadl";
+
+	/** A nested feature group is expanded in place, one level of feature instances per level of group. */
+	@Test
+	public void nestedFeatureGroupIsExpandedInPlace() throws Exception {
+		var root = instantiate(FILE, "Top.i").instance();
+
+		var outer = feature(root, "outer");
+		assertEquals(List.of("c", "nested"), featureNames(outer));
+		var nested = feature(outer, "nested");
+		assertEquals(FeatureCategory.FEATURE_GROUP, nested.getCategory());
+		assertEquals(List.of("a", "b"), featureNames(nested));
+		assertEquals(DirectionType.IN, feature(nested, "a").getDirection());
+		assertEquals(DirectionType.OUT, feature(nested, "b").getDirection());
+		assertEquals("Top_i_Instance.outer.nested.a", path(feature(nested, "a")));
+	}
+
+	/**
+	 * A feature group type that only declares an inverse takes the features of that inverse with their
+	 * directions turned around.
+	 */
+	@Test
+	public void featureGroupTypeWithOnlyAnInverseTurnsTheDirectionsAround() throws Exception {
+		var root = instantiate(FILE, "Top.i").instance();
+
+		var inverseType = feature(root, "inverse_type");
+		assertEquals(List.of("a", "b"), featureNames(inverseType));
+		assertEquals(DirectionType.OUT, feature(inverseType, "a").getDirection());
+		assertEquals(DirectionType.IN, feature(inverseType, "b").getDirection());
+	}
+
+	/** Declaring the feature itself as the inverse of a type turns the directions around as well. */
+	@Test
+	public void inverseOnTheFeatureTurnsTheDirectionsAround() throws Exception {
+		var root = instantiate(FILE, "Top.i").instance();
+
+		var inverseFeature = feature(root, "inverse_feature");
+		assertEquals(List.of("a", "b"), featureNames(inverseFeature));
+		assertEquals(DirectionType.OUT, feature(inverseFeature, "a").getDirection());
+		assertEquals(DirectionType.IN, feature(inverseFeature, "b").getDirection());
+	}
+
+	/**
+	 * An extension contributes the features of the extended type, with a refined feature replacing the
+	 * one it refines - at the end of the list, not at the position the refined feature had.
+	 */
+	@Test
+	public void extensionReplacesTheRefinedFeatureAtTheEnd() throws Exception {
+		var root = instantiate(FILE, "Top.i").instance();
+
+		var extended = feature(root, "extended");
+		assertEquals(List.of("y", "x"), featureNames(extended));
+		assertEquals(DirectionType.OUT, feature(extended, "y").getDirection());
+		assertEquals(DirectionType.IN, feature(extended, "x").getDirection());
+	}
+
+	/** A feature group type with no features is reported; a feature group with no type is not. */
+	@Test
+	public void groupWithoutFeaturesIsReportedAndGroupWithoutTypeIsNot() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+		var root = result.instance();
+
+		var empty = feature(root, "empty");
+		assertEquals(FeatureCategory.FEATURE_GROUP, empty.getCategory());
+		assertTrue(empty.getFeatureInstances().isEmpty());
+
+		var noType = feature(root, "no_type");
+		assertEquals(FeatureCategory.FEATURE_GROUP, noType.getCategory());
+		assertTrue(noType.getFeatureInstances().isEmpty());
+
+		assertEquals(List.of("Warning Top_i_Instance.empty: Feature group Top_i_Instance.empty has no features"),
+				diagnostics(result));
+	}
+
+	/** A feature group instance is in out whatever its members are. */
+	@Test
+	public void featureGroupInstanceIsInOut() throws Exception {
+		var root = instantiate(FILE, "Top.i").instance();
+
+		assertEquals(List.of("outer", "inverse_type", "inverse_feature", "extended", "empty", "no_type"),
+				featureNames(root));
+		for (var featureInstance : root.getFeatureInstances()) {
+			assertEquals(featureInstance.getName(), DirectionType.IN_OUT, featureInstance.getDirection());
+			assertEquals(featureInstance.getName(), 0, featureInstance.getIndex());
+		}
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/FeatureInstantiationTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/FeatureInstantiationTest.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.instantiation.components;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.DirectionType;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.aadl2.instance.FeatureCategory;
+import org.osate.testsupport.Aadl2InjectorProvider;
+
+/**
+ * The category and the direction a feature instance gets for every kind of feature. Access features
+ * have no direction of their own, so instantiation derives one from the access kind: provides becomes
+ * out, requires becomes in. A virtual bus access instantiates as a bus access, because the instance
+ * model has no separate category for it.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class FeatureInstantiationTest extends AbstractComponentInstantiationTest {
+	private static final String FILE = "FeatureKinds.aadl";
+
+	/**
+	 * Feature instances are grouped by the kind of feature they come from, not created in declaration
+	 * order.
+	 */
+	@Test
+	public void featureInstancesAreGroupedByKind() throws Exception {
+		var thread = thread(instantiate(FILE, "Top.i").instance());
+
+		assertEquals(List.of("fgroup", "abstract_plain", "abstract_in", "abstract_out", "data_in", "data_out",
+				"event_data_inout", "event_out", "data_access_req", "data_access_prov", "subprogram_access",
+				"subprogram_group_access"), featureNames(thread));
+	}
+
+	@Test
+	public void portsKeepTheirCategoryAndDirection() throws Exception {
+		var thread = thread(instantiate(FILE, "Top.i").instance());
+
+		assertFeature(thread, "data_in", FeatureCategory.DATA_PORT, DirectionType.IN);
+		assertFeature(thread, "data_out", FeatureCategory.DATA_PORT, DirectionType.OUT);
+		assertFeature(thread, "event_out", FeatureCategory.EVENT_PORT, DirectionType.OUT);
+		assertFeature(thread, "event_data_inout", FeatureCategory.EVENT_DATA_PORT, DirectionType.IN_OUT);
+	}
+
+	/** An access feature gets out for provides and in for requires. */
+	@Test
+	public void accessDirectionComesFromTheAccessKind() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+		var thread = thread(result.instance());
+
+		assertFeature(thread, "data_access_req", FeatureCategory.DATA_ACCESS, DirectionType.IN);
+		assertFeature(thread, "data_access_prov", FeatureCategory.DATA_ACCESS, DirectionType.OUT);
+		assertFeature(thread, "subprogram_access", FeatureCategory.SUBPROGRAM_ACCESS, DirectionType.OUT);
+		assertFeature(thread, "subprogram_group_access", FeatureCategory.SUBPROGRAM_GROUP_ACCESS, DirectionType.IN);
+
+		var device = component(result.instance(), "d");
+		assertFeature(device, "bus_access_req", FeatureCategory.BUS_ACCESS, DirectionType.IN);
+		assertFeature(device, "bus_access_prov", FeatureCategory.BUS_ACCESS, DirectionType.OUT);
+	}
+
+	/** A virtual bus access is instantiated as a bus access. */
+	@Test
+	public void virtualBusAccessBecomesBusAccess() throws Exception {
+		var device = component(instantiate(FILE, "Top.i").instance(), "d");
+
+		assertFeature(device, "virtual_bus_access", FeatureCategory.BUS_ACCESS, DirectionType.IN);
+	}
+
+	/** An abstract feature without a direction is in out; with one it keeps that direction. */
+	@Test
+	public void abstractFeatureDirectionDefaultsToInOut() throws Exception {
+		var thread = thread(instantiate(FILE, "Top.i").instance());
+
+		assertFeature(thread, "abstract_plain", FeatureCategory.ABSTRACT_FEATURE, DirectionType.IN_OUT);
+		assertFeature(thread, "abstract_in", FeatureCategory.ABSTRACT_FEATURE, DirectionType.IN);
+		assertFeature(thread, "abstract_out", FeatureCategory.ABSTRACT_FEATURE, DirectionType.OUT);
+	}
+
+	/** A feature group instance is in out and holds the features of its type. */
+	@Test
+	public void featureGroupIsInOutAndHoldsItsMembers() throws Exception {
+		var thread = thread(instantiate(FILE, "Top.i").instance());
+
+		var group = feature(thread, "fgroup");
+		assertEquals(FeatureCategory.FEATURE_GROUP, group.getCategory());
+		assertEquals(DirectionType.IN_OUT, group.getDirection());
+		assertEquals(List.of("member"), featureNames(group));
+		assertEquals(FeatureCategory.DATA_PORT, feature(group, "member").getCategory());
+	}
+
+	/** Parameters of a subprogram subcomponent are instantiated like any other feature. */
+	@Test
+	public void parametersAreInstantiatedOnSubprogramInstances() throws Exception {
+		var subprogram = component(thread(instantiate(FILE, "Top.i").instance()), "called");
+
+		assertFeature(subprogram, "param_in", FeatureCategory.PARAMETER, DirectionType.IN);
+		assertFeature(subprogram, "param_out", FeatureCategory.PARAMETER, DirectionType.OUT);
+	}
+
+	/** A feature that is not an array is indexed with zero and refers back to its declaration. */
+	@Test
+	public void featureThatIsNotAnArrayHasIndexZero() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+		var thread = thread(result.instance());
+
+		var dataIn = feature(thread, "data_in");
+		assertEquals(0, dataIn.getIndex());
+		assertEquals("data_in", dataIn.getFeature().getName());
+		assertSame(thread, dataIn.getComponentInstance());
+		assertEquals(List.of(), diagnostics(result));
+	}
+
+	private static ComponentInstance thread(ComponentInstance root) {
+		return component(component(root, "p"), "t");
+	}
+
+	private static void assertFeature(ComponentInstance owner, String name, FeatureCategory category,
+			DirectionType direction) {
+		var featureInstance = feature(owner, name);
+		assertEquals(name, category, featureInstance.getCategory());
+		assertEquals(name, direction, featureInstance.getDirection());
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/FlowSpecificationInstantiationTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/FlowSpecificationInstantiationTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.instantiation.components;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.testsupport.Aadl2InjectorProvider;
+
+/**
+ * Flow specification instances, which are created with the component hierarchy rather than by the end to
+ * end flow phase: one per flow specification of the component type, with the flow ends resolved to
+ * feature instances and the mode membership resolved to mode and mode transition instances.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class FlowSpecificationInstantiationTest extends AbstractComponentInstantiationTest {
+	private static final String FILE = "FlowSpecs.aadl";
+
+	/** One flow specification instance per declaration, in declaration order. */
+	@Test
+	public void oneInstancePerFlowSpecification() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+		var device = component(result.instance(), "d");
+
+		assertEquals(List.of("src", "snk", "thru", "fg_thru"), flowSpecificationNames(device));
+		assertEquals("src", flowSpecification(device, "src").getFlowSpecification().getName());
+		assertEquals(List.of(), diagnostics(result));
+	}
+
+	/** A flow source has only a destination, a flow sink only a source, a flow path both. */
+	@Test
+	public void flowEndsAreResolvedToFeatureInstances() throws Exception {
+		var device = component(instantiate(FILE, "Top.i").instance(), "d");
+
+		var source = flowSpecification(device, "src");
+		assertNull(source.getSource());
+		assertSame(feature(device, "out_p"), source.getDestination());
+
+		var sink = flowSpecification(device, "snk");
+		assertSame(feature(device, "in_p"), sink.getSource());
+		assertNull(sink.getDestination());
+
+		var path = flowSpecification(device, "thru");
+		assertSame(feature(device, "in_p"), path.getSource());
+		assertSame(feature(device, "out_p"), path.getDestination());
+	}
+
+	/** A flow end that names a feature group member is resolved inside that feature group instance. */
+	@Test
+	public void flowEndInsideAFeatureGroupIsResolved() throws Exception {
+		var device = component(instantiate(FILE, "Top.i").instance(), "d");
+		var path = flowSpecification(device, "fg_thru");
+
+		assertEquals("Top_i_Instance.d.fg.a", path(path.getSource()));
+		assertSame(feature(feature(device, "fg"), "a"), path.getSource());
+	}
+
+	/** Mode membership of a flow specification names mode instances, transition membership transitions. */
+	@Test
+	public void modeMembershipIsResolvedToInstances() throws Exception {
+		var modal = component(instantiate(FILE, "Top.i").instance(), "m");
+
+		var inMode = flowSpecification(modal, "modal_path");
+		assertEquals(List.of("Top_i_Instance.m.m1"), paths(inMode.getInModes()));
+		assertTrue(inMode.getInModeTransitions().isEmpty());
+
+		var inTransition = flowSpecification(modal, "transition_path");
+		assertTrue(inTransition.getInModes().isEmpty());
+		assertEquals(1, inTransition.getInModeTransitions().size());
+		assertSame(transition(modal, "t12"), inTransition.getInModeTransitions().get(0));
+		assertNotNull(inTransition.getSource());
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/ModeInstantiationTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/ModeInstantiationTest.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.instantiation.components;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.testsupport.Aadl2InjectorProvider;
+
+/**
+ * Mode instances, the modes a subcomponent instance is active in, and how a required mode is mapped to a
+ * mode of the containing component - explicitly through a mode binding, or implicitly by name.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class ModeInstantiationTest extends AbstractComponentInstantiationTest {
+	private static final String FILE = "ModeInstantiation.aadl";
+
+	/** Modes are instantiated in declaration order, and only the declared initial mode is initial. */
+	@Test
+	public void modesAreInstantiatedInDeclarationOrder() throws Exception {
+		var root = instantiate(FILE, "Top.i").instance();
+
+		assertEquals(List.of("m1", "m2"), modeNames(root));
+		assertTrue(mode(root, "m1").isInitial());
+		assertFalse(mode(root, "m2").isInitial());
+		assertFalse(mode(root, "m1").isDerived());
+		assertTrue(mode(root, "m1").getParents().isEmpty());
+		assertSame(root.getModeInstances().get(0).getMode(), mode(root, "m1").getMode());
+	}
+
+	/** A subcomponent is active in the modes its declaration names, and in all of them otherwise. */
+	@Test
+	public void subcomponentActiveModesComeFromItsDeclaration() throws Exception {
+		var root = instantiate(FILE, "Top.i").instance();
+
+		assertTrue(component(root, "always").getInModes().isEmpty());
+		assertEquals(List.of("Top_i_Instance.m1"), paths(component(root, "only_m1").getInModes()));
+	}
+
+	/** A subcomponent with its own modes gets its own mode instances, unrelated to its parent's. */
+	@Test
+	public void subcomponentWithOwnModesKeepsThemSeparate() throws Exception {
+		var own = component(instantiate(FILE, "Top.i").instance(), "own");
+
+		assertEquals(List.of("o1", "o2"), modeNames(own));
+		assertTrue(mode(own, "o1").isInitial());
+		assertFalse(mode(own, "o1").isDerived());
+		assertTrue(mode(own, "o1").getParents().isEmpty());
+	}
+
+	/** An explicit mode binding makes each required mode derived from the parent mode it is mapped to. */
+	@Test
+	public void explicitModeBindingLinksRequiredModesToParentModes() throws Exception {
+		var root = instantiate(FILE, "Top.i").instance();
+		var explicit = component(root, "derived_explicit");
+
+		assertEquals(List.of("d1", "d2"), modeNames(explicit));
+		assertTrue(mode(explicit, "d1").isDerived());
+		assertFalse(mode(explicit, "d1").isInitial());
+		assertEquals(List.of("Top_i_Instance.m1"), paths(mode(explicit, "d1").getParents()));
+		assertEquals(List.of("Top_i_Instance.m2"), paths(mode(explicit, "d2").getParents()));
+		assertEquals(List.of("Top_i_Instance.m1", "Top_i_Instance.m2"), paths(explicit.getInModes()));
+	}
+
+	/** Without a mode binding, required modes are mapped to the parent modes of the same name. */
+	@Test
+	public void implicitModeMapMatchesRequiredModesByName() throws Exception {
+		var root = instantiate(FILE, "Top.i").instance();
+		var implicit = component(root, "derived_implicit");
+
+		assertEquals(List.of("m1", "m2"), modeNames(implicit));
+		assertTrue(mode(implicit, "m1").isDerived());
+		assertEquals(List.of("Top_i_Instance.m1"), paths(mode(implicit, "m1").getParents()));
+		assertEquals(List.of("Top_i_Instance.m2"), paths(mode(implicit, "m2").getParents()));
+		assertTrue(implicit.getInModes().isEmpty());
+	}
+
+	/**
+	 * Required modes of the root are treated as ordinary modes, because there is no containing component
+	 * that could provide a parent mode.
+	 */
+	@Test
+	public void requiredModesOfTheRootAreNotDerived() throws Exception {
+		var result = instantiate(FILE, "Derived.i");
+		var root = result.instance();
+
+		assertEquals(List.of("d1", "d2"), modeNames(root));
+		assertFalse(mode(root, "d1").isDerived());
+		assertTrue(mode(root, "d1").getParents().isEmpty());
+		assertEquals(List.of("som_1", "som_2"), somNames(root));
+		assertEquals(List.of(), diagnostics(result));
+	}
+
+	/**
+	 * A required mode with no counterpart in the containing component is reported. The mode instance is
+	 * still created, and stays derived with no parent, which keeps it out of every system operation mode.
+	 */
+	@Test
+	public void requiredModeWithoutAParentModeIsReported() throws Exception {
+		var result = instantiate("MissingParentMode.aadl", "Top.i");
+		var child = component(result.instance(), "child");
+
+		assertEquals(List.of("nomatch"), modeNames(child));
+		assertTrue(mode(child, "nomatch").isDerived());
+		assertTrue(mode(child, "nomatch").getParents().isEmpty());
+		assertEquals(List.of("Error Top_i_Instance.child.nomatch: "
+				+ "Required mode 'nomatch' not found in containing component"), diagnostics(result));
+		assertEquals(List.of(List.of("Top_i_Instance.m1"), List.of("Top_i_Instance.m2")), somModes(result.instance()));
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/ModeTransitionInstantiationTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/ModeTransitionInstantiationTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.instantiation.components;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.testsupport.Aadl2InjectorProvider;
+
+/**
+ * Mode transition instances: the name each one gets, the mode instances it runs between, and which of
+ * its triggers end up on the instance. Only triggers that are ports become trigger references, but the
+ * generated name is built from the first trigger whether it is a port or not.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class ModeTransitionInstantiationTest extends AbstractComponentInstantiationTest {
+	private static final String FILE = "ModeTransitions.aadl";
+
+	/**
+	 * A declared name is kept. An unnamed transition is named source, trigger, destination, with the
+	 * subcomponent prefixed to the trigger when the trigger is reached through one.
+	 */
+	@Test
+	public void transitionNamesAreDeclaredOrGenerated() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+
+		assertEquals(List.of("named", "m2_top_trigger_m3", "m3_fg_trigger_m1", "m3_s_trigger_m2", "m1_ie_m3"),
+				transitionNames(result.instance()));
+		assertEquals(List.of(), diagnostics(result));
+	}
+
+	/** A transition instance runs between the mode instances of its declared source and destination. */
+	@Test
+	public void transitionRunsBetweenModeInstances() throws Exception {
+		var root = instantiate(FILE, "Top.i").instance();
+		var transition = transition(root, "named");
+
+		assertSame(mode(root, "m1"), transition.getSource());
+		assertSame(mode(root, "m2"), transition.getDestination());
+		assertNotNull(transition.getModeTransition());
+	}
+
+	/** A trigger in a subcomponent becomes a reference to that subcomponent's feature instance. */
+	@Test
+	public void triggerInASubcomponentIsResolvedToItsFeatureInstance() throws Exception {
+		var root = instantiate(FILE, "Top.i").instance();
+
+		assertEquals(List.of("Top_i_Instance.s.trigger"), paths(transition(root, "named").getTriggers()));
+	}
+
+	/** A trigger on the component itself and one inside a feature group are resolved the same way. */
+	@Test
+	public void triggerOnTheComponentAndInsideAFeatureGroupAreResolved() throws Exception {
+		var root = instantiate(FILE, "Top.i").instance();
+
+		assertEquals(List.of("Top_i_Instance.top_trigger"),
+				paths(transition(root, "m2_top_trigger_m3").getTriggers()));
+		assertEquals(List.of("Top_i_Instance.fg.fg_trigger"),
+				paths(transition(root, "m3_fg_trigger_m1").getTriggers()));
+	}
+
+	/** All triggers of a transition are kept, in declaration order, and the name uses the first one. */
+	@Test
+	public void allTriggersAreKeptInDeclarationOrder() throws Exception {
+		var root = instantiate(FILE, "Top.i").instance();
+
+		assertEquals(List.of("Top_i_Instance.s.trigger", "Top_i_Instance.top_trigger"),
+				paths(transition(root, "m3_s_trigger_m2").getTriggers()));
+	}
+
+	/**
+	 * A trigger that is not a port - here an internal event - contributes to the generated name but not
+	 * to the triggers of the instance.
+	 */
+	@Test
+	public void triggerThatIsNotAPortIsNamedButNotReferenced() throws Exception {
+		var root = instantiate(FILE, "Top.i").instance();
+		var transition = transition(root, "m1_ie_m3");
+
+		assertTrue(transition.getTriggers().isEmpty());
+		assertSame(mode(root, "m1"), transition.getSource());
+		assertSame(mode(root, "m3"), transition.getDestination());
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/PropertyCachingInstantiationTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/PropertyCachingInstantiationTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.instantiation.components;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.IntegerLiteral;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.testsupport.Aadl2InjectorProvider;
+
+/**
+ * Property caching runs over the finished hierarchy, so a value declared on a classifier lands on every
+ * instance of it, and a contained property association lands on the one instance it applies to. This
+ * pins the pipeline order rather than the caching itself, which the caching switches own.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class PropertyCachingInstantiationTest extends AbstractComponentInstantiationTest {
+	private static final String FILE = "PropertyCaching.aadl";
+
+	/** The value from the classifier is cached on the instance that has no association of its own. */
+	@Test
+	public void valueFromTheClassifierIsCachedOnTheInstance() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+		var thread = component(component(result.instance(), "p"), "t");
+
+		assertEquals(10, period(thread));
+		assertEquals(List.of(), diagnostics(result));
+	}
+
+	/** A contained property association overrides the classifier value on the instance it applies to. */
+	@Test
+	public void containedAssociationIsCachedOnTheInstanceItAppliesTo() throws Exception {
+		var process = component(instantiate(FILE, "Top.i").instance(), "p");
+
+		assertEquals(20, period(component(process, "u")));
+		assertEquals(10, period(component(process, "t")));
+	}
+
+	/** Nothing is cached where the property does not apply. */
+	@Test
+	public void noAssociationWhereThePropertyDoesNotApply() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+
+		assertTrue(result.instance().getOwnedPropertyAssociations().isEmpty());
+		assertTrue(component(result.instance(), "p").getOwnedPropertyAssociations().isEmpty());
+	}
+
+	private static long period(ComponentInstance component) {
+		var associations = component.getOwnedPropertyAssociations()
+				.stream()
+				.filter(association -> association.getProperty().getName().equals("Period"))
+				.toList();
+		assertEquals(path(component), 1, associations.size());
+		var value = associations.get(0).getOwnedValues().get(0).getOwnedValue();
+		return (long) ((IntegerLiteral) value).getValue();
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/PrototypeInstantiationTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/PrototypeInstantiationTest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.instantiation.components;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.DirectionType;
+import org.osate.aadl2.instance.FeatureCategory;
+import org.osate.testsupport.Aadl2InjectorProvider;
+
+/**
+ * What instantiation makes of prototypes: a component prototype decides the classifier of a
+ * subcomponent instance, a feature prototype decides the category of a feature instance, and a feature
+ * group prototype decides which features a feature group expands into.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class PrototypeInstantiationTest extends AbstractComponentInstantiationTest {
+	private static final String FILE = "PrototypeResolution.aadl";
+
+	/** A bound component prototype gives the subcomponent instance the classifier it is bound to. */
+	@Test
+	public void boundComponentPrototypeDecidesTheClassifier() throws Exception {
+		var bound = component(instantiate(FILE, "Top.i").instance(), "component_bound");
+
+		assertEquals("PrototypeResolution::B.i", component(bound, "u").getClassifier().getQualifiedName());
+		assertEquals("PrototypeResolution::B.i", component(bound, "c").getClassifier().getQualifiedName());
+	}
+
+	/**
+	 * Without a binding, a prototype falls back to its constraining classifier if it has one, and to no
+	 * classifier at all otherwise.
+	 */
+	@Test
+	public void unboundComponentPrototypeFallsBackToItsConstrainingClassifier() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+		var unbound = component(result.instance(), "component_unbound");
+
+		assertNull(component(unbound, "u").getClassifier());
+		assertEquals("PrototypeResolution::B", component(unbound, "c").getClassifier().getQualifiedName());
+		assertTrue(diagnostics(result).contains("Warning Top_i_Instance.component_unbound.u: "
+				+ "Instantiated subcomponent doesn't have a component classifier"));
+	}
+
+	/**
+	 * A feature declared with a feature prototype takes its category from what the prototype is bound
+	 * to, and stays an abstract feature when the prototype is not bound (see issue #3067).
+	 */
+	@Test
+	public void featurePrototypeDecidesTheFeatureCategory() throws Exception {
+		var root = instantiate(FILE, "Top.i").instance();
+
+		var port = feature(component(root, "feature_port"), "f");
+		assertEquals(FeatureCategory.DATA_PORT, port.getCategory());
+		assertEquals(DirectionType.IN, port.getDirection());
+
+		var access = feature(component(root, "feature_access"), "f");
+		assertEquals(FeatureCategory.DATA_ACCESS, access.getCategory());
+
+		var unbound = feature(component(root, "feature_unbound"), "f");
+		assertEquals(FeatureCategory.ABSTRACT_FEATURE, unbound.getCategory());
+		assertEquals(DirectionType.IN, unbound.getDirection());
+	}
+
+	/**
+	 * A bound feature group prototype expands into the features of the feature group type it is bound
+	 * to. The instantiator still reports the group as not bound yet, because the resolved actual carries
+	 * no bindings of its own.
+	 */
+	@Test
+	public void boundFeatureGroupPrototypeExpandsIntoItsMembers() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+		var group = feature(component(result.instance(), "group_bound"), "fg");
+
+		assertEquals(FeatureCategory.FEATURE_GROUP, group.getCategory());
+		assertEquals(List.of("p"), featureNames(group));
+		assertTrue(diagnostics(result).stream()
+				.anyMatch(message -> message.startsWith("Warning Top_i_Instance.group_bound.fg: ")
+						&& message.endsWith("is not bound yet to feature group type")));
+	}
+
+	/**
+	 * Characterizes a defect rather than intended behavior: a feature group typed with a feature group
+	 * prototype that is neither bound nor constrained makes instantiation fail with a
+	 * {@link NullPointerException}, instead of reporting the error that {@code expandFeatureGroupInstance}
+	 * has a message for. The AADL model is valid. When this is fixed, this test has to be replaced by one
+	 * that asserts the reported error.
+	 */
+	@Test
+	public void unboundFeatureGroupPrototypeCurrentlyFailsWithANullPointerException() throws Exception {
+		assertThrows(NullPointerException.class,
+				() -> instantiate("UnboundFeatureGroupPrototype.aadl", "Top.i"));
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/ReferencedClassifierInstantiationTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/ReferencedClassifierInstantiationTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.instantiation.components;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.ComponentCategory;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.testsupport.Aadl2InjectorProvider;
+
+/**
+ * A feature that has a component classifier gets a component instance for that classifier. Those
+ * instances are roots of their own next to the system instance in the instance resource, not part of the
+ * system instance tree, and one root serves every feature that names the same classifier.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class ReferencedClassifierInstantiationTest extends AbstractComponentInstantiationTest {
+	private static final String FILE = "ReferencedClassifiers.aadl";
+
+	/** The classifier roots sit in the resource, in the order they were discovered, after the root. */
+	@Test
+	public void referencedClassifiersBecomeRootsInTheResource() throws Exception {
+		var result = instantiate(FILE, "Top.i");
+		var contents = result.instance().eResource().getContents();
+
+		assertSame(result.instance(), contents.get(0));
+		assertEquals(3, contents.size());
+		assertEquals(List.of("ReferencedClassifiers::D.i", "ReferencedClassifiers::D"),
+				contents.subList(1, 3).stream().map(content -> ((ComponentInstance) content).getName()).toList());
+		assertTrue(contents.subList(1, 3).stream().noneMatch(SystemInstance.class::isInstance));
+		assertEquals(List.of(), diagnostics(result));
+	}
+
+	/** Every feature that names the same classifier points at the same root. */
+	@Test
+	public void featuresWithTheSameClassifierShareOneRoot() throws Exception {
+		var thread = component(component(instantiate(FILE, "Top.i").instance(), "p"), "t");
+
+		var shared = feature(thread, "p1").getType();
+		assertEquals("ReferencedClassifiers::D.i", shared.getName());
+		assertSame(shared, feature(thread, "p2").getType());
+		assertSame(shared, feature(thread, "shared").getType());
+	}
+
+	/** A different classifier gets a root of its own. */
+	@Test
+	public void differentClassifierGetsItsOwnRoot() throws Exception {
+		var thread = component(component(instantiate(FILE, "Top.i").instance(), "p"), "t");
+
+		var type = feature(thread, "p3").getType();
+		assertEquals("ReferencedClassifiers::D", type.getName());
+		assertEquals(ComponentCategory.DATA, type.getCategory());
+		assertTrue(type.getComponentInstances().isEmpty());
+	}
+
+	/** A feature without a classifier has no type instance. */
+	@Test
+	public void featureWithoutClassifierHasNoTypeInstance() throws Exception {
+		var thread = component(component(instantiate(FILE, "Top.i").instance(), "p"), "t");
+
+		assertNull(feature(thread, "event_no_classifier").getType());
+	}
+
+	/** A classifier root goes through the same hierarchy instantiation as the system instance. */
+	@Test
+	public void classifierRootIsInstantiatedLikeAnyOtherRoot() throws Exception {
+		var thread = component(component(instantiate(FILE, "Top.i").instance(), "p"), "t");
+		var implementationRoot = feature(thread, "p1").getType();
+
+		assertEquals(ComponentCategory.DATA, implementationRoot.getCategory());
+		assertEquals(List.of("field"), componentNames(implementationRoot));
+		assertEquals("ReferencedClassifiers::D.i.field", path(component(implementationRoot, "field")));
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/SubcomponentArrayInstantiationTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/SubcomponentArrayInstantiationTest.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.instantiation.components;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.testsupport.Aadl2InjectorProvider;
+
+/**
+ * What instantiation makes of subcomponent arrays: how many instances, in what order, and how each one
+ * is indexed. The element instances all carry the name of the subcomponent, so the index list is the
+ * only thing that tells them apart.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class SubcomponentArrayInstantiationTest extends AbstractComponentInstantiationTest {
+	private static final String FILE = "Arrays.aadl";
+	private static final String CONSTANTS = "ArrayConstants.aadl";
+
+	/** One instance per element, indexed from one, all under the name of the subcomponent. */
+	@Test
+	public void oneDimensionalArrayIsIndexedFromOne() throws Exception {
+		var result = instantiate(FILE, "Top.i", CONSTANTS);
+		var elements = components(result.instance(), "one");
+
+		assertEquals(3, elements.size());
+		assertEquals(List.of(List.of(1L), List.of(2L), List.of(3L)), elements.stream()
+				.map(ComponentInstance::getIndices)
+				.map(List::copyOf)
+				.toList());
+		assertEquals(List.of("Top_i_Instance.one[1]", "Top_i_Instance.one[2]", "Top_i_Instance.one[3]"),
+				paths(elements));
+		assertSame(elements.get(0).getSubcomponent(), elements.get(2).getSubcomponent());
+	}
+
+	/** A two dimensional array is enumerated with the last dimension changing fastest. */
+	@Test
+	public void twoDimensionalArrayIsEnumeratedLastDimensionFirst() throws Exception {
+		var result = instantiate(FILE, "Top.i", CONSTANTS);
+		var elements = components(result.instance(), "grid");
+
+		assertEquals(6, elements.size());
+		assertEquals(List.of(List.of(1L, 1L), List.of(1L, 2L), List.of(1L, 3L), List.of(2L, 1L), List.of(2L, 2L),
+				List.of(2L, 3L)),
+				elements.stream().map(ComponentInstance::getIndices).map(List::copyOf).toList());
+		assertEquals("Top_i_Instance.grid[2][3]", path(elements.get(5)));
+	}
+
+	/** An array with no elements produces no component instances and no diagnostic. */
+	@Test
+	public void emptyArrayProducesNothing() throws Exception {
+		var result = instantiate(FILE, "Top.i", CONSTANTS);
+
+		assertTrue(components(result.instance(), "empty").isEmpty());
+		assertEquals(List.of(), diagnostics(result));
+	}
+
+	/** The element count can come from a property constant instead of a literal. */
+	@Test
+	public void arraySizeCanComeFromAPropertyConstant() throws Exception {
+		var result = instantiate(FILE, "Top.i", CONSTANTS);
+		var elements = components(result.instance(), "sized");
+
+		assertEquals(2, elements.size());
+		assertEquals(List.of("Top_i_Instance.sized[1]", "Top_i_Instance.sized[2]"), paths(elements));
+	}
+
+	/** Indexing starts over inside each element of an enclosing array. */
+	@Test
+	public void arrayInsideAnArrayElementIsIndexedIndependently() throws Exception {
+		var result = instantiate(FILE, "Top.i", CONSTANTS);
+		var outer = components(result.instance(), "nested");
+
+		assertEquals(2, outer.size());
+		assertEquals(List.of("Top_i_Instance.nested[1].inner[1]", "Top_i_Instance.nested[1].inner[2]"),
+				paths(components(outer.get(0), "inner")));
+		assertEquals(List.of("Top_i_Instance.nested[2].inner[1]", "Top_i_Instance.nested[2].inner[2]"),
+				paths(components(outer.get(1), "inner")));
+	}
+
+	/** All the array elements of one declaration are siblings under the containing instance. */
+	@Test
+	public void allElementsAreSiblingsInOneList() throws Exception {
+		var result = instantiate(FILE, "Top.i", CONSTANTS);
+
+		assertEquals(13, result.instance().getComponentInstances().size());
+		assertEquals(List.of("one", "one", "one", "grid", "grid", "grid", "grid", "grid", "grid", "sized", "sized",
+				"nested", "nested"), componentNames(result.instance()));
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/SystemOperationModeInstantiationTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/SystemOperationModeInstantiationTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.instantiation.components;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.testsupport.Aadl2InjectorProvider;
+
+/**
+ * How the system operation modes are enumerated: one per combination of the modes of the modal
+ * components, in the order the modal components appear in a pre-order walk of the hierarchy, with a
+ * component that is not active in a combination contributing nothing to it.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class SystemOperationModeInstantiationTest extends AbstractComponentInstantiationTest {
+	private static final String FILE = "SystemOperationModes.aadl";
+
+	/** A model without modes gets the one system operation mode that stands for the normal state. */
+	@Test
+	public void modelWithoutModesGetsTheNormalSystemOperationMode() throws Exception {
+		var result = instantiate(FILE, "NonModal.i");
+
+		assertEquals(List.of(InstantiateModel.NORMAL_SOM_NAME), somNames(result.instance()));
+		assertTrue(result.instance().getSystemOperationModes().get(0).getCurrentModes().isEmpty());
+		assertEquals(List.of(), diagnostics(result));
+	}
+
+	/**
+	 * Two modal components produce the product of their modes, numbered from one, with the mode of the
+	 * component found last changing fastest.
+	 */
+	@Test
+	public void severalModalComponentsProduceTheProductOfTheirModes() throws Exception {
+		var result = instantiate(FILE, "Product.i");
+
+		assertEquals(List.of("som_1", "som_2", "som_3", "som_4", "som_5", "som_6"), somNames(result.instance()));
+		assertEquals(List.of(List.of("Product_i_Instance.a.a1", "Product_i_Instance.b.b1"),
+				List.of("Product_i_Instance.a.a1", "Product_i_Instance.b.b2"),
+				List.of("Product_i_Instance.a.a1", "Product_i_Instance.b.b3"),
+				List.of("Product_i_Instance.a.a2", "Product_i_Instance.b.b1"),
+				List.of("Product_i_Instance.a.a2", "Product_i_Instance.b.b2"),
+				List.of("Product_i_Instance.a.a2", "Product_i_Instance.b.b3")), somModes(result.instance()));
+	}
+
+	/**
+	 * A modal component that is not active in one of its parent's modes contributes no mode to the
+	 * combinations built over that parent mode, so those collapse into a single system operation mode.
+	 */
+	@Test
+	public void inactiveComponentContributesNoMode() throws Exception {
+		var result = instantiate(FILE, "Nested.i");
+
+		assertEquals(List.of("som_1", "som_2", "som_3"), somNames(result.instance()));
+		assertEquals(List.of(List.of("Nested_i_Instance.n1", "Nested_i_Instance.inner.a1"),
+				List.of("Nested_i_Instance.n1", "Nested_i_Instance.inner.a2"),
+				List.of("Nested_i_Instance.n2")), somModes(result.instance()));
+	}
+
+	/** Required modes restrict the product to the combinations the mode map allows. */
+	@Test
+	public void requiredModesRestrictTheProduct() throws Exception {
+		var result = instantiate(FILE, "DerivedParent.i");
+
+		assertEquals(List.of("som_1", "som_2"), somNames(result.instance()));
+		assertEquals(List.of(List.of("DerivedParent_i_Instance.n1", "DerivedParent_i_Instance.child.n1"),
+				List.of("DerivedParent_i_Instance.n2", "DerivedParent_i_Instance.child.n2")),
+				somModes(result.instance()));
+	}
+
+	/**
+	 * Enumeration stops once as many system operation modes as the limit allows have been created, and
+	 * reports that the list is incomplete. The limit is a project or workspace preference, so this test
+	 * reaches the enumeration directly to set one.
+	 */
+	@Test
+	public void enumerationStopsAtTheLimitAndReportsIt() throws Exception {
+		var impl = implementation(FILE, "Product.i");
+		var errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+		SystemInstance instance = InstantiateModel.instantiate(impl, errorManager);
+		assertEquals(6, instance.getSystemOperationModes().size());
+		instance.getSystemOperationModes().clear();
+
+		new LimitedEnumeration(errorManager).enumerate(instance, 4);
+
+		assertEquals(List.of("som_1", "som_2", "som_3", "som_4"), somNames(instance));
+		var reporter = (QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource());
+		assertEquals(List.of("Warning Product_i_Instance: "
+				+ "List of system operation modes is incomplete (see project property 'Instantiation')"),
+				reporter.getErrors()
+						.stream()
+						.map(message -> message.kind + " " + path(instance) + ": " + message.message)
+						.toList());
+	}
+
+	/** Reaches {@code createSystemOperationModes}, which is protected, with a limit of our choosing. */
+	private static final class LimitedEnumeration extends InstantiateModel {
+		private LimitedEnumeration(AnalysisErrorReporterManager errorManager) {
+			super(new NullProgressMonitor(), errorManager);
+		}
+
+		private void enumerate(SystemInstance root, int limit) throws InterruptedException {
+			createSystemOperationModes(root, limit);
+		}
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3037StructuralFailureTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3037StructuralFailureTest.java
@@ -113,7 +113,7 @@ public class Issue3037StructuralFailureTest extends XtextTest {
 				"Error | Source indices [1] do not match source dimension 2",
 				"Error | Source indices [2] do not match source dimension 2",
 				"Warning | There is already another connection between the same endpoints",
-				"Warning | Too few indices for connection end, using fist array element"),
+				"Warning | Too few indices for connection end, using first array element"),
 				messages("TooFewIndices.i"));
 	}
 

--- a/core/org.osate.ui/src/org/osate/ui/internal/instantiate/AbstractInstantiationEngine.java
+++ b/core/org.osate.ui/src/org/osate/ui/internal/instantiate/AbstractInstantiationEngine.java
@@ -50,7 +50,6 @@ import org.eclipse.core.runtime.jobs.JobGroup;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
 import org.osate.aadl2.instance.SystemInstance;
-import org.osate.aadl2.instantiation.InstantiateModel;
 import org.osate.aadl2.instantiation.RootMissingException;
 import org.osate.core.AadlNature;
 import org.osate.core.OsateCorePlugin;
@@ -218,7 +217,6 @@ abstract class AbstractInstantiationEngine<T> {
 			try {
 				final SystemInstance systemInstance = buildSystemInstance(subMonitor.split(1));
 				successful = systemInstance != null;
-				errorMessage = InstantiateModel.getErrorMessage();
 				delete = !successful;
 			} catch (final InterruptedException | OperationCanceledException e) {
 				// Instantiation was canceled by the user.


### PR DESCRIPTION
Steps 1 and 2 of #3066, with the characterization tests that back them. Does not close the issue: steps 3 to 6 follow.

## What is in here

**Characterization tests for component instantiation** (`a3214a2b38`). The instantiation pipeline had no tests of its own beyond the issue regressions, so the extraction and modernization steps had nothing to bisect against. 71 tests in `org.osate.core.tests.instantiation.components` over the new fixture project `core/org.osate.core.tests/models/componentInstantiation/` pin what the component half of the instantiator produces today: the root and the hierarchy below it, subcomponent arrays and their index enumeration, where a component instance takes its category from, the category and direction of every kind of feature, feature arrays, feature group expansion including both inversion forms and extension with a refinement, prototype resolution for component, feature and feature group prototypes, the roots created for referenced classifiers, mode instances and mode maps, mode transition names and triggers, system operation mode enumeration including the limit, flow specification instances, and property caching over the finished hierarchy.

Connection expansion and end-to-end flows are deliberately absent: #3053 and #3006 characterize those, and this suite sits in a sibling package to both.

Three of the instantiator's guards can only be reached by a model the AADL validator rejects, which nothing prevents from being instantiated, so those tests read the validator's messages as well and assert that the fixture is invalid in the expected way: subcomponent containment recursion, feature group containment recursion, and a feature array where no array is allowed. The neighbouring warning about a feature array with more than one dimension has no test, because the grammar accepts only one dimension on a feature, so no model can reach it.

**Step 1, modernization** (`b42ef7275e`). Language-level cleanup, no structural change:

- `checkCanceled()` in place of the 26 copies of the cancellation check.
- Pattern matching for `instanceof` at the cast-after-test sites, so that no branch re-casts what its own test established. The three remaining casts are unconditional ones in else branches, which keep throwing `ClassCastException` where they did before.
- Arrow form for the message switch in `createSystemInstanceInt`, with an explicit default that says a message of another kind is dropped, as it was.
- `canBeArray` returns a switch over the component category instead of a six-term disjunction. The switch is exhaustive on purpose: the list has to agree with the one the validator enforces, so a new category should not compile until it has been decided for here too.
- Diamond operator where the type arguments were redundant, `StringBuilder` instead of `StringBuffer`, `computeIfAbsent` for the mode-to-SOM map, `findFirst` for the implicit mode map lookup, an expression lambda in the SOM builder.
- `Stack<Long>` becomes `List<Long>` with `add` and `removeLast`. Not `ArrayDeque`: `instantiateSubcomponent` copies the index stack into the instance in list order, which `ArrayDeque` would reverse.

**Step 2, dead code and documentation** (`16f34fb714`). The commented-out semantics-check loop, subprogram call instantiation, component-type-only warning, referenced-components registration, reverse iteration in `getIndices`, `resolveConnectionReference` call, and the five `OsateDebug` lines; `errorMessage` with its setter and getter; the unreachable null checks in both `createNewConnection` overloads; and `InstantiationRoot.Phase`, of which only one literal was ever read. Class comment and Javadoc corrected where they named parameters the methods do not have, documented a return value on void methods, declared `@throws RollbackException` on a method that throws `Exception`, or claimed that `instantiateFGFeatures` handles feature arrays where the body reports them. Documented that the root list is emptied per `fillSystemInstance` call and that one instantiator is not safe for concurrent use.

## Behavior

No intended change, with one exception and one nuance.

**The preference key is corrected without a migration**, as decided: `PREF_SOM_USE_WORKSPACE` was `org.osage.aadl2.instantiation.som_use_workspace` and is now `org.osate...`. The UI property page persists that key in a project's `.settings`, so a project that had switched off "use workspace settings" reverts to the workspace SOM limit, because the entry stored under the old key is no longer read. Worth a release note.

**Three diagnostic strings changed**: `using fist array element` is now `using first array element`, the double space in `Feature group prototype  of` is gone, and the array size mismatch message no longer splits a literal across a removed comment. `Issue3037StructuralFailureTest` pinned the misspelled one and is updated to the corrected text; that is the only test change in this PR.

## API

Two source- and binary-incompatible changes against the 2.18.0 baseline, both on `InstantiateModel`, which is exported. No callers or subclasses in this repository.

- `instantiateSubcomponent(ComponentInstance, ModalElement, Subcomponent, List<Long>, int)` and `indexStackToString(List<Long>)` took `Stack<Long>`.
- `setErrorMessage(String)` and `getErrorMessage()` are removed. Nothing has ever called the setter, so the field was permanently null and the one reader assigned null to a local that was already null.

## One plan item not carried out

Step 2 of the plan asks to drop the assignment of the original error manager before the message-transfer loop in `createSystemInstanceInt`, because "the `finally` already covers it". It does not: the `finally` runs after that loop, so dropping the assignment would send the collected messages back into the queuing reporter instead of to the caller's error manager, and every instantiation diagnostic would vanish. The assignment is load-bearing; a comment says so now.

## Defects found while characterizing

Filed separately, with the tests that currently pin them named in each issue. None is caused by this PR; all three reproduce identically on master.

- #3074, a feature group typed with an unbound feature group prototype makes instantiation fail with a `NullPointerException`, on a valid model. `PrototypeInstantiationTest.unboundFeatureGroupPrototypeCurrentlyFailsWithANullPointerException` asserts the crash and has to be replaced when it is fixed.
- #3075, a bound feature group prototype is reported as not bound yet. `PrototypeInstantiationTest.boundFeatureGroupPrototypeExpandsIntoItsMembers` asserts the warning is present today, by substring so that the whitespace fix in this PR does not affect it.
- #3076, a replicated connection instance resolves its ends against the wrong array index, because the index list of the six-argument `analyzePath` has one entry per component level where `dims` has one per array dimension. This one has no test here; it should be settled before step 3 merges the two copies of `analyzePath`, along with #3069.

## Validation

Clean root reactor build with tests, against master with #3053 and #3006 merged:

```bash
mvn -s releng/osate.releng/settings.xml -Plocal \
  -Dtycho.localArtifacts=ignore \
  -Dpr.build=true -Dsign=false \
  -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
  -DfailIfNoTests=false \
  clean install
```

`BUILD SUCCESS`, 366 test bundles reporting, 0 failures and 0 errors.

SpotBugs on the two changed production bundles reports nothing new: 0 bug instances in `org.osate.aadl2.instantiation`, and none of the 14 pre-existing findings in `org.osate.ui` is in the changed class.

The suite was also checked for bite rather than just for green: swapping the provides/requires to out/in rule in `getDirection` makes two tests of `FeatureInstantiationTest` fail, and the mutation was reverted afterwards.

## Residual risk

The modernization is mechanical but large, and it touches the connection expansion block that steps 3 to 5 will move and reshape. What the characterization suite does not cover is connection expansion and end-to-end flows, which the suites from #3053 and #3006 cover instead; between the three, the reactor run above exercises the whole pipeline. The `Stack` to `List` change is the one place where a downstream subclass could break at compile time rather than being caught here.

Part of #3066.
