### PR TITLE
Decide feature group prototype binding by its actual 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
@@ -73,6 +73,7 @@ import org.osate.aadl2.EnumerationLiteral;
 import org.osate.aadl2.Feature;
 import org.osate.aadl2.FeatureClassifier;
 import org.osate.aadl2.FeatureGroup;
+import org.osate.aadl2.FeatureGroupPrototype;
 import org.osate.aadl2.FeatureGroupType;
 import org.osate.aadl2.FeaturePrototypeActual;
 import org.osate.aadl2.FeatureType;
@@ -1187,8 +1188,13 @@ public class InstantiateModel {
 				errManager.error(fi, "Could not resolve feature group type of feature group prototype "
 						+ fi.getInstanceObjectPath());
 				return;
-			} else if (ic.getBindings() != null && ic.getBindings().isEmpty()) {
-				// prototype has not been bound yet
+			} else if (ft instanceof FeatureGroupPrototype fgp
+					&& InstanceUtil.resolveFeatureGroupPrototype(fgp, fi, classifierCache) == null) {
+				/*
+				 * The prototype has no actual in this context: the feature group type above came from the
+				 * constraint on the prototype. The bindings of the instantiated classifier do not answer
+				 * this question, because an actual that names a feature group type carries none of its own.
+				 */
 				errManager.warning(fi, "Feature group prototype of " + fi.getInstanceObjectPath()
 						+ " is not bound yet to feature group type");
 			}

--- a/core/org.osate.core.tests/models/issue3075/.gitignore
+++ b/core/org.osate.core.tests/models/issue3075/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3075/.project
+++ b/core/org.osate.core.tests/models/issue3075/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3075</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3075/Issue3075.aadl
+++ b/core/org.osate.core.tests/models/issue3075/Issue3075.aadl
@@ -1,0 +1,61 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- Issue #3075: two feature groups typed with a feature group prototype. The prototype of 'bound' has an
+-- actual, so instantiation must expand it silently. The prototype of 'constrained' has no actual and
+-- falls back to its constraining feature group type, which is the case that is not bound yet and has to
+-- stay reported.
+package Issue3075
+public
+	data D
+	end D;
+
+	feature group FGT
+		features
+			p: in data port D;
+	end FGT;
+
+	abstract Proto
+		prototypes
+			fgp: feature group;
+		features
+			fg: feature group fgp;
+	end Proto;
+
+	abstract ConstrainedProto
+		prototypes
+			fgp: feature group FGT;
+		features
+			fg: feature group fgp;
+	end ConstrainedProto;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			bound: abstract Proto (fgp => feature group FGT);
+			constrained: abstract ConstrainedProto;
+	end Top.i;
+end Issue3075;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/PrototypeInstantiationTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/components/PrototypeInstantiationTest.java
@@ -24,6 +24,7 @@
 package org.osate.core.tests.instantiation.components;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -92,9 +93,8 @@ public class PrototypeInstantiationTest extends AbstractComponentInstantiationTe
 	}
 
 	/**
-	 * A bound feature group prototype expands into the features of the feature group type it is bound
-	 * to. The instantiator still reports the group as not bound yet, because the resolved actual carries
-	 * no bindings of its own.
+	 * A bound feature group prototype expands into the features of the feature group type it is bound to,
+	 * and nothing is reported for it (see issue #3075).
 	 */
 	@Test
 	public void boundFeatureGroupPrototypeExpandsIntoItsMembers() throws Exception {
@@ -103,9 +103,8 @@ public class PrototypeInstantiationTest extends AbstractComponentInstantiationTe
 
 		assertEquals(FeatureCategory.FEATURE_GROUP, group.getCategory());
 		assertEquals(List.of("p"), featureNames(group));
-		assertTrue(diagnostics(result).stream()
-				.anyMatch(message -> message.startsWith("Warning Top_i_Instance.group_bound.fg: ")
-						&& message.endsWith("is not bound yet to feature group type")));
+		assertFalse(diagnostics(result).stream()
+				.anyMatch(message -> message.startsWith("Warning Top_i_Instance.group_bound.fg: ")));
 	}
 
 	/**

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3075Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3075Test.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.aadl2.instance.FeatureInstance;
+import org.osate.aadl2.instance.InstanceObject;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * Whether a feature group prototype is bound is decided by the actual it resolves to, not by the
+ * prototype bindings that actual carries of its own. A bound prototype whose actual names a feature
+ * group type has no bindings of its own and must not be reported as unbound.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3075Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3075/Issue3075.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	/**
+	 * Both feature groups expand into the members of {@code FGT}. Only the one whose prototype has no
+	 * actual, and therefore falls back to its constraining feature group type, is reported.
+	 */
+	@Test
+	public void onlyAnUnboundFeatureGroupPrototypeIsReported() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+		ComponentImplementation implementation = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		var errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+
+		SystemInstance instance = InstantiateModel.instantiate(implementation, errorManager);
+
+		assertNotNull(instance);
+		assertEquals(List.of("p"), memberNames(featureGroup(instance, "bound")));
+		assertEquals(List.of("p"), memberNames(featureGroup(instance, "constrained")));
+		assertEquals(List.of("Warning Top_i_Instance.constrained.fg: Feature group prototype of "
+				+ "Top_i_Instance.constrained.fg is not bound yet to feature group type"),
+				((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource())).getErrors()
+						.stream()
+						.map(message -> message.kind + " "
+								+ ((InstanceObject) message.where).getInstanceObjectPath() + ": " + message.message)
+						.toList());
+	}
+
+	private static FeatureInstance featureGroup(SystemInstance instance, String subcomponentName) {
+		ComponentInstance subcomponent = instance.getComponentInstances()
+				.stream()
+				.filter(component -> component.getName().equals(subcomponentName))
+				.findFirst()
+				.orElseThrow();
+		return subcomponent.getFeatureInstances()
+				.stream()
+				.filter(feature -> feature.getName().equals("fg"))
+				.findFirst()
+				.orElseThrow();
+	}
+
+	private static List<String> memberNames(FeatureInstance group) {
+		return group.getFeatureInstances().stream().map(FeatureInstance::getName).toList();
+	}
+}


### PR DESCRIPTION
Fixes #3075

## Cause and correction

`InstantiateModel.expandFeatureGroupInstance` decided the "not bound yet" warning from the prototype bindings of the resolved classifier:

```java
} else if (ic.getBindings() != null && ic.getBindings().isEmpty()) {
```

For a resolved feature group prototype those bindings come from the `FeatureGroupPrototypeActual`, and an actual that names a feature group type without prototype bindings of its own carries none. An empty binding list means "the actual has no prototype bindings", not "the prototype is unbound", so every bound feature group prototype was reported as unbound even though its members had just been expanded from the feature group type it is bound to.

The condition now asks the question the diagnostic is about: whether the prototype resolves to an actual in this context, via `InstanceUtil.resolveFeatureGroupPrototype` — the idiom `filloutFeatureInstance` already uses for feature prototypes. When it does not resolve, the feature group type came from the constraint on the prototype, which is the case that is genuinely not bound yet and stays reported. The unresolvable case, where there is no constraint either, is the error branch above, made reachable by #3074.

The double space between "prototype" and "of" in that message was already corrected by #3066 step 2.

## Regression model and assertion

`core/org.osate.core.tests/models/issue3075/Issue3075.aadl` declares two feature groups typed with a feature group prototype: `bound`, whose prototype has an actual naming feature group type `FGT`, and `constrained`, whose prototype has no actual and falls back to its constraining feature group type. The model is valid AADL.

`Issue3075Test.onlyAnUnboundFeatureGroupPrototypeIsReported` instantiates `Top.i`, asserts that both feature groups expand into the members of `FGT`, and asserts that the only reported diagnostic is the "is not bound yet" warning for `Top_i_Instance.constrained.fg`. Before the fix, `Top_i_Instance.bound.fg` was warned about as well. Carrying both shapes in one fixture ties the assertion to the difference between them, so removing the warning altogether would not satisfy it.

`PrototypeInstantiationTest.boundFeatureGroupPrototypeExpandsIntoItsMembers` asserted the spurious warning was present; it now asserts that nothing is reported for `group_bound.fg`, updated in the fix commit.

## Validation

All run outside the sandbox, offline.

- `mvn -o -s releng/osate.releng/settings.xml -Plocal -pl :org.osate.core.tests -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -Dtest=Issue3075Test -DfailIfNoTests=false verify` — 1 test, passes; on the regression commit alone it fails with both feature groups reported.
- Same command with `-Dtest=Issue3074Test` (1 test), `-Dtest=PrototypeInstantiationTest` (5 tests) and `-Dtest=FeatureGroupInstantiationTest` (6 tests), run separately — pass.
- Full `org.osate.core.tests` bundle — 765 tests, 0 failures.
- `mvn -o -s releng/osate.releng/settings.xml -Plocal -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -DfailIfNoTests=false clean install` — all 137 projects succeed, 1,360 tests, 0 failures.

## Dependencies

Depends on PR #3082 (#3074) and must be merged after it. This PR is therefore based on `3074_unbound_feature_group_prototype` so its review diff contains only the two #3075 commits; GitHub retargets it to master when PR #3082 is merged. The order matters: this fix leaves the genuinely unresolvable prototype to the missing-classifier branch above it, which #3074 made reachable.

## Residual risk

Low. The warning is now emitted for strictly fewer feature groups: only where the prototype has no actual and the feature group type came from its constraint. Instance models are unchanged — the members expanded were already correct. The prototype is resolved a second time, after `getInstantiatedClassifier` already did; removing that would mean letting `InstantiatedClassifier` record whether its classifier came from an actual or from a constraint, which is an API change and belongs in its own issue. No API change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)