### PR TITLE
Report an unresolvable feature group prototype 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
@@ -1178,7 +1178,12 @@ public class InstantiateModel {
 			inverse ^= fg.isInverse();
 
 			InstantiatedClassifier ic = getInstantiatedClassifier(fi);
-			if (ic.getClassifier() == null) {
+			/*
+			 * A prototype that resolves to neither an actual nor a constraining feature group type has no
+			 * instantiated classifier at all: getInstantiatedClassifier returns null rather than an
+			 * InstantiatedClassifier holding a null classifier. Both spellings mean the same thing here.
+			 */
+			if (ic == null || ic.getClassifier() == null) {
 				errManager.error(fi, "Could not resolve feature group type of feature group prototype "
 						+ fi.getInstanceObjectPath());
 				return;

--- a/core/org.osate.core.tests/models/issue3074/.gitignore
+++ b/core/org.osate.core.tests/models/issue3074/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3074/.project
+++ b/core/org.osate.core.tests/models/issue3074/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3074</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3074/Issue3074.aadl
+++ b/core/org.osate.core.tests/models/issue3074/Issue3074.aadl
@@ -1,0 +1,44 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- Issue #3074: a feature group typed with a feature group prototype that is neither bound nor given a
+-- constraining feature group type. The model is valid AADL; instantiating Top.i must report that the
+-- feature group type cannot be resolved instead of failing with a NullPointerException.
+package Issue3074
+public
+	abstract FeatureGroupProto
+		prototypes
+			fgp: feature group;
+		features
+			fg: feature group fgp;
+	end FeatureGroupProto;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			unbound: abstract FeatureGroupProto;
+	end Top.i;
+end Issue3074;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/PrototypeInstantiationTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/PrototypeInstantiationTest.java
@@ -25,7 +25,6 @@ package org.osate.core.tests.instantiation.components;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
@@ -110,15 +109,17 @@ public class PrototypeInstantiationTest extends AbstractComponentInstantiationTe
 	}
 
 	/**
-	 * Characterizes a defect rather than intended behavior: a feature group typed with a feature group
-	 * prototype that is neither bound nor constrained makes instantiation fail with a
-	 * {@link NullPointerException}, instead of reporting the error that {@code expandFeatureGroupInstance}
-	 * has a message for. The AADL model is valid. When this is fixed, this test has to be replaced by one
-	 * that asserts the reported error.
+	 * A feature group prototype that is neither bound nor constrained has no feature group type to expand.
+	 * That is reported and the feature group is instantiated without members (see issue #3074).
 	 */
 	@Test
-	public void unboundFeatureGroupPrototypeCurrentlyFailsWithANullPointerException() throws Exception {
-		assertThrows(NullPointerException.class,
-				() -> instantiate("UnboundFeatureGroupPrototype.aadl", "Top.i"));
+	public void unboundFeatureGroupPrototypeIsReported() throws Exception {
+		var result = instantiate("UnboundFeatureGroupPrototype.aadl", "Top.i");
+		var group = feature(component(result.instance(), "unbound"), "fg");
+
+		assertEquals(FeatureCategory.FEATURE_GROUP, group.getCategory());
+		assertEquals(List.of(), featureNames(group));
+		assertTrue(diagnostics(result).contains("Error Top_i_Instance.unbound.fg: "
+				+ "Could not resolve feature group type of feature group prototype Top_i_Instance.unbound.fg"));
 	}
 }

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3074Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3074Test.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instance.FeatureInstance;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * A feature group typed with a feature group prototype that is neither bound nor constrained has no
+ * feature group type to expand. Instantiation has to report that and carry on, not fail with a
+ * {@link NullPointerException}.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3074Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3074/Issue3074.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	/** The unresolvable feature group type is reported, and the feature group is left without members. */
+	@Test
+	public void unresolvedFeatureGroupPrototypeIsReported() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+		ComponentImplementation implementation = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		var errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+
+		SystemInstance instance = InstantiateModel.instantiate(implementation, errorManager);
+
+		assertNotNull(instance);
+		FeatureInstance group = instance.getComponentInstances()
+				.get(0)
+				.getFeatureInstances()
+				.stream()
+				.filter(feature -> feature.getName().equals("fg"))
+				.findFirst()
+				.orElseThrow();
+		assertEquals("Top_i_Instance.unbound.fg", group.getInstanceObjectPath());
+		assertEquals(List.of(), group.getFeatureInstances());
+		assertEquals(List.of("Error: Could not resolve feature group type of feature group prototype "
+				+ "Top_i_Instance.unbound.fg"),
+				((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource())).getErrors()
+						.stream()
+						.map(message -> message.kind + ": " + message.message)
+						.toList());
+	}
+}


### PR DESCRIPTION
Fixes #3074

## Cause and correction

`InstantiateModel.expandFeatureGroupInstance` dereferenced the result of `getInstantiatedClassifier(fi)` right away:

```java
InstantiatedClassifier ic = getInstantiatedClassifier(fi);
if (ic.getClassifier() == null) {
```

`InstanceUtil.getInstantiatedClassifier` returns `null`, not an `InstantiatedClassifier` holding a `null` classifier, when a prototype resolves to neither an actual nor a constraining classifier — the convention issue #986 established for component prototypes. The guard the method already had for the missing-classifier case was therefore unreachable, and the `NullPointerException` escaped `InstantiateModel.instantiate`: no instance model was produced and nothing was reported to the user.

The guard now accepts both spellings of "no classifier". The error the method already had a message for is reported, the feature group is instantiated without members, as it is for a feature group with no type at all, and instantiation continues.

## Regression model and assertion

`core/org.osate.core.tests/models/issue3074/Issue3074.aadl` declares a feature group typed with a feature group prototype that is neither bound nor given a constraining feature group type. The model is valid AADL; the validator reports nothing for it.

`Issue3074Test.unresolvedFeatureGroupPrototypeIsReported` instantiates `Top.i` and asserts that the feature group instance `Top_i_Instance.unbound.fg` exists with no members and that the only reported diagnostic is `Error: Could not resolve feature group type of feature group prototype Top_i_Instance.unbound.fg`. Before the fix it failed with the `NullPointerException` from the issue.

`PrototypeInstantiationTest` pinned the crash in `unboundFeatureGroupPrototypeCurrentlyFailsWithANullPointerException`; that test is now `unboundFeatureGroupPrototypeIsReported` and pins the reported error and the empty feature group, updated in the fix commit.

## Validation

All run outside the sandbox, offline.

- `mvn -o -s releng/osate.releng/settings.xml -Plocal -pl :org.osate.core.tests -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -Dtest=Issue3074Test -DfailIfNoTests=false verify` — 1 test, passes; fails with the `NullPointerException` on the regression commit alone.
- Same command with `-Dtest=PrototypeInstantiationTest` (5 tests) and `-Dtest=FeatureGroupInstantiationTest` (6 tests), run separately — pass.
- Full `org.osate.core.tests` bundle — 765 tests, 0 failures.
- `mvn -o -s releng/osate.releng/settings.xml -Plocal -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -DfailIfNoTests=false clean install` — all 137 projects succeed, 1,360 tests, 0 failures.

## Dependencies

None. The branch is based on master at `84c741f4a9`. It is the first of two independent fixes in `expandFeatureGroupInstance`; the fix for #3075 is in PR filed alongside this one and is based on this branch, because the branch this PR fixes is the one #3075 leaves the genuinely unbound case to.

## Residual risk

Low, and confined to the previously unreachable branch. A feature group whose prototype cannot be resolved now yields a member-less feature group instance where instantiation used to abort; downstream code that walks feature group members has to tolerate an empty one, which it already does for a feature group declared without a type. No API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)