### PR TITLE
Fix cyclic double-step connection patterns 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/ConnectionArrayExpander.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/ConnectionArrayExpander.java
@@ -301,14 +301,8 @@ public final class ConnectionArrayExpander {
 		CYCLIC_PREVIOUS(1, 0, 1, (i, size) -> i == 1 ? size : i - 1),
 		NEXT_NEXT(1, 2, 1, (i, size) -> i + 2),
 		PREVIOUS_PREVIOUS(3, 0, 1, (i, size) -> i - 2),
-		/*
-		 * The two cyclic double step patterns wrap around by two elements but advance by one everywhere
-		 * else, where Next_Next and Previous_Previous advance by two. That is the arithmetic these two
-		 * have always had, and issue #3066 is a refactoring with no intended change in behavior, so it is
-		 * carried over as it stands rather than corrected here.
-		 */
-		CYCLIC_NEXT_NEXT(1, 0, 1, (i, size) -> i == size ? 2 : (i == size - 1 ? 1 : i + 1)),
-		CYCLIC_PREVIOUS_PREVIOUS(1, 0, 1, (i, size) -> i == 2 ? size : (i == 1 ? size - 1 : i - 1)),
+		CYCLIC_NEXT_NEXT(1, 0, 1, (i, size) -> (i + 1) % size + 1),
+		CYCLIC_PREVIOUS_PREVIOUS(1, 0, 1, (i, size) -> (i + size - 3) % size + 1),
 		EVEN_TO_EVEN(2, 0, 2, (i, size) -> i),
 		ODD_TO_ODD(1, 0, 2, (i, size) -> i);
 

--- a/core/org.osate.core.tests/models/issue3085/.gitignore
+++ b/core/org.osate.core.tests/models/issue3085/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3085/.project
+++ b/core/org.osate.core.tests/models/issue3085/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3085</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3085/Issue3085.aadl
+++ b/core/org.osate.core.tests/models/issue3085/Issue3085.aadl
@@ -1,0 +1,31 @@
+package Issue3085
+public
+	device Endpoint
+	features
+		in_p: in event data port;
+		out_p: out event data port;
+	end Endpoint;
+
+	system Top
+	end Top;
+
+	system implementation Top.cyclic_next_next
+	subcomponents
+		src: device Endpoint[5];
+		dst: device Endpoint[5];
+	connections
+		c: port src.out_p -> dst.in_p {
+			Communication_Properties::Connection_Pattern => ((Cyclic_Next_Next));
+		};
+	end Top.cyclic_next_next;
+
+	system implementation Top.cyclic_previous_previous
+	subcomponents
+		src: device Endpoint[5];
+		dst: device Endpoint[5];
+	connections
+		c: port src.out_p -> dst.in_p {
+			Communication_Properties::Connection_Pattern => ((Cyclic_Previous_Previous));
+		};
+	end Top.cyclic_previous_previous;
+end Issue3085;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/patterns/ConnectionPatternInstantiationTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/patterns/ConnectionPatternInstantiationTest.java
@@ -53,9 +53,8 @@ import com.itemis.xtext.testing.XtextTest;
  * instance per pair of array elements the pattern pairs up.
  *
  * <p>
- * The expected pairs of the twelve patterns that agree with AS5506D section 9.2.3 are written from the
- * standard, not from what the instantiator produces. The two patterns of issue #3085 are pinned as they
- * are today, which is not what the standard says, and their tests say so.
+ * The expected pairs of all fourteen patterns are written from AS5506D section 9.2.3, not from what the
+ * instantiator produces.
  * </p>
  *
  * <p>
@@ -138,25 +137,16 @@ public class ConnectionPatternInstantiationTest extends XtextTest {
 		assertPattern("Pair.previous_previous", "3 -> 1", "4 -> 2", "5 -> 3");
 	}
 
-	/**
-	 * Issue #3085: Cyclic_Next_Next wraps the last two elements to the first two, as AS5506D section
-	 * 9.2.3 requires, but shifts the interior of the dimension by one instead of by two. The expected
-	 * pairs of the standard are {@code 1 -> 3}, {@code 2 -> 4}, {@code 3 -> 5}, {@code 4 -> 1} and
-	 * {@code 5 -> 2}.
-	 */
+	/** Cyclic_Next_Next shifts by two and wraps the last two elements to the first two. */
 	@Test
-	public void cyclicNextNextCurrentlyShiftsTheInteriorByOnlyOne() throws Exception {
-		assertPattern("Pair.cyclic_next_next", "1 -> 2", "2 -> 3", "3 -> 4", "4 -> 1", "5 -> 2");
+	public void cyclicNextNextShiftsByTwoAndWraps() throws Exception {
+		assertPattern("Pair.cyclic_next_next", "1 -> 3", "2 -> 4", "3 -> 5", "4 -> 1", "5 -> 2");
 	}
 
-	/**
-	 * Issue #3085: Cyclic_Previous_Previous has the same defect as Cyclic_Next_Next. The expected pairs
-	 * of the standard are {@code 1 -> 4}, {@code 2 -> 5}, {@code 3 -> 1}, {@code 4 -> 2} and
-	 * {@code 5 -> 3}.
-	 */
+	/** Cyclic_Previous_Previous shifts back by two and wraps the first two elements to the last two. */
 	@Test
-	public void cyclicPreviousPreviousCurrentlyShiftsTheInteriorByOnlyOne() throws Exception {
-		assertPattern("Pair.cyclic_previous_previous", "1 -> 4", "2 -> 5", "3 -> 2", "4 -> 3", "5 -> 4");
+	public void cyclicPreviousPreviousShiftsBackByTwoAndWraps() throws Exception {
+		assertPattern("Pair.cyclic_previous_previous", "1 -> 4", "2 -> 5", "3 -> 1", "4 -> 2", "5 -> 3");
 	}
 
 	/** Even_To_Even connects the even elements to the same even element. */

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3085Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3085Test.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instance.ConnectionInstance;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3085Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3085/Issue3085.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void cyclicNextNextMovesForwardByTwoWithWraparound() throws Exception {
+		assertConnections("Top.cyclic_next_next", "src[1].out_p --> dst[3].in_p",
+				"src[2].out_p --> dst[4].in_p", "src[3].out_p --> dst[5].in_p",
+				"src[4].out_p --> dst[1].in_p", "src[5].out_p --> dst[2].in_p");
+	}
+
+	@Test
+	public void cyclicPreviousPreviousMovesBackByTwoWithWraparound() throws Exception {
+		assertConnections("Top.cyclic_previous_previous", "src[1].out_p --> dst[4].in_p",
+				"src[2].out_p --> dst[5].in_p", "src[3].out_p --> dst[1].in_p",
+				"src[4].out_p --> dst[2].in_p", "src[5].out_p --> dst[3].in_p");
+	}
+
+	private void assertConnections(String implementationName, String... expected) throws Exception {
+		AadlPackage pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+		var implementation = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals(implementationName))
+				.findFirst()
+				.orElseThrow();
+		var errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+
+		SystemInstance instance = InstantiateModel.instantiate(implementation, errorManager);
+
+		assertEquals(List.of(expected),
+				instance.getConnectionInstances().stream().map(ConnectionInstance::getName).toList());
+		var reporter = (QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource());
+		assertEquals(List.of(), reporter.getErrors());
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #3085.

`Cyclic_Next_Next` and `Cyclic_Previous_Previous` preserved their two-element wraparound cases but moved every interior destination index by only one. The connection-pattern table now uses one-based modular arithmetic to move every destination by two in the required direction.

## Regression

`Issue3085Test` instantiates a valid external AADL model with five-element source and destination arrays for both cyclic double-step patterns. It asserts all five generated connection-instance names and requires no instantiation diagnostics. The existing all-14-pattern characterization suite now pins both corrected mappings to AS5506D section 9.2.3.

Before the fix, both issue tests failed on the three interior pairs while the wraparound pairs matched. After the fix, the issue regression passes 2/2 and the full connection-pattern characterization passes 19/19.

## Validation

- `mvn -o -s releng/osate.releng/settings.xml -Plocal -pl :org.osate.aadl2.instantiation,:org.osate.core.tests,:org.osate.core.feature -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -Dtest=Issue3085Test -DfailIfNoTests=false verify` — 2 tests passed
- Same focused reactor with `-Dtest=ConnectionPatternInstantiationTest` — 19 tests passed
- `mvn -o -s releng/osate.releng/settings.xml -Plocal -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -DfailIfNoTests=false clean install` — 137-project reactor passed; `org.osate.core.tests` ran 787 tests

## Dependency and risk

This PR is based on `3066_split_instantiate_model` at `5b01b3cca9b07c997982118877068565de7802bd` because that refactoring introduced the table-driven location corrected here. Merge it after the #3066 branch.

Residual risk is limited to models that use the two affected property literals: their instance connection mappings intentionally change to the standard-defined double step. The other twelve patterns retain their characterized mappings.