### PR TITLE
Fix replicated connection end array indices 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
@@ -1824,20 +1824,16 @@ public class InstantiateModel {
 				names.add(current.getName());
 			}
 			if (current instanceof ComponentInstance componentInstance) {
-				EList<Long> idx = componentInstance.getIndices();
-				if (!idx.isEmpty()) {
-					indices.addAll(idx);
+				d = componentInstance.getSubcomponent().getArrayDimensions().size();
+				if (d != 0) {
+					indices.addAll(componentInstance.getIndices());
 				}
 			} else if (current instanceof FeatureInstance featureInstance) {
 				long idx = featureInstance.getIndex();
 				if (idx != 0) {
+					d = 1;
 					indices.add(idx);
 				}
-			}
-			if (current instanceof ComponentInstance componentInstance) {
-				d = componentInstance.getSubcomponent().getArrayDimensions().size();
-			} else if (current instanceof FeatureInstance featureInstance && featureInstance.getIndex() != 0) {
-				d = 1;
 			}
 			if (dims != null) {
 				dims.add(d);

--- a/core/org.osate.core.tests/models/issue3076/.gitignore
+++ b/core/org.osate.core.tests/models/issue3076/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3076/.project
+++ b/core/org.osate.core.tests/models/issue3076/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3076</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3076/ReplicationProbe.aadl
+++ b/core/org.osate.core.tests/models/issue3076/ReplicationProbe.aadl
@@ -1,0 +1,84 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- of this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses only
+-- apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+-- A connection instance inside an array element, whose source path passes through a level that is not
+-- an array on its way to an indexed level. Replication into the sibling array element must preserve the
+-- corresponding ultimate source instead of stopping at the intermediate boundary feature.
+package ReplicationProbe
+public
+	data D
+	end D;
+
+	device Producer
+		features
+			out_p: out data port D;
+	end Producer;
+
+	device Consumer
+		features
+			in_p: in data port D;
+	end Consumer;
+
+	system Mid
+		features
+			out_p: out data port D;
+	end Mid;
+
+	system implementation Mid.i
+		subcomponents
+			inner: device Producer [2];
+		connections
+			c: port inner.out_p -> out_p;
+	end Mid.i;
+
+	system Arr
+		features
+			out_p: out data port D;
+	end Arr;
+
+	system implementation Arr.i
+		subcomponents
+			mid: system Mid.i;
+		connections
+			c: port mid.out_p -> out_p;
+	end Arr.i;
+
+	system Holder
+	end Holder;
+
+	system implementation Holder.i
+		subcomponents
+			arr: system Arr.i [2];
+			consumer: device Consumer;
+		connections
+			c: port arr.out_p -> consumer.in_p;
+	end Holder.i;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			holder: system Holder.i [2];
+	end Top.i;
+end ReplicationProbe;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3076Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3076Test.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * A replicated connection instance re-resolves its endpoints in the sibling element. The endpoint
+ * path may pass through both array and non-array component levels; only array dimensions contribute
+ * indices to that resolution.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3076Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3076/ReplicationProbe.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	/** A non-array level must not shift the array index used to resolve the replica's source. */
+	@Test
+	public void replicaUsesOneIndexPerArrayDimension() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+		ComponentImplementation implementation = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		var errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+
+		SystemInstance instance = InstantiateModel.instantiate(implementation, errorManager);
+
+		assertNotNull(instance);
+		assertEquals(List.of(
+				"Top_i_Instance.holder[1].arr[1].mid.inner[1].out_p --> Top_i_Instance.holder[1].consumer.in_p",
+				"Top_i_Instance.holder[2].arr[1].mid.inner[1].out_p --> Top_i_Instance.holder[2].consumer.in_p"),
+				instance.getComponentInstances()
+						.stream()
+						.flatMap(holder -> holder.getConnectionInstances().stream())
+						.map(connection -> connection.getSource().getInstanceObjectPath() + " --> "
+								+ connection.getDestination().getInstanceObjectPath())
+						.sorted()
+						.toList());
+		// Issue #3048 independently reports the many-to-one destination as an index mismatch.
+		assertEquals(List.of("Error: Too few indices for connection destination for "
+				+ "arr[1].mid.inner[1].out_p -> consumer.in_p"),
+				((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource())).getErrors()
+						.stream()
+						.map(message -> message.kind + ": " + message.message)
+						.toList());
+	}
+}


### PR DESCRIPTION
Fixes #3076

## Cause

The six-argument `analyzePath` recorded every `ComponentInstance.getIndices()` entry, including the synthetic zero on non-array subcomponents, while `dims` recorded zero dimensions at those levels. `resolveConnectionInstancePath` advances indices according to dimensions, so the extra index shifted later array indices and could resolve a replica to an intermediate feature.

## Correction

Derive the subcomponent dimensions first and record component indices only when the declaration has array dimensions. This keeps `indices` aligned with `dims`; indexed feature behavior is unchanged.

## Regression

`Issue3076Test` validates and instantiates `models/issue3076/ReplicationProbe.aadl`. Its source path crosses non-array `mid` before indexed `inner`, and the test requires both holder elements to resolve to `arr[1].mid.inner[1].out_p`. Before the production fix, holder 2 resolved only to `arr[1].mid.out_p`.

The fixture also records the independent #3048 `Too few indices for connection destination` diagnostic. This change does not address that pattern guard.

## Validation

- Focused `Issue3076Test`: 1 test, 0 failures, 0 errors, 0 skipped
- Related `Issue3034Test`: 5 tests, 0 failures, 0 errors, 0 skipped
- Related `Issue3037StructuralExpansionTest`: 5 tests, 0 failures, 0 errors, 0 skipped
- Clean offline root reactor with `-Dtycho.localArtifacts=ignore`: all 137 modules passed

## Dependencies and residual risk

PR #3078 for #3069 is merged, and this branch is rebased onto its master merge commit `dcef348bd8`. Residual risk is limited to connection-end replication index alignment. Issues #3048 and #3049 remain separate follow-up work.