### PR TITLE
Expand one-sided array connections 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
@@ -1526,19 +1526,12 @@ public class InstantiateModel {
 		}
 		String patternName = "One_to_One";
 		if (patterns == null) {
-			// default one-to-one pattern
-			if (!conni.isComplete()) {
-				// outgoing or incoming only
-				InstanceObject io = conni.getSource();
-				if (io instanceof FeatureInstance && io.getContainingComponentInstance() instanceof SystemInstance) {
-					if (srcSizes.isEmpty()) {
-						patternName = isOpposite ? "All_to_One" : "One_To_All";
-					}
-				} else {
-					if (dstSizes.isEmpty()) {
-						patternName = isOpposite ? "One_To_All" : "All_to_One";
-					}
-				}
+			// A default pattern pairs dimensions one-to-one. If only one end has dimensions,
+			// every element on that end maps to the one scalar end.
+			if (srcSizes.isEmpty()) {
+				patternName = isOpposite ? "All_to_One" : "One_To_All";
+			} else if (dstSizes.isEmpty()) {
+				patternName = isOpposite ? "One_To_All" : "All_to_One";
 			}
 		} else {
 			NamedValue nv = (NamedValue) patterns.get(offset);

--- a/core/org.osate.core.tests/models/issue3037/ArraysAndFeatureGroups.aadl
+++ b/core/org.osate.core.tests/models/issue3037/ArraysAndFeatureGroups.aadl
@@ -200,11 +200,8 @@ public
 			link: feature group reacher.bundle <-> collector.bundle;
 	end Top.soloReachedInto;
 
-	-- The same with the array. Semantically there are two connections, one per producer, and
-	-- only one is produced: expansion rejects the replication with "Too few indices for
-	-- connection destination" and leaves the un-replicated provisional attached. Reacher.i on
-	-- its own replicates the very same declaration correctly, so what the pivot changes is
-	-- worth finding out. 2.18.0 produced this too, so it is pinned rather than fixed here.
+	-- The same with the array. Semantically there are two connections, one per producer.
+	-- Issue #3048 ensures that structural expansion retains both of them across the pivot.
 	system implementation Top.reachedInto
 		subcomponents
 			reacher: process Reacher.i;

--- a/core/org.osate.core.tests/models/issue3048/.gitignore
+++ b/core/org.osate.core.tests/models/issue3048/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3048/.project
+++ b/core/org.osate.core.tests/models/issue3048/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3048</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3048/Issue3048.aadl
+++ b/core/org.osate.core.tests/models/issue3048/Issue3048.aadl
@@ -21,64 +21,61 @@
 -- of this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses only
 -- apply to the Third Party Software and not any other portion of this program or this program as a whole.
 -------------------------------------------------------------------------------
--- A connection instance inside an array element, whose source path passes through a level that is not
--- an array on its way to an indexed level. Replication into the sibling array element must preserve the
--- corresponding ultimate source instead of stopping at the intermediate boundary feature.
-package ReplicationProbe
+-- Two array elements feed a boundary feature group member. The semantic connection crosses
+-- the system-level feature group connection and descends into the collector, so structural
+-- expansion must retain both source elements while mapping them to the one destination.
+package Issue3048
 public
 	data D
 	end D;
 
-	device Producer
+	feature group Bundle
 		features
-			out_p: out event data port D;
+			signal: out event data port D;
+	end Bundle;
+
+	thread Producer
+		features
+			outp: out event data port D;
 	end Producer;
 
-	device Consumer
+	thread Consumer
 		features
-			in_p: in event data port D;
+			inp: in event data port D;
 	end Consumer;
 
-	system Mid
+	process Feeder
 		features
-			out_p: out event data port D;
-	end Mid;
+			bundle: feature group Bundle;
+	end Feeder;
 
-	system implementation Mid.i
+	process implementation Feeder.i
 		subcomponents
-			inner: device Producer [2];
+			producers: thread Producer[2];
 		connections
-			c: port inner.out_p -> out_p;
-	end Mid.i;
+			c: port producers.outp -> bundle.signal;
+	end Feeder.i;
 
-	system Arr
+	process Collector
 		features
-			out_p: out event data port D;
-	end Arr;
+			bundle: feature group inverse of Bundle;
+	end Collector;
 
-	system implementation Arr.i
+	process implementation Collector.i
 		subcomponents
-			mid: system Mid.i;
+			consumer: thread Consumer;
 		connections
-			c: port mid.out_p -> out_p;
-	end Arr.i;
-
-	system Holder
-	end Holder;
-
-	system implementation Holder.i
-		subcomponents
-			arr: system Arr.i [2];
-			consumer: device Consumer;
-		connections
-			c: port arr.out_p -> consumer.in_p;
-	end Holder.i;
+			c: port bundle.signal -> consumer.inp;
+	end Collector.i;
 
 	system Top
 	end Top;
 
 	system implementation Top.i
 		subcomponents
-			holder: system Holder.i [2];
+			feeder: process Feeder.i;
+			collector: process Collector.i;
+		connections
+			link: feature group feeder.bundle <-> collector.bundle;
 	end Top.i;
-end ReplicationProbe;
+end Issue3048;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3037ArrayFeatureGroupTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3037ArrayFeatureGroupTest.java
@@ -87,14 +87,22 @@ public class Issue3037ArrayFeatureGroupTest extends XtextTest {
 				"consumers[2].bundle.ack --> producers[2].bundle.ack",
 				"producers[1].bundle.signal --> consumers[1].bundle.signal",
 				"producers[2].bundle.signal --> consumers[2].bundle.signal");
-		assertConnections("SourceArray.i", "consumer.bundle.ack -> producers[1].bundle.ack",
-				"producers[1].bundle.signal -> consumer.bundle.signal");
-		assertConnections("Top.sourceArray", "consumer.bundle.ack -> producers[1].bundle.ack",
-				"producers[1].bundle.signal -> consumer.bundle.signal");
-		assertConnections("DestinationArray.i", "consumers[1].bundle.ack -> producer.bundle.ack",
-				"producer.bundle.signal -> consumers[1].bundle.signal");
-		assertConnections("Top.destinationArray", "consumers[1].bundle.ack -> producer.bundle.ack",
-				"producer.bundle.signal -> consumers[1].bundle.signal");
+		assertConnections("SourceArray.i", "consumer.bundle.ack --> producers[1].bundle.ack",
+				"consumer.bundle.ack --> producers[2].bundle.ack",
+				"producers[1].bundle.signal --> consumer.bundle.signal",
+				"producers[2].bundle.signal --> consumer.bundle.signal");
+		assertConnections("Top.sourceArray", "consumer.bundle.ack --> producers[1].bundle.ack",
+				"consumer.bundle.ack --> producers[2].bundle.ack",
+				"producers[1].bundle.signal --> consumer.bundle.signal",
+				"producers[2].bundle.signal --> consumer.bundle.signal");
+		assertConnections("DestinationArray.i", "consumers[1].bundle.ack --> producer.bundle.ack",
+				"consumers[2].bundle.ack --> producer.bundle.ack",
+				"producer.bundle.signal --> consumers[1].bundle.signal",
+				"producer.bundle.signal --> consumers[2].bundle.signal");
+		assertConnections("Top.destinationArray", "consumers[1].bundle.ack --> producer.bundle.ack",
+				"consumers[2].bundle.ack --> producer.bundle.ack",
+				"producer.bundle.signal --> consumers[1].bundle.signal",
+				"producer.bundle.signal --> consumers[2].bundle.signal");
 	}
 
 	/** Whole nested feature groups between arrays, so pairing descends before it reaches a port. */
@@ -150,46 +158,24 @@ public class Issue3037ArrayFeatureGroupTest extends XtextTest {
 				InstanceReport.diagnosticSet(InstanceSnapshot.of(run.instance(), run.errorManager())));
 	}
 
-	/**
-	 * The same pivot fed from an array, where all but the first element is lost.
-	 *
-	 * <p>
-	 * Two producers feed the boundary group member, so there are two connection instances
-	 * across the pivot. One is instantiated. Structural expansion rejects the replication with
-	 * "Too few indices for connection destination" and leaves the un-replicated provisional
-	 * attached, which is why the surviving name has a single arrow rather than the double
-	 * arrow of a replica. {@code Reacher.i} replicates the very same declaration correctly
-	 * when the connection ends at the boundary instead of crossing the pivot, so it is the
-	 * pivot that changes the outcome.
-	 * </p>
-	 *
-	 * <p>
-	 * This is what 2.18.0 produced too, so it is structural expansion's defect and not the
-	 * traversal's. It is pinned here so that fixing it shows up as a failure of this test
-	 * rather than as an unexplained change; the fix itself is separate work.
-	 * </p>
-	 */
+	/** The same pivot fed from an array must retain every source element. */
 	@Test
-	public void anArrayReachingIntoAMemberAcrossAPivotLosesAllButTheFirstElement() throws Exception {
+	public void anArrayReachingIntoAMemberAcrossAPivotKeepsEveryElement() throws Exception {
 		var run = isolated.run(MODEL, "Top.reachedInto");
 		var actual = InstanceSnapshot.of(run.instance(), run.errorManager());
 
-		assertEquals("producers[2] is missing, and the survivor is the provisional connection",
+		assertEquals("one materialized connection per producer",
 				List.of("collector.consumer.bundle.ack -> reacher.bundle.ack",
-						"reacher.producers[1].outp -> collector.consumer.bundle.signal"),
+						"reacher.producers[1].outp --> collector.consumer.bundle.signal",
+						"reacher.producers[2].outp --> collector.consumer.bundle.signal"),
 				InstanceCharacterization.names(isolated, MODEL, "Top.reachedInto"));
-
-		String expansionError = "Error | Too few indices for connection destination for reacher.producers[1].outp"
-				+ " -> collector.consumer.bundle.signal"
-				+ " | at Top_reachedInto_Instance.reacher.producers[1].outp -> collector.consumer.bundle.signal"
-				+ "|ConnectionInstance | in ArraysAndFeatureGroups_Top_reachedInto_Instance.aaxl2";
 		/*
-		 * Allowlist entry 5 again: before issue #3037 "No connection declaration from feature bundle
-		 * of component reacher to subcomponents. Connection instance ends at reacher" accompanied the
-		 * expansion error, which is the report that actually describes the model.
+		 * Issue #3049 separately covers the replicated references. This assertion is limited to
+		 * issue #3048's expansion diagnostic so the two fixes remain independent.
 		 */
-		assertEquals("the expansion error is what remains", List.of(expansionError),
-				InstanceReport.diagnosticSet(actual));
+		var diagnostics = InstanceReport.diagnosticSet(actual);
+		assertEquals("structural expansion diagnostics: " + diagnostics, false,
+				diagnostics.stream().anyMatch(message -> message.contains("Too few indices")));
 	}
 
 	/** Arrays, nested inverse feature groups, and a structural pattern at once. */

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3048Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3048Test.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.core.tests.instantiation.InstanceCharacterization;
+import org.osate.core.tests.instantiation.InstanceReport;
+import org.osate.core.tests.instantiation.InstanceSnapshot;
+import org.osate.core.tests.instantiation.IsolatedInstantiation;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/** Regression for issue #3048: default expansion of an array connection across a pivot. */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3048Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3048/Issue3048.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Inject
+	private IsolatedInstantiation isolated;
+
+	/** Both source array elements must survive a pivot into one scalar destination. */
+	@Test
+	public void pivotedArrayConnectionKeepsEverySourceElement() throws Exception {
+		validationHelper.assertNoIssues(testHelper.parseFile(MODEL));
+
+		var run = isolated.run(MODEL, "Top.i");
+
+		assertEquals(List.of("feeder.producers[1].outp --> collector.consumer.inp",
+				"feeder.producers[2].outp --> collector.consumer.inp"), InstanceCharacterization.names(run));
+		var diagnostics = InstanceReport.diagnosticSet(InstanceSnapshot.of(run.instance(), run.errorManager()));
+		/* Issue #3049 independently covers diagnostics caused by stale replicated references. */
+		assertEquals("structural expansion diagnostics: " + diagnostics, false,
+				diagnostics.stream().anyMatch(message -> message.contains("Too few indices")));
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3076Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3076Test.java
@@ -79,7 +79,13 @@ public class Issue3076Test extends XtextTest {
 		assertNotNull(instance);
 		assertEquals(List.of(
 				"Top_i_Instance.holder[1].arr[1].mid.inner[1].out_p --> Top_i_Instance.holder[1].consumer.in_p",
-				"Top_i_Instance.holder[2].arr[1].mid.inner[1].out_p --> Top_i_Instance.holder[2].consumer.in_p"),
+				"Top_i_Instance.holder[1].arr[1].mid.inner[2].out_p --> Top_i_Instance.holder[1].consumer.in_p",
+				"Top_i_Instance.holder[1].arr[2].mid.inner[1].out_p --> Top_i_Instance.holder[1].consumer.in_p",
+				"Top_i_Instance.holder[1].arr[2].mid.inner[2].out_p --> Top_i_Instance.holder[1].consumer.in_p",
+				"Top_i_Instance.holder[2].arr[1].mid.inner[1].out_p --> Top_i_Instance.holder[2].consumer.in_p",
+				"Top_i_Instance.holder[2].arr[1].mid.inner[2].out_p --> Top_i_Instance.holder[2].consumer.in_p",
+				"Top_i_Instance.holder[2].arr[2].mid.inner[1].out_p --> Top_i_Instance.holder[2].consumer.in_p",
+				"Top_i_Instance.holder[2].arr[2].mid.inner[2].out_p --> Top_i_Instance.holder[2].consumer.in_p"),
 				instance.getComponentInstances()
 						.stream()
 						.flatMap(holder -> holder.getConnectionInstances().stream())
@@ -87,9 +93,8 @@ public class Issue3076Test extends XtextTest {
 								+ connection.getDestination().getInstanceObjectPath())
 						.sorted()
 						.toList());
-		// Issue #3048 independently reports the many-to-one destination as an index mismatch.
-		assertEquals(List.of("Error: Too few indices for connection destination for "
-				+ "arr[1].mid.inner[1].out_p -> consumer.in_p"),
+		// Issue #3048 expands both source array elements without an index mismatch.
+		assertEquals(List.of(),
 				((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource())).getErrors()
 						.stream()
 						.map(message -> message.kind + ": " + message.message)


### PR DESCRIPTION
## Summary

- infer implicit structural connection patterns from endpoint array dimensions
- preserve every source or destination element for one-sided array connections, including paths that cross a system-level pivot
- update affected connection characterizations and the nested replication probe

## Cause and correction

`interpretConnectionPatterns` selected the implicit many-to-one or one-to-many pattern only for incomplete connection instances. Across-first traversal joins boundary legs into a complete semantic connection, so an array-to-scalar path fell through to `One_To_One`, reported `Too few indices in array component reference`, and retained only the provisional first element.

The correction derives the default from `srcSizes` and `dstSizes`: one populated side selects `All_To_One` or `One_To_All`; two populated sides remain `One_To_One`.

## Regression

`Issue3048Test` instantiates a standalone valid AADL project where two event data port producers feed a boundary feature-group member across a system pivot. It asserts that both expanded source elements reach the scalar destination and that the false index diagnostic is absent. Updated #3037 and #3076 characterizations cover feature groups, direct one-sided arrays, and nested arrays.

## Validation

All Maven commands ran offline.

- focused `Issue3048Test`: 1 test, 0 failures, 0 errors, 0 skipped
- focused `Issue3037ArrayFeatureGroupTest`: 7 tests, 0 failures, 0 errors, 0 skipped
- focused `Issue3076Test`: 1 test, 0 failures, 0 errors, 0 skipped
- owning production bundle, test bundle, and feature: 763 tests, 0 failures, 0 errors, 0 skipped
- clean root reactor with `-Dtycho.localArtifacts=ignore`: all 137 projects succeeded

## Dependencies and residual risk

This work depends on #3037 / PR #3053, which is already merged. Issue #3049 remains separate: copied connection reference chains can still point to the wrong array element. This PR should merge before #3049 and the connection-instantiation cleanup tracked after #3066 steps 3 through 5.

Fixes #3048