### PR TITLE
Repair replicated connection reference endpoints 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
@@ -2000,8 +2000,8 @@ public class InstantiateModel {
 	private void alignConnectionReferenceEndpoints(ConnectionInstance connection) {
 		List<ConnectionReference> references = connection.getConnectionReferences();
 		if (!references.isEmpty()) {
-			references.get(0).setSource(connection.getSource());
-			references.get(references.size() - 1).setDestination(connection.getDestination());
+			references.getFirst().setSource(connection.getSource());
+			references.getLast().setDestination(connection.getDestination());
 		}
 	}
 

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
@@ -1924,6 +1924,7 @@ public class InstantiateModel {
 		}
 		newConn.setSource((ConnectionInstanceEnd) src);
 		newConn.setDestination((ConnectionInstanceEnd) dst);
+		alignConnectionReferenceEndpoints(newConn);
 		newConn.setName(sb.toString());
 		container.getConnectionInstances().add(newConn);
 
@@ -1983,9 +1984,25 @@ public class InstantiateModel {
 		relocateConnectionReferenceContexts(newConn, conni.getContainingComponentInstance(), targetComponent);
 		newConn.setSource((ConnectionInstanceEnd) src);
 		newConn.setDestination((ConnectionInstanceEnd) dst);
+		alignConnectionReferenceEndpoints(newConn);
 		newConn.setName(sb.toString());
 		targetComponent.getConnectionInstances().add(newConn);
 
+	}
+
+	/**
+	 * Keep the ends of a copied connection's reference chain aligned with the ends that were resolved
+	 * for the copy. Re-resolving from a declaration that names a feature group can otherwise leave the
+	 * reference at the group, and a failed nested lookup can leave it in the original array element.
+	 *
+	 * @param connection the copied connection whose source and destination have been resolved
+	 */
+	private void alignConnectionReferenceEndpoints(ConnectionInstance connection) {
+		List<ConnectionReference> references = connection.getConnectionReferences();
+		if (!references.isEmpty()) {
+			references.get(0).setSource(connection.getSource());
+			references.get(references.size() - 1).setDestination(connection.getDestination());
+		}
 	}
 
 	/**

--- a/core/org.osate.core.tests/models/issue3049/.gitignore
+++ b/core/org.osate.core.tests/models/issue3049/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3049/.project
+++ b/core/org.osate.core.tests/models/issue3049/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3049</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3049/Issue3049.aadl
+++ b/core/org.osate.core.tests/models/issue3049/Issue3049.aadl
@@ -1,0 +1,62 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with this program. The
+-- parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries of this
+-- license with respect to the terms applicable to their Third Party Software. Third Party Software licenses only
+-- apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+-- Structural expansion copies the connection for the second element of each array. The copy's
+-- connection references must name that element all the way through the nested feature groups.
+package Issue3049
+public
+	data D
+	end D;
+
+	feature group Bundle
+		features
+			signal: out event data port D;
+			ack: in event data port D;
+	end Bundle;
+
+	feature group Nest
+		features
+			inner: feature group Bundle;
+	end Nest;
+
+	thread Producer
+		features
+			nest: feature group Nest;
+	end Producer;
+
+	thread Consumer
+		features
+			nest: feature group inverse of Nest;
+	end Consumer;
+
+	process Pair
+	end Pair;
+
+	process implementation Pair.i
+		subcomponents
+			producers: thread Producer[2];
+			consumers: thread Consumer[2];
+		connections
+			c: feature group producers.nest <-> consumers.nest;
+	end Pair.i;
+end Issue3049;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/InstanceCharacterization.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/InstanceCharacterization.java
@@ -67,34 +67,6 @@ public final class InstanceCharacterization {
 		return run;
 	}
 
-	/**
-	 * The same, for an implementation whose array replicas carry the stale reference chains
-	 * that structural expansion leaves behind.
-	 *
-	 * <p>
-	 * Expansion re-resolves a replicated connection's reference endpoints from the
-	 * declaration, so for a nested feature group the chain names array element 1 whatever
-	 * element the replica belongs to. Both traversals produced that identically, which is why
-	 * it is recorded here rather than repaired: it is structural expansion's to answer, and it
-	 * is item 3 of the follow-up work issue #3037 hands over.
-	 * </p>
-	 *
-	 * @param staleReferences how many replicas have a source that does not match their first
-	 *            reference
-	 */
-	public static InstanceRun assertConnectionsWithStaleArrayReferences(IsolatedInstantiation isolated, String model,
-			String implementation, int staleReferences, String... expected) throws Exception {
-		var run = isolated.run(model, implementation);
-		assertEquals(implementation + " connections", List.of(expected), names(run));
-		var violations = InstanceIntegrity.check(run.instance());
-		assertEquals(implementation + " integrity " + violations, staleReferences, violations.size());
-		for (var violation : violations) {
-			assertEquals(implementation + " unexpected violation: " + violation, true,
-					violation.contains("does not match first reference source"));
-		}
-		return run;
-	}
-
 	/** The connection instance names of the whole model, sorted. */
 	public static List<String> names(InstanceRun run) {
 		return run.instance()

--- a/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/InstanceIntegrity.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/InstanceIntegrity.java
@@ -148,12 +148,9 @@ public final class InstanceIntegrity {
 	 *
 	 * <p>
 	 * A reference may name a feature group where the connection names the member of it that
-	 * the connection actually connects, so one end nested in the other is the same point at
-	 * a different granularity. That is not an across-first choice: structural expansion
-	 * re-resolves a replicated connection's reference endpoints from the declaration, which
-	 * names the group, while the connection keeps the member. Both strategies produce it,
-	 * identically, for every connection replicated across a component array through a
-	 * feature group.
+	 * the connection actually connects, so one end nested in the other is the same point at a
+	 * different granularity. This is valid for a reference to the original declaration; copied
+	 * connections align the outer reference endpoints with their resolved leaf endpoints.
 	 * </p>
 	 */
 	private static boolean samePoint(ConnectionInstanceEnd one, ConnectionInstanceEnd other) {

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3037ArrayFeatureGroupTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3037ArrayFeatureGroupTest.java
@@ -108,11 +108,11 @@ public class Issue3037ArrayFeatureGroupTest extends XtextTest {
 	/** Whole nested feature groups between arrays, so pairing descends before it reaches a port. */
 	@Test
 	public void nestedFeatureGroupsBetweenArraysAgree() throws Exception {
-		assertConnections("NestedGroupArrays.i", 2, "consumers[1].nest.inner.ack --> producers[1].nest.inner.ack",
+		assertConnections("NestedGroupArrays.i", "consumers[1].nest.inner.ack --> producers[1].nest.inner.ack",
 				"consumers[2].nest.inner.ack --> producers[2].nest.inner.ack",
 				"producers[1].nest.inner.signal --> consumers[1].nest.inner.signal",
 				"producers[2].nest.inner.signal --> consumers[2].nest.inner.signal");
-		assertConnections("Top.nestedGroupArrays", 2, "consumers[1].nest.inner.ack --> producers[1].nest.inner.ack",
+		assertConnections("Top.nestedGroupArrays", "consumers[1].nest.inner.ack --> producers[1].nest.inner.ack",
 				"consumers[2].nest.inner.ack --> producers[2].nest.inner.ack",
 				"producers[1].nest.inner.signal --> consumers[1].nest.inner.signal",
 				"producers[2].nest.inner.signal --> consumers[2].nest.inner.signal");
@@ -181,7 +181,7 @@ public class Issue3037ArrayFeatureGroupTest extends XtextTest {
 	/** Arrays, nested inverse feature groups, and a structural pattern at once. */
 	@Test
 	public void arraysNestedGroupsAndAPatternAgree() throws Exception {
-		assertConnections("Patterned.i", 4, "consumers[1].nest.inner.ack --> producers[1].nest.inner.ack",
+		assertConnections("Patterned.i", "consumers[1].nest.inner.ack --> producers[1].nest.inner.ack",
 				"consumers[1].nest.inner.ack --> producers[2].nest.inner.ack",
 				"consumers[2].nest.inner.ack --> producers[1].nest.inner.ack",
 				"consumers[2].nest.inner.ack --> producers[2].nest.inner.ack",
@@ -189,7 +189,7 @@ public class Issue3037ArrayFeatureGroupTest extends XtextTest {
 				"producers[1].nest.inner.signal --> consumers[2].nest.inner.signal",
 				"producers[2].nest.inner.signal --> consumers[1].nest.inner.signal",
 				"producers[2].nest.inner.signal --> consumers[2].nest.inner.signal");
-		assertConnections("Top.patterned", 4, "consumers[1].nest.inner.ack --> producers[1].nest.inner.ack",
+		assertConnections("Top.patterned", "consumers[1].nest.inner.ack --> producers[1].nest.inner.ack",
 				"consumers[1].nest.inner.ack --> producers[2].nest.inner.ack",
 				"consumers[2].nest.inner.ack --> producers[1].nest.inner.ack",
 				"consumers[2].nest.inner.ack --> producers[2].nest.inner.ack",
@@ -201,11 +201,6 @@ public class Issue3037ArrayFeatureGroupTest extends XtextTest {
 
 	private void assertConnections(String implementation, String... expected) throws Exception {
 		InstanceCharacterization.assertConnections(isolated, MODEL, implementation, expected);
-	}
-
-	private void assertConnections(String implementation, int staleReferences, String... expected) throws Exception {
-		InstanceCharacterization.assertConnectionsWithStaleArrayReferences(isolated, MODEL, implementation,
-				staleReferences, expected);
 	}
 
 }

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3049Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3049Test.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with this program. The
+ * parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries of this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.instance.ConnectionInstance;
+import org.osate.aadl2.instance.InstanceObject;
+import org.osate.core.tests.instantiation.InstanceCharacterization;
+import org.osate.core.tests.instantiation.IsolatedInstantiation;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/** Regression for issue #3049: replicated connection references must name their own array element. */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3049Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3049/Issue3049.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Inject
+	private IsolatedInstantiation isolated;
+
+	@Test
+	public void replicatedReferencesUseTheirConnectionEndpoints() throws Exception {
+		validationHelper.assertNoIssues(testHelper.parseFile(MODEL));
+
+		var run = isolated.run(MODEL, "Pair.i");
+
+		assertEquals(List.of("consumers[1].nest.inner.ack --> producers[1].nest.inner.ack",
+				"consumers[2].nest.inner.ack --> producers[2].nest.inner.ack",
+				"producers[1].nest.inner.signal --> consumers[1].nest.inner.signal",
+				"producers[2].nest.inner.signal --> consumers[2].nest.inner.signal"),
+				InstanceCharacterization.names(run));
+		assertEquals(List.of(
+				"consumers[1].nest.inner.ack --> producers[1].nest.inner.ack"
+						+ " = consumers[1].nest.inner.ack --> producers[1].nest.inner.ack",
+				"consumers[2].nest.inner.ack --> producers[2].nest.inner.ack"
+						+ " = consumers[2].nest.inner.ack --> producers[2].nest.inner.ack",
+				"producers[1].nest.inner.signal --> consumers[1].nest.inner.signal"
+						+ " = producers[1].nest.inner.signal --> consumers[1].nest.inner.signal",
+				"producers[2].nest.inner.signal --> consumers[2].nest.inner.signal"
+						+ " = producers[2].nest.inner.signal --> consumers[2].nest.inner.signal"),
+				referenceEndpoints(run.instance().getAllConnectionInstances()));
+	}
+
+	private static List<String> referenceEndpoints(List<ConnectionInstance> connections) {
+		return connections.stream().map(connection -> {
+			var references = connection.getConnectionReferences();
+			return connection.getName() + " = " + relativePath(connection, references.get(0).getSource()) + " --> "
+					+ relativePath(connection, references.get(references.size() - 1).getDestination());
+		}).sorted().toList();
+	}
+
+	private static String relativePath(ConnectionInstance connection, InstanceObject end) {
+		var containerPath = connection.getContainingComponentInstance().getInstanceObjectPath() + ".";
+		var endPath = end.getInstanceObjectPath();
+		return endPath.startsWith(containerPath) ? endPath.substring(containerPath.length()) : endPath;
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3049Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3049Test.java
@@ -84,8 +84,8 @@ public class Issue3049Test extends XtextTest {
 	private static List<String> referenceEndpoints(List<ConnectionInstance> connections) {
 		return connections.stream().map(connection -> {
 			var references = connection.getConnectionReferences();
-			return connection.getName() + " = " + relativePath(connection, references.get(0).getSource()) + " --> "
-					+ relativePath(connection, references.get(references.size() - 1).getDestination());
+			return connection.getName() + " = " + relativePath(connection, references.getFirst().getSource()) + " --> "
+					+ relativePath(connection, references.getLast().getDestination());
 		}).sorted().toList();
 	}
 


### PR DESCRIPTION
Fixes #3049

## Cause and correction

Connection expansion copied the declaration's `ConnectionReference` objects before replacing the copied connection's source and destination with the resolved instance endpoints. For replicated component arrays, the first reference could therefore retain the original array element. For nested feature groups, the last reference could stop at the feature group instead of the leaf feature.

After each `createNewConnection` path assigns the resolved endpoints, synchronize the first reference's source and the last reference's destination with those endpoints. Internal reference links remain unchanged.

The #3037 array-feature-group characterization now requires a clean integrity result instead of allowing the stale-reference findings.

## Regression

`Issue3049.aadl` is a separate AADL test project with replicated producer and consumer arrays connected through nested feature groups. `Issue3049Test` validates the model and asserts the exact first and last connection-reference endpoint paths for all four generated connections.

Before the production fix, the regression failed because element-2 source references still named element 1 and destination references stopped at the nested feature group rather than the leaf feature.

## Dependency

This branch was created from the then-current `3048_expand_pivoted_array_connection` tip as requested. PR #3080 has since merged, and that tip is now an ancestor of `master`; this PR therefore targets `master` and contains only the two #3049 commits.

## Validation

- `Issue3049Test`: 1 test passed
- `Issue3037ArrayFeatureGroupTest`: 7 tests passed
- `Issue3034Test`: 5 tests passed
- `Issue3048Test`: 1 test passed
- `Issue3076Test`: 1 test passed
- Full `org.osate.core.tests` bundle: 764 tests passed
- Clean offline root reactor with `-Dtycho.localArtifacts=ignore`: all 137 projects and 1,359 tests passed

All Maven validation was run offline.

## Residual risk

The correction is limited to the two outer reference endpoints of copied connections. The internal reference chain and connection-expansion cardinality are unchanged, and the related characterization tests cover both nested feature groups and replicated arrays.
