### PR TITLE
Preserve dotted instance source names 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
@@ -552,15 +552,7 @@ public class InstantiateModel {
 	public static URI getInstanceModelURI(ComponentImplementation ci) {
 		Resource res = ci.eResource();
 		URI modeluri = res.getURI();
-		String last = modeluri.lastSegment();
-		/*
-		 * Issue #3086: this keeps the part of the source file name before the first dot rather than
-		 * dropping its extension, so two file names that differ only after the first dot produce the same
-		 * instance model file, and a name without an extension raises an exception. Correcting it renames
-		 * the instance model file of every source whose name contains a dot, which is why it is not part
-		 * of the refactoring in #3066.
-		 */
-		String filename = last.substring(0, last.indexOf('.'));
+		String filename = modeluri.trimFileExtension().lastSegment();
 		URI path = modeluri.trimSegments(1);
 		URI instanceURI = path.appendSegment(FileNameConstants.AADL_INSTANCES_DIR)
 				.appendSegment(filename + "_" + ci.getTypeName() + "_" + ci.getImplementationName()

--- a/core/org.osate.core.tests/models/issue3086/.gitignore
+++ b/core/org.osate.core.tests/models/issue3086/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3086/.project
+++ b/core/org.osate.core.tests/models/issue3086/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3086</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3086/Issue3086.aadl
+++ b/core/org.osate.core.tests/models/issue3086/Issue3086.aadl
@@ -1,0 +1,8 @@
+package Issue3086
+public
+	system Top
+	end Top;
+
+	system implementation Top.i
+	end Top.i;
+end Issue3086;

--- a/core/org.osate.core.tests/models/issue3086/Sensors.v1.aadl
+++ b/core/org.osate.core.tests/models/issue3086/Sensors.v1.aadl
@@ -1,0 +1,8 @@
+package SensorsV1
+public
+	system Top
+	end Top;
+
+	system implementation Top.i
+	end Top.i;
+end SensorsV1;

--- a/core/org.osate.core.tests/models/issue3086/Sensors.v2.aadl
+++ b/core/org.osate.core.tests/models/issue3086/Sensors.v2.aadl
@@ -1,0 +1,8 @@
+package SensorsV2
+public
+	system Top
+	end Top;
+
+	system implementation Top.i
+	end Top.i;
+end SensorsV2;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3086Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3086Test.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3086Test extends XtextTest {
+	private static final String PATH = "org.osate.core.tests/models/issue3086/";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void dottedSourceNamesProduceDistinctInstanceModelNames() throws Exception {
+		AadlPackage sensorsV1 = testHelper.parseFile(PATH + "Sensors.v1.aadl", PATH + "Sensors.v2.aadl");
+		AadlPackage sensorsV2 = sensorsV1.eResource()
+				.getResourceSet()
+				.getResources()
+				.stream()
+				.flatMap(resource -> resource.getContents().stream())
+				.filter(AadlPackage.class::isInstance)
+				.map(AadlPackage.class::cast)
+				.filter(pkg -> pkg.getName().equals("SensorsV2"))
+				.findFirst()
+				.orElseThrow();
+		validationHelper.assertNoIssues(sensorsV1);
+		validationHelper.assertNoIssues(sensorsV2);
+
+		URI v1URI = InstantiateModel.getInstanceModelURI(implementation(sensorsV1));
+		URI v2URI = InstantiateModel.getInstanceModelURI(implementation(sensorsV2));
+
+		assertEquals("Sensors.v1_Top_i_Instance.aaxl2", v1URI.lastSegment());
+		assertEquals("Sensors.v2_Top_i_Instance.aaxl2", v2URI.lastSegment());
+		assertNotEquals(v1URI, v2URI);
+	}
+
+	@Test
+	public void extensionlessSourceURIProducesAnInstanceModelName() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(PATH + "Issue3086.aadl");
+		validationHelper.assertNoIssues(pkg);
+		pkg.eResource().setURI(pkg.eResource().getURI().trimFileExtension());
+
+		URI instanceURI = InstantiateModel.getInstanceModelURI(implementation(pkg));
+
+		assertEquals("Issue3086_Top_i_Instance.aaxl2", instanceURI.lastSegment());
+	}
+
+	private static ComponentImplementation implementation(AadlPackage pkg) {
+		return (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+	}
+}


### PR DESCRIPTION
Fixes #3086

## Cause and correction

`InstantiateModel.getInstanceModelURI` derived the source stem by truncating the last path segment at its first period. As a result, sources such as `Sensors.v1.aadl` and `Sensors.v2.aadl` both generated `Sensors_<implementation>_Instance.aaxl2`, while extensionless resource URIs caused a `StringIndexOutOfBoundsException`.

Derive the stem with EMF URI extension handling instead. `trimFileExtension().lastSegment()` removes only the final extension, retains earlier periods, and also handles extensionless URIs.

## Regression

`Issue3086Test` uses separate valid AADL source files named `Sensors.v1.aadl` and `Sensors.v2.aadl`, validates both models, and asserts distinct instance filenames. It also covers an extensionless source URI.

Before the fix:
- dotted sources produced `Sensors_Top_i_Instance.aaxl2` instead of retaining `Sensors.v1` and `Sensors.v2`
- the extensionless source threw `StringIndexOutOfBoundsException`

After the fix:
- `Issue3086Test`: 2 tests passed
- related `Issue2989Test`: 1 test passed

## Validation

- Focused regression and related tests were run separately with offline Maven; all selected tests passed with non-zero counts.
- Clean offline root reactor: 137/137 projects succeeded with `-Dtycho.localArtifacts=ignore`.

## Dependency

This PR is based on `3066_split_instantiate_model` at `5b01b3cca9b07c997982118877068565de7802bd` and should be reviewed/merged after that branch.

## Release note

Instance files generated from AADL source filenames containing periods now retain the complete source stem. For example, `Sensors.v1.aadl` generates `Sensors.v1_<implementation>_Instance.aaxl2`. An older output with the truncated name may remain on disk; regenerate instances after removing that stale generated file if necessary.

## Residual risk

The change intentionally renames generated outputs for dotted source filenames. It does not automatically delete prior truncated outputs, avoiding removal of potentially user-managed files.