### PR TITLE
Refactor CreateEndToEndFlowsSwitch into focused collaborators 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/doc/e2e_instantiation.md
+++ b/core/org.osate.aadl2.instantiation/doc/e2e_instantiation.md
@@ -3,9 +3,23 @@
 This document describes how OSATE turns declarative AADL end-to-end flows into
 `EndToEndFlowInstance` objects in the instance model.
 
-Unless another file is named, all types and methods mentioned here live in
-`core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java`.
-References are by type and method name only — no line numbers, since those move.
+All types mentioned here live under
+`core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/`, one per file, in the
+package shown below. References are by type and method name only — no line numbers, since those
+move.
+
+| Type | Package | Responsibility |
+|---|---|---|
+| `CreateEndToEndFlowsSwitch` | `instantiation` | the traversal adapter: component callbacks, classifier lookup, cancellation, the compatibility entry point, and every protected extension point |
+| `EndToEndFlowSession` | `instantiation.internal` | one component instance's discovery: candidates, traversal state, expansion, deferred diagnostics, and the atomic commit |
+| `FlowConnectionMatcher` | `instantiation.internal` | stateless connection lookup and compatibility predicates |
+| `EndToEndFlowModes` | `instantiation.internal` | mode resolution and system-operation-mode computation |
+| `FlowInstantiationHost` | `instantiation.internal` | the adapter's extension points as the session sees them |
+| `FlowIterator` | `instantiation.internal` | branch-local cursor over one declaration |
+| `ETEInfo` | `instantiation.internal` | the legacy per-variant view published on request |
+
+Issue #3055 split these out of what was one class; the ownership boundaries are §4.1 and the
+decomposition is not observable in the instance model.
 
 ---
 
@@ -61,13 +75,21 @@ referenced classifiers.
 
 The switch extends `AadlProcessingSwitchWithProgress` and is constructed with
 `PROCESS_PRE_ORDER_ALL`, so its `InstanceSwitch.caseComponentInstance` fires for **every**
-component instance in pre-order. Each component instantiates the ETEs declared in *its own*
-implementation, obtained via `ComponentImplementation.getAllEndToEndFlows()`.
+component instance in pre-order. It creates one `EndToEndFlowSession` per visited component,
+instantiates the ETEs declared in *its own* implementation — obtained via
+`ComponentImplementation.getAllEndToEndFlows()` — into that session, and commits it.
 
 `org.osate.aadl2.instantiation` is an exported package (see the bundle `MANIFEST.MF`), so the
 `public`/`protected` members of this class — the constructor, `instantiateEndToEndFlow`,
 `processETE`, `processETESegment`, `processSubcomponentFlow`, `processFlowImpl`, `processFlowStep`,
 `setCloneName`, `resetETECloneCount`, `getModeInstances`, `fillinModes` — are external API.
+`org.osate.aadl2.instantiation.internal` is **not** exported, which bounds what a subclass outside
+the bundle can actually reach: `instantiateEndToEndFlow`, `processETESegment`,
+`processSubcomponentFlow`, and both `processFlowStep` overloads name `ETEInfo` or `FlowIterator` in
+their signatures, so they are overridable only from inside the bundle. That was already true when
+both types were package-private members of the switch. The hooks reachable from another bundle are
+`processETE`, `processFlowImpl`, `setCloneName`, `resetETECloneCount`, `getModeInstances`, and
+`fillinModes`.
 
 ---
 
@@ -161,14 +183,48 @@ consequences:
 - `FlowCandidate` carries an explicit `owner` field instead of relying on `eContainer()`.
 - Every diagnostic is queued and replayed after commit (§8).
 
+### 4.1 Who owns what
+
+```text
+CreateEndToEndFlowsSwitch                     ← public, exported, the compatibility promise
+  visits component instances, resolves their implementation through the classifier cache,
+  watches the progress monitor, reports errors, counts clone names,
+  declares every protected extension point, and holds activeSession
+        │                                     ▲
+        │ creates one per                     │ every traversal step and both mode
+        │ component instance                  │ computations leave the session through
+        ▼                                     │ FlowInstantiationHost, never around it
+EndToEndFlowSession                           ← internal, one component instance
+  candidates, expansions, traversal state, deferred diagnostics, atomic commit
+        │ uses
+        ├─► FlowConnectionMatcher   stateless: which connection instance can continue this flow
+        ├─► EndToEndFlowModes       mode instances and system operation modes
+        ├─► FlowIterator            branch-local cursor over one declaration
+        └─► ETEInfo                 legacy per-variant view, only when a caller asks for one
+```
+
+The session never calls its own traversal steps directly and never computes modes directly. Both go
+out through `FlowInstantiationHost`, whose methods are the switch's protected ones seen from inside,
+implemented by a private inner class of the switch that forwards to them. That indirection is the
+reason an override still decides an outcome no matter how deep in the traversal the step is reached
+from — `ExtensionHookEndToEndFlowInstantiationTest` pins exactly that. `FlowConnectionMatcher` and
+`EndToEndFlowModes` hold no state and are reached statically; the matcher's predicates are pure
+questions about a connection instance, so they can be read without knowing how the flow got there.
+
+The switch resolves the session for a protected step from `activeSession` and throws
+`IllegalStateException("No active end-to-end flow instantiation context")` when there is none, so
+calling a hook outside an instantiation fails instead of touching an unrelated component.
+
 ---
 
 ## 5. Data structures
 
-Three nested scopes, plus one branch-local cursor:
+Three nested scopes, plus one branch-local cursor. All of them are private to
+`EndToEndFlowSession`; nothing outside it sees a candidate:
 
 ```text
-FlowInstantiationContext                      ← per ComponentInstance
+EndToEndFlowSession                           ← per ComponentInstance
+  host               : FlowInstantiationHost  (the switch's extension points)
   owner              : ComponentInstance      (explicit; no eContainer() reliance)
   initialFlows       : List.copyOf(owner.getEndToEndFlows())  ← commit precondition
   expansions         : EndToEndFlow → FlowExpansion   (IdentityHashMap, memoized)
@@ -193,34 +249,40 @@ FlowInstantiationContext                      ← per ComponentInstance
                 sequence        : long               ← creation order, drives naming
                 status          : ACTIVE | COMPLETE | FAILED | ABORTED
 
-TraversalState                                ← branch-local cursor, held in a switch field
+TraversalState                                ← branch-local cursor, held in a session field
   candidate           : FlowCandidate
   continuations       : Deque<FlowIterator>   ← descent stack
   connections         : List<Connection>      ← pending connection filter
   flowImplementations : List<FlowImplementation>  ← source/destination feature constraints
 ```
 
-Note that `TraversalState` is **not** owned by `FlowInstantiationContext`. Two fields of the switch
-hold the current scope:
+Two fields hold the current scope, one in each class:
 
-- `activeContext` — the `FlowInstantiationContext` of the component being visited
-- `activeState` — the `TraversalState` of the branch currently advancing
+- `CreateEndToEndFlowsSwitch.activeSession` — the session of the component being visited
+- `EndToEndFlowSession.activeState` — the `TraversalState` of the branch currently advancing
 
-`caseComponentInstance` and `instantiateEndToEndFlow` save and restore both around their bodies, so
-re-entrant calls nest cleanly. `getCandidate(etei)` and `getState(etei)` are the guarded accessors:
-they throw `IllegalStateException` if an instance is not part of the active context, or if a branch
-tries to advance while it is no longer the active one.
+`caseComponentInstance` and `instantiateEndToEndFlow` save and restore `activeSession` around their
+bodies, and `expand` does the same for `activeState`, so re-entrant calls nest cleanly. Restoring the
+session restores its traversal state with it, since the state belongs to the session. `session()`,
+`getCandidate(etei)`, and `getState(etei)` are the guarded accessors: they throw
+`IllegalStateException` if there is no instantiation in progress, if an instance is not part of the
+active session, or if a branch tries to advance while it is no longer the active one.
+
+A session belongs to one component instance. `instantiateEndToEndFlow` enforces that by throwing
+`IllegalStateException("End-to-end flow expansion crossed component contexts")` when it is asked to
+expand a declaration in a component other than the active session's owner, which is why `expand`
+can use the session's `owner` as the component context.
 
 `FlowIterator` is a uniform cursor over either `EndToEndFlow.getAllFlowSegments()` or
 `FlowImplementation.getOwnedFlowSegments()`. It holds a single `List<? extends Element> segments`
-plus an `index`, and its private `copy()` returns a new iterator over the same list at the same
-position — that is how a fork resumes exactly where its sibling was.
+plus an `index`, and its `copy()` returns a new iterator over the same list at the same position —
+that is how a fork resumes exactly where its sibling was.
 
-`ETEInfo` is the legacy record (`preConns`, `etei`, `postConns`) published through
-`updateCompatibilityInfo` into the `HashMap<EndToEndFlow, List<ETEInfo>>` that
-`instantiateEndToEndFlow` accepts. It exists for API compatibility and is populated once when an
-external caller supplies a map; internal calls pass `null` because traversal uses `FlowCandidate`
-directly.
+`ETEInfo` is the legacy per-variant view (`preConns`, `etei`, `postConns`) that
+`EndToEndFlowSession.compatibilityInfo` builds from a declaration's candidates, in creation order,
+for the `HashMap<EndToEndFlow, List<ETEInfo>>` that `instantiateEndToEndFlow` accepts. It exists for
+API compatibility and is built only when a caller supplies a map; internal calls pass `null` because
+traversal uses `FlowCandidate` directly.
 
 ---
 
@@ -309,7 +371,7 @@ segments may still refine a feature-group endpoint to one of its features.
 continueFlow(ci, etei, iter, errorElement):
   candidate = getCandidate(etei)
   loop:
-    if monitor canceled                → activeContext.canceled = true; return
+    if monitor canceled                → session canceled = true; return
     if activeState is null or its candidate != candidate
                                        → return       (a fork took over)
     if ci == null                      → EXISTING_ELEMENT error
@@ -389,7 +451,8 @@ processFlowStep(ci, etei, leaf, nextFlowImpl, iter)
                  pop flowImplementations
 ```
 
-The three `isValidContinuation` overloads are pure predicates:
+Connection resolution itself is `FlowConnectionMatcher`, which asks nothing about how the flow was
+reached. Its three `isValidContinuation` overloads are pure predicates:
 
 | Overload | Question |
 |---|---|
@@ -419,6 +482,11 @@ match rules:
 `getLastFeature` supplies that last feature, recursing into a trailing nested
 `EndToEndFlowInstance`, taking a `FlowSpecificationInstance`'s destination, or a
 `ConnectionInstance`'s destination when it is a `FeatureInstance`.
+
+`testConnection`, `isSameOrRefinedConnection`, `isSameorContains`, `getLastFeature`,
+`containsConnectionPath`, and `getFirstConnectionEnd` are private to the matcher; discovery only
+calls `collectConnectionInstances`, the three `isValidContinuation` overloads, and
+`isCompatibleNestedConnection`.
 
 ### 6.5 Leaf elements
 
@@ -454,14 +522,15 @@ connection from the iterator. That preserves the remainder of a multi-hop access
 `processEndToEndFlow` handles an ETE referenced inside another ETE, in the same component context.
 
 ```text
-① cycle check: activeContext.activeDeclarations.indexOf(ete) >= 0
+① cycle check: activeDeclarations.indexOf(ete) >= 0
      → mark every expansion from cycleStart..end FAILED, and all their candidates FAILED
        candidate error "Cyclic dependency between end to end flows involving …"   (#2987)
        clear pending; return
 
-② memoize: if not yet expanded → instantiateEndToEndFlow(ci, ete, null)
-     (this is what makes forward references work, and routes them through the same
-      expansion bookkeeping and commit-time naming as declared-order flows)      (#2985)
+② memoize: if not yet expanded → host.expandNestedFlow(ci, ete)
+     (that is instantiateEndToEndFlow(ci, ete, null) on the switch, which is what makes
+      forward references work and routes them through the same expansion bookkeeping
+      and commit-time naming as declared-order flows)                            (#2985)
    nested expansion FAILED → parent expansion FAILED, all its candidates FAILED
    nested expansion has no COMPLETE candidates → candidate error
        "No nested end to end flows instantiated for …"
@@ -478,7 +547,8 @@ connection from the iterator. That preserves the remainder of a multi-hop access
          otherwise build the full match list:
              record NestedMatch(ConnectionInstance connection, FlowCandidate nested)
              for each conni × each nested where
-                 containsConnectionPath(conni, nested.preConnections)             (#2986)
+                 isCompatibleNestedConnection(conni, nested.preConnections,
+                                              nested.instance)                    (#2986)
          matches empty → candidate error
              "No compatible nested end to end flow instance for …"; clear pending; return
          otherwise FORK PER MATCH:
@@ -503,8 +573,10 @@ Nested declaration
 
 The `preConnections` / `postConnections` pair exists precisely for this handshake: a nested flow's
 *leading* declarative connections identify which parent connection instance can reach it, and its
-*trailing* ones seed the parent's next filter. `containsConnectionPath` is the contiguous-sequence
-test over a connection instance's references (an empty path matches trivially).
+*trailing* ones seed the parent's next filter. `FlowConnectionMatcher.isCompatibleNestedConnection`
+asks two things of a pairing: that the connection instance contains the nested variant's leading
+declarative path as a contiguous sequence of its references — that is `containsConnectionPath`, and
+an empty path matches trivially — and that its destination reaches the nested flow's first endpoint.
 
 Matching is materialised as a list rather than counted, so every compatible
 `(connection, nested)` pair produces exactly one parent branch — including the case where one
@@ -522,7 +594,7 @@ forkState(source)
   preConnections = source.candidate.instance.getFlowElements().isEmpty()
                      ? new ArrayList<>()
                      : new ArrayList<>(source.candidate.preConnections)
-  candidate = createCandidate(activeContext, source.candidate.expansion, instance, preConnections)
+  candidate = createCandidate(source.candidate.expansion, instance, preConnections)
                                                             ← fresh sequence number
   return source.copy(candidate)   ← copies the continuations deque (each FlowIterator
                                     copied), the pending connections, and the
@@ -588,18 +660,19 @@ Resulting candidate tree for `BranchingTop.i`:
 still `ACTIVE`. Both statuses stop `continueFlow` from extending that branch, preventing cascaded
 diagnostics after the first failure; sibling branches are unaffected.
 
-At the *expansion* level, `expandEndToEndFlow`'s `finally` block resolves status: if the expansion is
-`FAILED`, every candidate of that declaration becomes `FAILED`; otherwise every still-`ACTIVE`
-candidate with at least one flow element becomes `COMPLETE`, while an empty candidate becomes
-`FAILED`. The `finally` block also pops `activeDeclarations`, restores `activeState`, sets
-`context.canceled` if the monitor was cancelled, and leaves compatibility-map publication to the
-protected entry point when a caller supplied one.
+At the *expansion* level, `EndToEndFlowSession.expand`'s `finally` block resolves status: if the
+expansion is `FAILED`, every candidate of that declaration becomes `FAILED`; otherwise every
+still-`ACTIVE` candidate with at least one flow element becomes `COMPLETE`, while an empty candidate
+becomes `FAILED`. The `finally` block also pops `activeDeclarations`, restores `activeState`, sets
+the session's `canceled` flag if the monitor was cancelled, and leaves compatibility-map publication
+to the protected entry point when a caller supplied one.
 
 ---
 
 ## 9. Commit
 
-Nothing touches the instance model until `commit(context)`, which runs once per component instance.
+Nothing touches the instance model until `EndToEndFlowSession.commit()`, which runs once per
+component instance. The switch calls it after the last declaration of a component has been expanded.
 
 ```mermaid
 sequenceDiagram
@@ -620,8 +693,8 @@ sequenceDiagram
 ```
 
 ```text
-commit(context):
-  if context.canceled or monitor canceled  → attach nothing                     ①
+commit():
+  if session canceled or monitor canceled  → attach nothing                     ①
   if owner.getEndToEndFlows() != initialFlows → IllegalStateException
        "End-to-end flow list changed during candidate discovery"                ②
 
@@ -642,7 +715,7 @@ commit(context):
   owner.getEndToEndFlows().addAll(instances)   ← THE ONLY MUTATION (sequence order)
 
   ┌ MODE FINALIZATION — post-order over the nesting graph ────────────────────┐
-  │ finalizeModes(context, candidate, finalized, finalizing):                 │
+  │ finalizeModes(candidate, finalized, finalizing):                          │
   │   recurse into nested COMPLETE candidates FIRST, so a parent reads        │
   │   already-computed nested inSystemOperationModes                          │
   │   `finalizing` guard → IllegalStateException                              │
@@ -678,6 +751,10 @@ nothing, cancellation after expansion attaches nothing, and a `fillinModes` that
 `getEndToEndFlows()` exactly as it was.
 
 ### Mode and SOM computation
+
+The arithmetic is `EndToEndFlowModes`; the protected `getModeInstances` and `fillinModes` are thin
+delegates to `modeInstances` and `fillInModes` there, and discovery reaches them only through those
+delegates, so an override still decides the result.
 
 `fillinModes` reduces the candidate system operation modes in three passes. It returns immediately
 if the system instance has one SOM or fewer.
@@ -740,22 +817,34 @@ cyclic declarations terminate without flows while reporting the cycle on the con
 
 ## 11. Reading order for the code
 
-1. `initSwitches` / `caseComponentInstance` — per-component scoping, and where `commit` is called.
-2. `instantiateEndToEndFlow` / `expandEndToEndFlow` — memoization, the DFS stack, and status
-   resolution in the `finally` block.
-3. `continueFlow` — the driver loop; understand `continuations` first.
-4. `processFlowStep` — the pending-connection filter and the fork idiom.
-5. `testConnection` / `isSameOrRefinedConnection` / `getLastFeature` — semantic-connection matching.
-6. `processEndToEndFlow` — nesting, cycles, and the pre/post-connection handshake.
-7. `commit` / `finalizeModes` / `fillinModes` — materialization.
+In `CreateEndToEndFlowsSwitch`:
+
+1. `initSwitches` / `caseComponentInstance` — per-component scoping, where a session is created and
+   where `commit` is called.
+2. `instantiateEndToEndFlow` — the compatibility entry point, the one-component-per-session rule, and
+   the standalone case.
+3. the protected steps and `SessionHost` — how a traversal step leaves the session and comes back.
+
+Then in `EndToEndFlowSession`:
+
+4. `expand` — memoization, the DFS stack, and status resolution in the `finally` block.
+5. `continueFlow` — the driver loop; understand `continuations` first.
+6. `processFlowStep` — the pending-connection filter and the fork idiom.
+7. `processEndToEndFlow` — nesting, cycles, and the pre/post-connection handshake.
+8. `commit` / `finalizeModes` — materialization.
+
+And finally the two stateless collaborators: `FlowConnectionMatcher.testConnection` /
+`isSameOrRefinedConnection` / `getLastFeature` for semantic-connection matching, and
+`EndToEndFlowModes.fillInModes` for system operation modes.
 
 The characterization tests in
 `core/org.osate.core.tests/src/org/osate/core/tests/instantiation/flows/`, with models in
 `core/org.osate.core.tests/models/endToEndFlowInstantiation/`, are the executable specification.
 `AbstractEndToEndFlowInstantiationTest` provides the shared helpers (`instantiate`,
 `instantiateWithErrors`, `flowNames`, `flow`, `flowSpecification`, `connection`, `nestedFlow`, …),
-and the suites are `Basic`, `Nested`, `Invalid`, `Modal`, `Access`, `FeatureGroupAndRefinement`, and
-`Cancellation`. `BasicAndBranching.aadl` and `NestedFlows.aadl` are the two most instructive models.
+and the suites are `Basic`, `Nested`, `Invalid`, `Modal`, `Access`, `FeatureGroupAndRefinement`,
+`Cancellation`, and `ExtensionHook`. `BasicAndBranching.aadl` and `NestedFlows.aadl` are the two most
+instructive models.
 
 ---
 
@@ -776,3 +865,4 @@ attributions in this document can be checked without relying on the source comme
 | [#2986](https://github.com/osate/osate2/issues/2986) | Nested end-to-end flow composition combines incompatible path variants | §6.7, §10 — `containsConnectionPath` pairing |
 | [#2987](https://github.com/osate/osate2/issues/2987) | Cyclic nested end-to-end flows create cyclic instance graphs | §6.7, §10 — `activeDeclarations` cycle check |
 | [#2988](https://github.com/osate/osate2/issues/2988) | End-to-end flow connection matching ignores declarative connection context | §6.4 — `isSameOrRefinedConnection` |
+| [#3055](https://github.com/osate/osate2/issues/3055) | Refactor `CreateEndToEndFlowsSwitch` into focused collaborators | §1, §4.1 — where each type lives and what it owns |

--- a/core/org.osate.aadl2.instantiation/doc/e2e_instantiation.md
+++ b/core/org.osate.aadl2.instantiation/doc/e2e_instantiation.md
@@ -232,7 +232,7 @@ EndToEndFlowSession                           ← per ComponentInstance
   candidates         : List<FlowCandidate>            (global creation order)
   candidatesByInstance : EndToEndFlowInstance → FlowCandidate
   activeDeclarations : List<EndToEndFlow>              ← DFS stack, cycle detection
-  diagnostics        : List<PendingDiagnostic>         ← deferred, replayed at commit
+  diagnostics        : List<PendingDiagnostic>         ← sealed; deferred, replayed at commit
   nextCandidateSequence, nextDiagnosticSequence, canceled
 
    └── FlowExpansion                          ← per declarative EndToEndFlow
@@ -374,7 +374,7 @@ continueFlow(ci, etei, iter, errorElement):
     if monitor canceled                → session canceled = true; return
     if activeState is null or its candidate != candidate
                                        → return       (a fork took over)
-    if ci == null                      → EXISTING_ELEMENT error
+    if ci == null                      → ElementError diagnostic
                                           "Flow instance leaves system instance for flow …";
                                           clear pending connections; return
     while iter.hasNext():
@@ -431,9 +431,9 @@ processFlowStep(ci, etei, leaf, nextFlowImpl, iter)
       │                    from feature 'x'"
       │
       └─ filter each conni — issue 1984: filter first, report only if none survive
-           flowFilter (previous impl's out end) → isValidContinuation(fimpl, conni)
-           nextFlowImpl known                  → isValidContinuation(conni, fimpl)
-           plain flow-spec leaf                → isValidContinuation(ci, conni, fspec)
+           flowFilter (previous impl's out end) → startsAtFlowOutput(fimpl, conni)
+           nextFlowImpl known                  → endsAtFlowInput(conni, fimpl)
+           plain flow-spec leaf                → endsAtFlowSource(ci, conni, fspec)
            │
            ├─ none survive → owner error
            │                 "… no semantic connections that connect to the start of
@@ -452,16 +452,16 @@ processFlowStep(ci, etei, leaf, nextFlowImpl, iter)
 ```
 
 Connection resolution itself is `FlowConnectionMatcher`, which asks nothing about how the flow was
-reached. Its three `isValidContinuation` overloads are pure predicates:
+reached. Its three endpoint predicates are pure:
 
-| Overload | Question |
+| Predicate | Question |
 |---|---|
-| `(ConnectionInstance, FlowImplementation)` | does the connection *end* at the implementation's in-end feature? |
-| `(FlowImplementation, ConnectionInstance)` | does the connection *start* at the implementation's out-end feature? |
-| `(ComponentInstance, ConnectionInstance, FlowSpecification)` | does the connection end at the flow specification's source feature, or at a feature nested inside it? (walks up the `FeatureInstance` containment chain) |
+| `endsAtFlowInput(conni, fimpl)` | does the connection end at the implementation's in-end feature? |
+| `startsAtFlowOutput(fimpl, conni)` | does the connection start at the implementation's out-end feature? |
+| `endsAtFlowSource(ci, conni, fspec)` | does the connection end at the flow specification's source feature, or at a feature nested inside it? (walks up the `FeatureInstance` containment chain) |
 
 `collectConnectionInstances` iterates `ci.allEnclosingConnectionInstances()` and keeps those for
-which `testConnection` holds. `testConnection` matches the pending declarative sequence against the
+which `carriesConnectionPath` holds. That test matches the pending declarative sequence against the
 connection instance's `ConnectionReference` chain:
 
 ```text
@@ -475,7 +475,7 @@ match rules:
     refinements match while unrelated same-named connections do not          (#2988)
   • single-connection filter → direction check: the connection instance's source
     component must lie inside the component of the flow's last element
-  • source-feature check → isSameorContains(lastFeature, connSource): accepts
+  • source-feature check → isSameOrContains(lastFeature, connSource): accepts
     connection instances produced by feature-group expansion
 ```
 
@@ -483,9 +483,9 @@ match rules:
 `EndToEndFlowInstance`, taking a `FlowSpecificationInstance`'s destination, or a
 `ConnectionInstance`'s destination when it is a `FeatureInstance`.
 
-`testConnection`, `isSameOrRefinedConnection`, `isSameorContains`, `getLastFeature`,
+`carriesConnectionPath`, `isSameOrRefinedConnection`, `isSameOrContains`, `getLastFeature`,
 `containsConnectionPath`, and `getFirstConnectionEnd` are private to the matcher; discovery only
-calls `collectConnectionInstances`, the three `isValidContinuation` overloads, and
+calls `collectConnectionInstances`, the three endpoint predicates, and
 `isCompatibleNestedConnection`.
 
 ### 6.5 Leaf elements
@@ -727,12 +727,12 @@ commit():
                                   restore snapshot ③, rethrow
 
   ┌ DIAGNOSTICS — replayed sorted by sequence ───────────────────────────────┐
-  │ OWNER            → error(candidate.owner, msg)             always        │
-  │ CANDIDATE        → COMPLETE: error(candidate.instance, msg)              │
-  │                    otherwise: error(candidate.owner,                     │
-  │                        candidate.name + " could not be instantiated: "   │
-  │                        + msg)                                            │
-  │ EXISTING_ELEMENT → error(existingElement, msg)             always        │
+  │ OwnerError     → error(candidate.owner, msg)               always        │
+  │ CandidateError → COMPLETE: error(candidate.instance, msg)                │
+  │                  otherwise: error(candidate.owner,                       │
+  │                      candidate.name + " could not be instantiated: "     │
+  │                      + msg)                                              │
+  │ ElementError   → error(element, msg)                       always        │
   └──────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -742,7 +742,8 @@ these invariants is broken could return an untrustworthy instance model. Discove
 detached, and an exception during mode finalization removes the newly attached instances and
 restores their mode snapshots before it is rethrown.
 
-Only `CANDIDATE`-targeted diagnostics are status-filtered. Diagnostics about discarded branches are
+`PendingDiagnostic` is a sealed interface with one record per target, so the replay switch is
+exhaustive without a default. Only `CandidateError` is status-filtered. Diagnostics about discarded branches are
 therefore **not** lost — they are simply reported against the owning component instead of against a
 flow instance that does not exist.
 
@@ -753,8 +754,10 @@ nothing, cancellation after expansion attaches nothing, and a `fillinModes` that
 ### Mode and SOM computation
 
 The arithmetic is `EndToEndFlowModes`; the protected `getModeInstances` and `fillinModes` are thin
-delegates to `modeInstances` and `fillInModes` there, and discovery reaches them only through those
-delegates, so an override still decides the result.
+delegates to `modeInstances` and `assignSystemOperationModes` there, and discovery reaches them only
+through those delegates, so an override still decides the result. The protected names are the
+historical ones and stay, because renaming an overridable method would silently stop calling an
+existing subclass's override.
 
 `fillinModes` reduces the candidate system operation modes in three passes. It returns immediately
 if the system instance has one SOM or fewer.
@@ -833,9 +836,9 @@ Then in `EndToEndFlowSession`:
 7. `processEndToEndFlow` — nesting, cycles, and the pre/post-connection handshake.
 8. `commit` / `finalizeModes` — materialization.
 
-And finally the two stateless collaborators: `FlowConnectionMatcher.testConnection` /
+And finally the two stateless collaborators: `FlowConnectionMatcher.carriesConnectionPath` /
 `isSameOrRefinedConnection` / `getLastFeature` for semantic-connection matching, and
-`EndToEndFlowModes.fillInModes` for system operation modes.
+`EndToEndFlowModes.assignSystemOperationModes` for system operation modes.
 
 The characterization tests in
 `core/org.osate.core.tests/src/org/osate/core/tests/instantiation/flows/`, with models in
@@ -859,7 +862,7 @@ attributions in this document can be checked without relying on the source comme
 |---|---|---|
 | [#612](https://github.com/osate/osate2/issues/612) | End to end flow instantiation continues after error | §6.5, §8 — `addLeafElement` failure aborts the candidate |
 | 1953 | (cited in source) thread flow implementations treated as atomic | §6.2 — `ThreadClassifier` shortcut |
-| 1984 | (cited in source) `isValidContinuation` is a filter, not a reporter | §6.4, §10 — filter first, report only if none survive |
+| 1984 | (cited in source) the endpoint predicates are a filter, not a reporter | §6.4, §10 — filter first, report only if none survive |
 | [#2872](https://github.com/osate/osate2/issues/2872) | Flow instantiation silently fails when subcomponents have connections but not flow implementations | §6.2, §10 — `AadlUtil.hasPortComponents` check |
 | [#2985](https://github.com/osate/osate2/issues/2985) | Forward-referenced nested end-to-end flows bypass cleanup and clone naming | §6.7 — memoized expansion of forward references |
 | [#2986](https://github.com/osate/osate2/issues/2986) | Nested end-to-end flow composition combines incompatible path variants | §6.7, §10 — `containsConnectionPath` pairing |

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
@@ -23,240 +23,54 @@
  */
 package org.osate.aadl2.instantiation;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.Deque;
 import java.util.HashMap;
-import java.util.IdentityHashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
-import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.osate.aadl2.Access;
-import org.osate.aadl2.ComponentCategory;
 import org.osate.aadl2.ComponentImplementation;
-import org.osate.aadl2.Connection;
-import org.osate.aadl2.DataAccess;
 import org.osate.aadl2.Element;
 import org.osate.aadl2.EndToEndFlow;
-import org.osate.aadl2.EndToEndFlowElement;
-import org.osate.aadl2.EndToEndFlowSegment;
-import org.osate.aadl2.Feature;
 import org.osate.aadl2.FlowImplementation;
-import org.osate.aadl2.FlowSegment;
 import org.osate.aadl2.FlowSpecification;
 import org.osate.aadl2.ModalElement;
-import org.osate.aadl2.Mode;
 import org.osate.aadl2.NamedElement;
-import org.osate.aadl2.Subcomponent;
-import org.osate.aadl2.SubprogramAccess;
-import org.osate.aadl2.ThreadClassifier;
 import org.osate.aadl2.instance.ComponentInstance;
-import org.osate.aadl2.instance.ConnectionInstance;
-import org.osate.aadl2.instance.ConnectionInstanceEnd;
-import org.osate.aadl2.instance.ConnectionReference;
 import org.osate.aadl2.instance.EndToEndFlowInstance;
-import org.osate.aadl2.instance.FeatureInstance;
-import org.osate.aadl2.instance.FlowElementInstance;
-import org.osate.aadl2.instance.FlowSpecificationInstance;
-import org.osate.aadl2.instance.InstanceFactory;
 import org.osate.aadl2.instance.InstanceObject;
 import org.osate.aadl2.instance.ModeInstance;
 import org.osate.aadl2.instance.SystemInstance;
-import org.osate.aadl2.instance.SystemOperationMode;
 import org.osate.aadl2.instance.util.InstanceSwitch;
 import org.osate.aadl2.instance.util.InstanceUtil;
 import org.osate.aadl2.instance.util.InstanceUtil.InstantiatedClassifier;
+import org.osate.aadl2.instantiation.internal.ETEInfo;
+import org.osate.aadl2.instantiation.internal.EndToEndFlowModes;
+import org.osate.aadl2.instantiation.internal.EndToEndFlowSession;
+import org.osate.aadl2.instantiation.internal.FlowInstantiationHost;
+import org.osate.aadl2.instantiation.internal.FlowIterator;
 import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
 import org.osate.aadl2.modelsupport.modeltraversal.AadlProcessingSwitchWithProgress;
-import org.osate.aadl2.modelsupport.util.AadlUtil;
 
 /**
  * Instantiates declarative end-to-end flows for each component instance.
  * <p>
- * Flow discovery builds detached candidates with branch-local traversal state. A declaration may produce multiple
- * candidates when several flow implementations, connection instances, access targets, or nested end-to-end flow
- * variants match. Only completed candidates are attached to the component, in one commit after discovery finishes.
- * Cancellation therefore leaves the component's existing end-to-end flows unchanged.
+ * This is the public entry point for the end-to-end flow phase, and it stays one whatever the discovery behind it does.
+ * It visits component instances, resolves the implementation instantiated for each of them, watches for cancellation,
+ * and declares the protected methods a subclass may override. Discovery itself belongs to
+ * {@link EndToEndFlowSession}: one session per visited component instance owns that component's candidates, traversal
+ * state, deferred diagnostics, and its single atomic commit, and reaches every overridable step back through this class
+ * so that an override still decides the outcome. Connection lookup and compatibility are the stateless predicates of
+ * {@code FlowConnectionMatcher}, and mode arithmetic is {@code EndToEndFlowModes}, which the two protected mode methods
+ * below delegate to.
  * <p>
- * Nested end-to-end flows are expanded once per component context. Their leading and trailing declarative connection
- * paths are retained so parent candidates can select compatible nested variants and continue after them.
- * <p>
- * Internal consistency failures throw {@link IllegalStateException} intentionally. Continuing after an invariant has
- * failed could publish an instance model whose flow graph cannot be trusted.
+ * A session is detached from the instance model while it discovers candidates and attaches the ones that completed in
+ * one commit, so cancellation and internal-consistency failures leave a component's existing end-to-end flows
+ * unchanged. {@code doc/e2e_instantiation.md} describes discovery, commit, and diagnostics in full.
  *
  * @author lwrage
  */
 public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress {
-
-	static class FlowIterator implements Iterator<Element> {
-
-		private final List<? extends Element> segments;
-
-		private int index;
-
-		public FlowIterator(EndToEndFlow ete) {
-			this(ete.getAllFlowSegments(), 0);
-		}
-
-		public FlowIterator(FlowImplementation flowImpl) {
-			this(flowImpl.getOwnedFlowSegments(), 0);
-		}
-
-		private FlowIterator(List<? extends Element> segments, int index) {
-			this.segments = segments;
-			this.index = index;
-		}
-
-		@Override
-		public boolean hasNext() {
-			return index < segments.size();
-		}
-
-		@Override
-		public Element next() {
-			if (!hasNext()) {
-				throw new NoSuchElementException();
-			}
-			return segments.get(index++);
-		}
-
-		private FlowIterator copy() {
-			return new FlowIterator(segments, index);
-		}
-	}
-
-	static class ETEInfo {
-		List<Connection> preConns;
-		EndToEndFlowInstance etei;
-		List<Connection> postConns = new ArrayList<>();
-
-		public ETEInfo(EndToEndFlowInstance etei) {
-			preConns = new ArrayList<>();
-			this.etei = etei;
-		}
-
-		public ETEInfo(List<Connection> preConns, EndToEndFlowInstance etei) {
-			this.preConns = preConns;
-			this.etei = etei;
-		}
-	}
-
-	/**
-	 * Candidate discovery states. A failed candidate has no valid semantic continuation or belongs to a failed
-	 * declaration expansion. An aborted candidate could not append a resolved flow element because the instance model
-	 * did not satisfy the declaration.
-	 */
-	private enum CandidateStatus {
-		ACTIVE, COMPLETE, FAILED, ABORTED
-	}
-
-	private enum ExpansionStatus {
-		EXPANDING, COMPLETE, FAILED
-	}
-
-	private enum DiagnosticTarget {
-		OWNER, CANDIDATE, EXISTING_ELEMENT
-	}
-
-	private record PendingDiagnostic(long sequence, DiagnosticTarget target, FlowCandidate candidate,
-			Element existingElement, String message) {
-	}
-
-	/**
-	 * Expansion of one declarative end-to-end flow and all candidate paths derived from it.
-	 */
-	private static final class FlowExpansion {
-		private final EndToEndFlow declaration;
-		private final List<FlowCandidate> candidates = new ArrayList<>();
-		private ExpansionStatus status = ExpansionStatus.EXPANDING;
-
-		private FlowExpansion(EndToEndFlow declaration) {
-			this.declaration = declaration;
-		}
-	}
-
-	/**
-	 * A detached end-to-end flow instance under construction.
-	 */
-	private static final class FlowCandidate {
-		private final ComponentInstance owner;
-		private final FlowExpansion expansion;
-		private final EndToEndFlowInstance instance;
-		/*
-		 * Declarative connection paths before the first and after the last concrete flow element. Parent flows use these
-		 * paths to select compatible nested candidates and continue beyond them.
-		 */
-		private final List<Connection> preConnections;
-		private final List<Connection> postConnections = new ArrayList<>();
-		private final long sequence;
-		private CandidateStatus status = CandidateStatus.ACTIVE;
-
-		private FlowCandidate(ComponentInstance owner, FlowExpansion expansion, EndToEndFlowInstance instance,
-				List<Connection> preConnections, long sequence) {
-			this.owner = owner;
-			this.expansion = expansion;
-			this.instance = instance;
-			this.preConnections = preConnections;
-			this.sequence = sequence;
-		}
-	}
-
-	/**
-	 * Branch-local traversal data. Continuations resume enclosing declarations after descending into a flow
-	 * implementation or another nested construct; connections are the declarative path awaiting resolution to a
-	 * connection instance; flowImplementations constrain the source and destination features accepted for that
-	 * connection instance.
-	 */
-	private static final class TraversalState {
-		private final FlowCandidate candidate;
-		private final Deque<FlowIterator> continuations = new ArrayDeque<>();
-		private final List<Connection> connections = new ArrayList<>();
-		private final List<FlowImplementation> flowImplementations = new ArrayList<>();
-
-		private TraversalState(FlowCandidate candidate) {
-			this.candidate = candidate;
-		}
-
-		private TraversalState copy(FlowCandidate candidate) {
-			TraversalState copy = new TraversalState(candidate);
-			for (FlowIterator continuation : continuations) {
-				copy.continuations.addLast(continuation.copy());
-			}
-			copy.connections.addAll(connections);
-			copy.flowImplementations.addAll(flowImplementations);
-			return copy;
-		}
-	}
-
-	/**
-	 * All discovery and commit state for one component instance.
-	 */
-	private static final class FlowInstantiationContext {
-		private final ComponentInstance owner;
-		private final List<EndToEndFlowInstance> initialFlows;
-		private final Map<EndToEndFlow, FlowExpansion> expansions = new IdentityHashMap<>();
-		private final List<FlowExpansion> expansionOrder = new ArrayList<>();
-		private final List<FlowCandidate> candidates = new ArrayList<>();
-		private final Map<EndToEndFlowInstance, FlowCandidate> candidatesByInstance = new IdentityHashMap<>();
-		private final List<EndToEndFlow> activeDeclarations = new ArrayList<>();
-		private final List<PendingDiagnostic> diagnostics = new ArrayList<>();
-		private long nextCandidateSequence;
-		private long nextDiagnosticSequence;
-		private boolean canceled;
-
-		private FlowInstantiationContext(ComponentInstance owner) {
-			this.owner = owner;
-			initialFlows = List.copyOf(owner.getEndToEndFlows());
-		}
-	}
 
 	/**
 	 * A classifier for an instance object when it is a prototype in the
@@ -268,8 +82,14 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 	 */
 	private final Map<InstanceObject, InstantiatedClassifier> classifierCache;
 
-	private FlowInstantiationContext activeContext;
-	private TraversalState activeState;
+	/**
+	 * The view a session has of this switch. It is an object of its own rather than the switch itself so that routing a
+	 * traversal step back to an overridable method does not require making that method public.
+	 */
+	private final FlowInstantiationHost host = new SessionHost();
+
+	/** The session of the component instance being instantiated, or null outside instantiation. */
+	private EndToEndFlowSession activeSession;
 
 	/**
 	 * Create an end-to-end flow instantiation pass.
@@ -294,40 +114,55 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 					cancelTraversal();
 					return DONE;
 				}
-				ComponentImplementation impl;
-
 				if (ci.getContainingComponentInstance() instanceof SystemInstance) {
 					monitor.subTask("Creating end-to-end flows in " + ci.getName());
 				}
-				FlowInstantiationContext previousContext = activeContext;
-				TraversalState previousState = activeState;
-				FlowInstantiationContext context = new FlowInstantiationContext(ci);
-				activeContext = context;
-				activeState = null;
+				EndToEndFlowSession previousSession = activeSession;
+				EndToEndFlowSession session = new EndToEndFlowSession(host, ci);
+				activeSession = session;
 				try {
-					impl = InstanceUtil.getComponentImplementation(ci, 0, classifierCache);
+					ComponentImplementation impl = getComponentImplementation(ci);
 					if (impl != null) {
 						for (EndToEndFlow ete : impl.getAllEndToEndFlows()) {
 							if (monitor.isCanceled()) {
-								context.canceled = true;
+								session.cancel();
 								cancelTraversal();
 								break;
 							}
-							if (!context.expansions.containsKey(ete)) {
+							if (!session.isExpanded(ete)) {
 								instantiateEndToEndFlow(ci, ete, null);
 							}
 						}
 					}
-					if (!context.canceled && !monitor.isCanceled()) {
-						commit(context);
+					if (!session.isCanceled() && !monitor.isCanceled()) {
+						session.commit();
 					}
 				} finally {
-					activeContext = previousContext;
-					activeState = previousState;
+					activeSession = previousSession;
 				}
 				return DONE;
 			}
 		};
+	}
+
+	/**
+	 * The implementation instantiated for a component instance, with prototypes resolved through the classifier cache.
+	 */
+	private ComponentImplementation getComponentImplementation(ComponentInstance ci) {
+		return InstanceUtil.getComponentImplementation(ci, 0, classifierCache);
+	}
+
+	/**
+	 * The session that is instantiating flows right now.
+	 *
+	 * @throws IllegalStateException if there is no instantiation in progress, which means a traversal step was reached
+	 *             from outside an instantiation
+	 */
+	private EndToEndFlowSession session() {
+		if (activeSession == null) {
+			throw new IllegalStateException("No active end-to-end flow instantiation context");
+		}
+		return activeSession;
 	}
 
 	int ETEInstanceCloneCount = 1;
@@ -343,284 +178,39 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 	/**
 	 * Expand one declaration and optionally publish its legacy compatibility view. Internal callers pass {@code null};
 	 * the map parameter is retained for protected API compatibility.
+	 * <p>
+	 * The declaration is expanded in the session of the component instance being visited. Called outside a traversal, it
+	 * starts a session of its own for {@code ci} and commits it before returning.
 	 */
 	protected void instantiateEndToEndFlow(ComponentInstance ci, EndToEndFlow ete,
 			HashMap<EndToEndFlow, List<ETEInfo>> ete2info) {
-		FlowInstantiationContext previousContext = activeContext;
-		TraversalState previousState = activeState;
-		boolean standalone = activeContext == null;
+		EndToEndFlowSession previousSession = activeSession;
+		boolean standalone = activeSession == null;
 		if (standalone) {
-			activeContext = new FlowInstantiationContext(ci);
-		} else if (activeContext.owner != ci) {
+			activeSession = new EndToEndFlowSession(host, ci);
+		} else if (activeSession.owner() != ci) {
 			// EndToEndFlow is not a FlowElement, so a nested ETE segment can only be expanded at its declaration's level.
 			throw new IllegalStateException("End-to-end flow expansion crossed component contexts");
 		}
 
 		try {
-			FlowExpansion expansion = expandEndToEndFlow(activeContext, ci, ete);
-			updateCompatibilityInfo(expansion, ete2info);
-			if (standalone && !activeContext.canceled && !monitor.isCanceled()) {
-				commit(activeContext);
+			EndToEndFlowSession session = activeSession;
+			session.expand(ete);
+			if (ete2info != null) {
+				ete2info.put(ete, session.compatibilityInfo(ete));
+			}
+			if (standalone && !session.isCanceled() && !monitor.isCanceled()) {
+				session.commit();
 			}
 		} finally {
 			if (standalone) {
-				activeContext = previousContext;
-				activeState = previousState;
+				activeSession = previousSession;
 			}
 		}
-	}
-
-	private FlowExpansion expandEndToEndFlow(FlowInstantiationContext context, ComponentInstance ci,
-			EndToEndFlow ete) {
-		FlowExpansion existing = context.expansions.get(ete);
-		if (existing != null) {
-			return existing;
-		}
-
-		FlowExpansion expansion = new FlowExpansion(ete);
-		context.expansions.put(ete, expansion);
-		context.expansionOrder.add(expansion);
-		context.activeDeclarations.add(ete);
-
-		EndToEndFlowInstance etei = InstanceFactory.eINSTANCE.createEndToEndFlowInstance();
-		etei.setName(ete.getName());
-		etei.setEndToEndFlow(ete);
-		FlowCandidate candidate = createCandidate(context, expansion, etei, new ArrayList<>());
-		TraversalState previousState = activeState;
-		activeState = new TraversalState(candidate);
-		etei.getModesList().add(getModeInstances(ci, ete));
-		try {
-			processETE(ci, etei, ete);
-		} finally {
-			context.activeDeclarations.removeLast();
-			if (monitor.isCanceled()) {
-				context.canceled = true;
-			}
-			if (expansion.status == ExpansionStatus.FAILED) {
-				for (FlowCandidate createdCandidate : expansion.candidates) {
-					createdCandidate.status = CandidateStatus.FAILED;
-				}
-			} else {
-				for (FlowCandidate createdCandidate : expansion.candidates) {
-					if (createdCandidate.status == CandidateStatus.ACTIVE) {
-						createdCandidate.status = createdCandidate.instance.getFlowElements().isEmpty()
-								? CandidateStatus.FAILED
-								: CandidateStatus.COMPLETE;
-					}
-				}
-				expansion.status = ExpansionStatus.COMPLETE;
-			}
-			activeState = previousState;
-		}
-		return expansion;
-	}
-
-	private FlowCandidate createCandidate(FlowInstantiationContext context, FlowExpansion expansion,
-			EndToEndFlowInstance instance, List<Connection> preConnections) {
-		FlowCandidate candidate = new FlowCandidate(context.owner, expansion, instance, preConnections,
-				context.nextCandidateSequence++);
-		expansion.candidates.add(candidate);
-		context.candidates.add(candidate);
-		context.candidatesByInstance.put(instance, candidate);
-		return candidate;
-	}
-
-	/**
-	 * Fork the active path before processing another alternative. Both the detached instance and every mutable traversal
-	 * structure must be copied so subsequent alternatives cannot modify one another.
-	 */
-	private TraversalState forkState(TraversalState source) {
-		EndToEndFlowInstance instance = EcoreUtil.copy(source.candidate.instance);
-		// Preserve accumulated mode constraints, which are not part of the copied flow-element containment tree.
-		instance.getModesList().addAll(source.candidate.instance.getModesList());
-		List<Connection> preConnections = source.candidate.instance.getFlowElements().isEmpty()
-				? new ArrayList<>()
-				: new ArrayList<>(source.candidate.preConnections);
-		FlowCandidate candidate = createCandidate(activeContext, source.candidate.expansion, instance, preConnections);
-		return source.copy(candidate);
-	}
-
-	private void updateCompatibilityInfo(FlowExpansion expansion, HashMap<EndToEndFlow, List<ETEInfo>> ete2info) {
-		if (ete2info == null) {
-			return;
-		}
-		List<ETEInfo> infos = new ArrayList<>();
-		for (FlowCandidate candidate : expansion.candidates) {
-			ETEInfo info = new ETEInfo(candidate.preConnections, candidate.instance);
-			info.postConns = candidate.postConnections;
-			infos.add(info);
-		}
-		ete2info.put(expansion.declaration, infos);
-	}
-
-	private FlowCandidate getCandidate(EndToEndFlowInstance etei) {
-		if (activeContext == null) {
-			throw new IllegalStateException("No active end-to-end flow instantiation context");
-		}
-		FlowCandidate candidate = activeContext.candidatesByInstance.get(etei);
-		if (candidate == null) {
-			throw new IllegalStateException("End-to-end flow instance is not part of the active context");
-		}
-		return candidate;
-	}
-
-	private TraversalState getState(EndToEndFlowInstance etei) {
-		FlowCandidate candidate = getCandidate(etei);
-		if (activeState == null || activeState.candidate != candidate) {
-			throw new IllegalStateException("End-to-end flow branch is not active");
-		}
-		return activeState;
-	}
-
-	private void reportOwnerError(FlowCandidate candidate, String message) {
-		activeContext.diagnostics.add(new PendingDiagnostic(activeContext.nextDiagnosticSequence++,
-				DiagnosticTarget.OWNER, candidate, null, message));
-	}
-
-	private void reportCandidateError(FlowCandidate candidate, String message) {
-		activeContext.diagnostics.add(new PendingDiagnostic(activeContext.nextDiagnosticSequence++,
-				DiagnosticTarget.CANDIDATE, candidate, null, message));
-	}
-
-	private void reportExistingElementError(FlowCandidate candidate, Element element, String message) {
-		activeContext.diagnostics.add(new PendingDiagnostic(activeContext.nextDiagnosticSequence++,
-				DiagnosticTarget.EXISTING_ELEMENT, candidate, element, message));
-	}
-
-	private String getProspectivePath(FlowCandidate candidate) {
-		return candidate.owner.getInstanceObjectPath() + "." + candidate.instance.getName();
-	}
-
-	private void failCandidate(FlowCandidate candidate) {
-		if (candidate.status == CandidateStatus.ACTIVE) {
-			candidate.status = CandidateStatus.FAILED;
-		}
-	}
-
-	private void abortCandidate(FlowCandidate candidate) {
-		candidate.status = CandidateStatus.ABORTED;
-	}
-
-	/**
-	 * Publish all completed candidates for a component. Candidate names are assigned deterministically, nested
-	 * references are checked before attachment, and modes are finalized with nested flows before their parents. If mode
-	 * finalization fails, attachment and transient mode state are rolled back before the exception is propagated.
-	 * Diagnostics are emitted only after a successful commit. Diagnostics for completed candidates target the attached
-	 * flow instance; diagnostics for discarded candidates target the owning component instance.
-	 */
-	private void commit(FlowInstantiationContext context) {
-		if (context.canceled || monitor.isCanceled()) {
-			return;
-		}
-		if (!context.owner.getEndToEndFlows().equals(context.initialFlows)) {
-			throw new IllegalStateException("End-to-end flow list changed during candidate discovery");
-		}
-
-		for (FlowExpansion expansion : context.expansionOrder) {
-			List<FlowCandidate> successful = expansion.candidates.stream()
-					.filter(candidate -> candidate.status == CandidateStatus.COMPLETE)
-					.sorted(Comparator.comparingLong(candidate -> candidate.sequence))
-					.toList();
-			if (successful.size() == 1) {
-				successful.get(0).instance.setName(expansion.declaration.getName());
-			} else if (successful.size() > 1) {
-				resetETECloneCount();
-				for (FlowCandidate candidate : successful) {
-					setCloneName(candidate.instance);
-				}
-			}
-		}
-
-		List<FlowCandidate> successful = context.candidates.stream()
-				.filter(candidate -> candidate.status == CandidateStatus.COMPLETE)
-				.sorted(Comparator.comparingLong(candidate -> candidate.sequence))
-				.toList();
-		for (FlowCandidate candidate : successful) {
-			for (FlowElementInstance element : candidate.instance.getFlowElements()) {
-				if (element instanceof EndToEndFlowInstance nested) {
-					FlowCandidate nestedCandidate = context.candidatesByInstance.get(nested);
-					if (nestedCandidate == null || nestedCandidate.status != CandidateStatus.COMPLETE) {
-						throw new IllegalStateException("Candidate references an unavailable end-to-end flow");
-					}
-				}
-			}
-		}
-
-		List<EndToEndFlowInstance> instances = successful.stream().map(candidate -> candidate.instance).toList();
-		Map<FlowCandidate, List<EList<ModeInstance>>> modeSnapshots = new IdentityHashMap<>();
-		Map<FlowCandidate, List<SystemOperationMode>> somSnapshots = new IdentityHashMap<>();
-		for (FlowCandidate candidate : successful) {
-			modeSnapshots.put(candidate, new ArrayList<>(candidate.instance.getModesList()));
-			somSnapshots.put(candidate, new ArrayList<>(candidate.instance.getInSystemOperationModes()));
-		}
-
-		context.owner.getEndToEndFlows().addAll(instances);
-		try {
-			Map<FlowCandidate, Boolean> finalized = new IdentityHashMap<>();
-			Map<FlowCandidate, Boolean> finalizing = new IdentityHashMap<>();
-			for (FlowCandidate candidate : successful) {
-				finalizeModes(context, candidate, finalized, finalizing);
-			}
-		} catch (RuntimeException | Error exception) {
-			context.owner.getEndToEndFlows().removeAll(instances);
-			for (FlowCandidate candidate : successful) {
-				candidate.instance.getModesList().clear();
-				candidate.instance.getModesList().addAll(modeSnapshots.get(candidate));
-				candidate.instance.getInSystemOperationModes().clear();
-				candidate.instance.getInSystemOperationModes().addAll(somSnapshots.get(candidate));
-			}
-			throw exception;
-		}
-
-		for (PendingDiagnostic diagnostic : context.diagnostics.stream()
-				.sorted(Comparator.comparingLong(PendingDiagnostic::sequence))
-				.toList()) {
-			switch (diagnostic.target()) {
-			case OWNER -> error(diagnostic.candidate().owner, diagnostic.message());
-			case CANDIDATE -> {
-				if (diagnostic.candidate().status == CandidateStatus.COMPLETE) {
-					error(diagnostic.candidate().instance, diagnostic.message());
-				} else {
-					error(diagnostic.candidate().owner,
-							diagnostic.candidate().instance.getName() + " could not be instantiated: "
-									+ diagnostic.message());
-				}
-			}
-			case EXISTING_ELEMENT -> error(diagnostic.existingElement(), diagnostic.message());
-			}
-		}
-	}
-
-	/**
-	 * Finalize a candidate's system operation modes after finalizing any nested candidates it references.
-	 */
-	private void finalizeModes(FlowInstantiationContext context, FlowCandidate candidate,
-			Map<FlowCandidate, Boolean> finalized, Map<FlowCandidate, Boolean> finalizing) {
-		if (finalized.containsKey(candidate)) {
-			return;
-		}
-		if (finalizing.put(candidate, Boolean.TRUE) != null) {
-			throw new IllegalStateException("Cyclic committed end-to-end flow graph");
-		}
-		for (FlowElementInstance element : candidate.instance.getFlowElements()) {
-			if (element instanceof EndToEndFlowInstance nested) {
-				FlowCandidate nestedCandidate = context.candidatesByInstance.get(nested);
-				if (nestedCandidate != null && nestedCandidate.status == CandidateStatus.COMPLETE) {
-					finalizeModes(context, nestedCandidate, finalized, finalizing);
-				}
-			}
-		}
-		fillinModes(candidate.instance);
-		candidate.instance.getModesList().clear();
-		finalizing.remove(candidate);
-		finalized.put(candidate, Boolean.TRUE);
 	}
 
 	protected void processETE(final ComponentInstance ci, final EndToEndFlowInstance etei, final EndToEndFlow ete) {
-		FlowIterator iter = new FlowIterator(ete);
-		EndToEndFlowSegment fe = (EndToEndFlowSegment) iter.next();
-
-		processETESegment(ci, etei, fe, iter, ete);
+		session().processETE(ci, etei, ete);
 	}
 
 	/**
@@ -635,45 +225,7 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 	 */
 	protected void processETESegment(ComponentInstance ci, EndToEndFlowInstance etei, Element fs, FlowIterator iter,
 			NamedElement errorElement) {
-		TraversalState traversal = getState(etei);
-		FlowCandidate candidate = traversal.candidate;
-		Element fe = switch (fs) {
-		case FlowSegment segment -> segment.getFlowElement();
-		case EndToEndFlowSegment segment -> segment.getFlowElement();
-		default -> throw new IllegalArgumentException("Unsupported flow segment " + fs.eClass().getName());
-		};
-
-		if (fe instanceof Connection connection) {
-			if (etei.getFlowElements().isEmpty()) {
-				candidate.preConnections.add(connection);
-			} else {
-				traversal.connections.add(connection);
-			}
-		} else if (fe instanceof FlowSpecification flowSpecification) {
-			Subcomponent sc = (Subcomponent) switch (fs) {
-			case FlowSegment segment -> segment.getContext();
-			case EndToEndFlowSegment segment -> segment.getContext();
-			default -> throw new IllegalArgumentException("Unsupported flow segment " + fs.eClass().getName());
-			};
-			ComponentInstance sci = ci.findSubcomponentInstance(sc);
-			if (sci != null) {
-				processSubcomponentFlow(sci, etei, flowSpecification, iter);
-			} else {
-				reportOwnerError(candidate,
-						"Incomplete End-to-end flow instance " + etei.getName()
-								+ ": Could not find component instance for subcomponent " + sc.getName()
-								+ " in flow implementation " + errorElement.getName());
-			}
-		} else if (fe instanceof Subcomponent subcomponent) {
-			ComponentInstance sci = ci.findSubcomponentInstance(subcomponent);
-			processFlowStep(sci, etei, fe, iter);
-		} else if (fe instanceof DataAccess dataAccess) {
-			processAccess(ci, etei, dataAccess, iter);
-		} else if (fe instanceof SubprogramAccess subprogramAccess) {
-			processAccess(ci, etei, subprogramAccess, iter);
-		} else if (fe instanceof EndToEndFlow endToEndFlow) {
-			processEndToEndFlow(ci, etei, endToEndFlow, iter);
-		}
+		session().processETESegment(ci, etei, fs, iter, errorElement);
 	}
 
 	/**
@@ -687,70 +239,7 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 	 */
 	protected void processSubcomponentFlow(final ComponentInstance ci, EndToEndFlowInstance etei,
 			final FlowSpecification fs, FlowIterator iter) {
-		FlowCandidate candidate = getCandidate(etei);
-		final ComponentImplementation subImpl = InstanceUtil.getComponentImplementation(ci, 0, classifierCache);
-		final EList<FlowImplementation> flowImpls = new BasicEList<>(10);
-
-		// Collect flow impls for this flow spec
-		if (subImpl != null) {
-			for (FlowImplementation fl : subImpl.getAllFlowImplementations()) {
-				if (fl.getSpecification().getName().equalsIgnoreCase(fs.getName())) {
-					flowImpls.add(fl);
-				}
-			}
-		}
-
-		if (flowImpls.isEmpty()) {
-			// we are at a leaf
-			int errorsBefore = activeContext.diagnostics.size();
-			processFlowStep(ci, etei, fs, iter);
-			if (subImpl != null && AadlUtil.hasPortComponents(subImpl)
-					&& activeContext.diagnostics.size() == errorsBefore) {
-				reportOwnerError(candidate, "Cannot create end to end flow '" + etei.getName()
-						+ "' because component '" + ci.getName()
-						+ "' has subcomponents but no flow implementation for flow '" + fs.getName() + "'");
-			}
-		} else {
-			Iterator<FlowImplementation> itt = flowImpls.iterator();
-
-			getState(etei).continuations.push(iter);
-			while (itt.hasNext()) {
-				TraversalState stateClone = null;
-				FlowIterator iterClone = null;
-				FlowImplementation flowImpl = itt.next();
-				boolean prepareNext = itt.hasNext();
-
-				if (prepareNext) {
-					stateClone = forkState(getState(etei));
-					iterClone = iter.copy();
-				}
-
-				/*
-				 * Issue 1953: Treat a thread flow implementation with owned segments as an atomic flow specification
-				 * instead of expanding its internal path, which prevents unnecessary instance-model combinations. An
-				 * empty implementation still follows the normal path because it may refine a feature-group endpoint to
-				 * one of its features.
-				 *
-				 * The flow implementation still contributes mode constraints even though its segments are ignored.
-				 */
-				if (subImpl instanceof ThreadClassifier && !flowImpl.getOwnedFlowSegments().isEmpty()) {
-					etei.getModesList().add(getModeInstances(ci, flowImpl));
-					getState(etei).continuations.pop();
-
-					processFlowStep(ci, etei, fs, iter);
-				} else {
-					if (!processFlowImpl(ci, etei, flowImpl)) {
-						processFlowStep(ci, etei, fs, flowImpl, iter);
-					}
-				}
-
-				if (prepareNext) {
-					activeState = stateClone;
-					etei = stateClone.candidate.instance;
-					iter = iterClone;
-				}
-			}
-		}
+		session().processSubcomponentFlow(ci, etei, fs, iter);
 	}
 
 	/**
@@ -763,16 +252,7 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 	 * @return whether traversal entered the flow implementation; false if it has fewer than two segments
 	 */
 	protected boolean processFlowImpl(ComponentInstance ci, EndToEndFlowInstance etei, FlowImplementation flowImpl) {
-		etei.getModesList().add(getModeInstances(ci, flowImpl));
-
-		if (flowImpl.getOwnedFlowSegments().size() < 2) {
-			// the flow impl doesn't include a subcomponent, nothing to do
-			getState(etei).continuations.pop();
-			return false;
-		}
-
-		continueFlow(ci, etei, new FlowIterator(flowImpl), ci);
-		return true;
+		return session().processFlowImpl(ci, etei, flowImpl);
 	}
 
 	/**
@@ -793,723 +273,7 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 	 */
 	protected void processFlowStep(ComponentInstance ci, EndToEndFlowInstance etei, Element leaf,
 			FlowImplementation nextFlowImpl, FlowIterator iter) {
-		TraversalState traversal = getState(etei);
-		FlowCandidate candidate = traversal.candidate;
-		// add connection(s), will be empty when starting the ETE
-		if (traversal.connections.isEmpty()) {
-			if (!addLeafElement(ci, etei, leaf)) {
-				abortCandidate(candidate);
-				return;
-			}
-			traversal.flowImplementations.add(nextFlowImpl);
-			continueFlow(ci.getContainingComponentInstance(), etei, iter, ci);
-			traversal.flowImplementations.removeLast();
-		} else {
-			List<ConnectionInstance> connis = collectConnectionInstances(ci, etei, traversal.connections);
-
-			if (connis.isEmpty()) {
-				traversal.connections.clear();
-				failCandidate(candidate);
-
-				if (!traversal.flowImplementations.isEmpty()) {
-					FlowImplementation flowFilter = traversal.flowImplementations.getLast();
-					if (flowFilter != null) {
-						// A semantic connection was expected after the preceding flow implementation.
-						reportOwnerError(candidate,
-								"Cannot create end to end flow '" + etei.getName()
-										+ "' because there are no semantic connections that continue the flow '"
-										+ flowFilter.getSpecification().getName() + "' from feature '"
-										+ flowFilter.getOutEnd().getFeature().getName() + "'");
-					}
-				}
-			} else {
-				FlowImplementation flowFilter = traversal.flowImplementations.isEmpty()
-						? null
-						: traversal.flowImplementations.getLast();
-
-				/*
-				 * Issue 1984: isValidContinuation() is a filter, not an error reporter. Determine the applicable
-				 * connections first and report an error only when none of the candidates can continue this flow.
-				 */
-				final List<ConnectionInstance> connectionsToUse = new ArrayList<>();
-				for (final ConnectionInstance ciToCheck : connis) {
-					if ((flowFilter == null || isValidContinuation(flowFilter, ciToCheck))
-							&& (nextFlowImpl == null
-									? (leaf instanceof FlowSpecification flowSpecification
-											? isValidContinuation(ci, ciToCheck, flowSpecification)
-											: true)
-									: isValidContinuation(ciToCheck, nextFlowImpl))) {
-						connectionsToUse.add(ciToCheck);
-					}
-				}
-
-				if (connectionsToUse.isEmpty()) {
-					/*
-					 * Connections may bypass the start of the selected flow implementation: the declarative flow and the
-					 * actual component connections then describe different paths.
-					 */
-					if (flowFilter == null && nextFlowImpl == null) {
-						final FlowSpecification flowSpec = (FlowSpecification) leaf;
-						reportOwnerError(candidate, "Cannot create end to end flow '" + etei.getName()
-								+ "' because there are no semantic connections that connect to the start of the flow '"
-								+ flowSpec.getName() + "' at feature '" + flowSpec.getAllInEnd().getFeature().getName()
-								+ "'");
-					} else {
-						final FlowImplementation ff = flowFilter == null ? nextFlowImpl : flowFilter;
-						reportOwnerError(candidate, "Cannot create end to end flow '" + etei.getName()
-								+ "' because there are no semantic connections that connect to the start of the flow '"
-								+ ff.getSpecification().getName() + "' at feature '"
-								+ ff.getInEnd().getFeature().getName() + "'");
-					}
-					traversal.connections.clear();
-					failCandidate(candidate);
-				} else {
-					// continue the flow along each eligible connection instance
-					Iterator<ConnectionInstance> connIter = connectionsToUse.iterator();
-					while (connIter.hasNext()) {
-						final ConnectionInstance conni = connIter.next();
-						final boolean prepareNext = connIter.hasNext();
-						TraversalState branchState = getState(etei);
-						TraversalState stateClone = null;
-						FlowIterator iterClone = null;
-
-						if (prepareNext) {
-							stateClone = forkState(branchState);
-							iterClone = iter.copy();
-						}
-
-						branchState.flowImplementations.add(nextFlowImpl);
-						etei.getFlowElements().add(conni);
-						if (addLeafElement(ci, etei, leaf)) {
-							// prepare next connection filter
-							branchState.connections.clear();
-							if (iter.hasNext()) {
-								Connection conn = getConnection(iter.next());
-								if (conn != null) {
-									branchState.connections.add(conn);
-								}
-							}
-
-							continueFlow(ci.getContainingComponentInstance(), etei, iter, ci);
-						} else {
-							branchState.connections.clear();
-							abortCandidate(getCandidate(etei));
-						}
-
-						branchState.flowImplementations.removeLast();
-
-						if (prepareNext) {
-							activeState = stateClone;
-							etei = stateClone.candidate.instance;
-							iter = iterClone;
-						}
-					}
-				}
-			}
-		}
-	}
-
-	/**
-	 * Check whether a connection instance ends at the input feature of a flow implementation.
-	 *
-	 * @param conni the connection instance
-	 * @param fimpl the flow implementation that must follow the connection
-	 * @return whether the connection destination is the flow input
-	 */
-	boolean isValidContinuation(ConnectionInstance conni, FlowImplementation fimpl) {
-		boolean result = false;
-		ConnectionInstanceEnd dst = conni.getDestination();
-		if (dst instanceof FeatureInstance featureInstance) {
-			Feature flowIn = fimpl.getInEnd().getFeature();
-			Feature connDst = featureInstance.getFeature();
-			result = flowIn == connDst;
-		}
-		return result;
-	}
-
-	/**
-	 * Check whether a connection instance ends at a flow specification's source feature. A connection to the source
-	 * feature itself or to a feature nested within it is accepted by walking up the feature-instance containment chain.
-	 *
-	 * @param flowComponent the component that owns the flow specification instance
-	 * @param conni the connection instance
-	 * @param fspec the flow specification that must follow the connection
-	 * @return whether the connection destination reaches the flow source
-	 */
-	boolean isValidContinuation(ComponentInstance flowComponent, ConnectionInstance conni, FlowSpecification fspec) {
-		ConnectionInstanceEnd cie = conni.getDestination();
-		if (cie instanceof FeatureInstance conniFi) {
-			FlowSpecificationInstance fsi = flowComponent.findFlowSpecInstance(fspec);
-			if (fsi != null) {
-				FeatureInstance fsSrcFi = fsi.getSource();
-				EObject e = conniFi;
-				while (e instanceof FeatureInstance fi) {
-					if (fi == fsSrcFi) {
-						return true;
-					}
-					e = fi.eContainer();
-				}
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * Check whether a connection instance starts at the output feature of a flow implementation.
-	 *
-	 * @param fimpl the flow implementation that must precede the connection
-	 * @param conni the connection instance
-	 * @return whether the connection source is the flow output
-	 */
-	boolean isValidContinuation(FlowImplementation fimpl, ConnectionInstance conni) {
-		boolean result = false;
-		ConnectionInstanceEnd src = conni.getSource();
-		if (src instanceof FeatureInstance featureInstance) {
-			Feature flowOut = fimpl.getOutEnd().getFeature();
-			Feature connSrc = featureInstance.getFeature();
-			result = flowOut == connSrc;
-		}
-		return result;
-	}
-
-	/**
-	 * Continue through a data or subprogram access. The accessed component instance, rather than the access feature, is
-	 * added as the flow element. Multiple matching access connections create independent candidates.
-	 *
-	 * @param ci the component containing the access
-	 * @param etei the current end-to-end flow candidate
-	 * @param a the data or subprogram access
-	 * @param iter the continuation in the enclosing flow declaration
-	 */
-	private void processAccess(ComponentInstance ci, EndToEndFlowInstance etei, Access a, FlowIterator iter) {
-		TraversalState traversal = getState(etei);
-		FlowCandidate candidate = traversal.candidate;
-		// add connection(s), will be empty when starting the ETE
-		if (traversal.connections.isEmpty()) {
-			addLeafElement(ci, etei, a);
-			continueFlow(ci.getContainingComponentInstance(), etei, iter, ci);
-		} else {
-			List<ConnectionInstance> connis = collectConnectionInstances(ci, etei, traversal.connections);
-
-			if (connis.isEmpty()) {
-				reportCandidateError(candidate, "Incomplete end-to-end flow instance " + etei.getName()
-						+ ": Missing connection instance to " + a.getName());
-				traversal.connections.clear();
-			} else {
-				record AccessMatch(ConnectionInstance connection, ComponentInstance target,
-						EndToEndFlowElement leaf) {
-				}
-				List<AccessMatch> matches = new ArrayList<>();
-				boolean invalidTarget = false;
-				for (ConnectionInstance conni : connis) {
-					if (conni.getDestination() instanceof ComponentInstance target
-							&& (target.getCategory() == ComponentCategory.DATA
-									|| target.getCategory() == ComponentCategory.SUBPROGRAM)) {
-						matches.add(new AccessMatch(conni, target, target.getSubcomponent()));
-					} else {
-						invalidTarget = true;
-					}
-				}
-
-				if (invalidTarget) {
-					reportCandidateError(candidate, "Access feature " + a.getQualifiedName()
-							+ " is not a proxy for a data or subprogram component.");
-				}
-				if (matches.isEmpty()) {
-					traversal.connections.clear();
-					failCandidate(candidate);
-					return;
-				}
-
-				Iterator<AccessMatch> matchIter = matches.iterator();
-				traversal.continuations.push(iter);
-				while (matchIter.hasNext()) {
-					TraversalState branchState = getState(etei);
-					TraversalState stateClone = null;
-					AccessMatch match = matchIter.next();
-					boolean prepareNext = matchIter.hasNext();
-
-					if (prepareNext) {
-						stateClone = forkState(branchState);
-						etei.setName(etei.getEndToEndFlow().getName());
-					}
-					FlowIterator continuation = branchState.continuations.pop();
-
-					etei.getFlowElements().add(match.connection());
-					addLeafElement(match.target(), etei, match.leaf());
-
-					// prepare next connection filter
-					Connection lastConn = branchState.connections.getLast();
-					branchState.connections.clear();
-					if (continuation.hasNext()) {
-						Connection nextConn = getConnection(continuation.next());
-						if (nextConn != null) {
-							int i = match.connection().getConnectionReferences().size() - 1;
-							Connection preConn = null;
-
-							while (i > 0 && preConn != lastConn) {
-								preConn = match.connection().getConnectionReferences().get(i--).getConnection();
-								if (preConn != lastConn) {
-									branchState.connections.add(preConn);
-								}
-							}
-							branchState.connections.add(nextConn);
-						}
-					}
-
-					continueFlow(ci, etei, continuation, ci);
-
-					if (prepareNext) {
-						activeState = stateClone;
-						etei = stateClone.candidate.instance;
-					}
-				}
-			}
-		}
-	}
-
-	/**
-	 * Continue through a nested end-to-end flow. The nested declaration is expanded once per component context, and the
-	 * parent candidate is forked for every nested candidate whose leading connection path is compatible.
-	 */
-	private void processEndToEndFlow(ComponentInstance ci, EndToEndFlowInstance etei, EndToEndFlow ete,
-			FlowIterator iter) {
-		TraversalState traversal = getState(etei);
-		FlowCandidate candidate = traversal.candidate;
-
-		int cycleStart = activeContext.activeDeclarations.indexOf(ete);
-		if (cycleStart >= 0) {
-			for (int i = cycleStart; i < activeContext.activeDeclarations.size(); i++) {
-				FlowExpansion failedExpansion = activeContext.expansions.get(activeContext.activeDeclarations.get(i));
-				failedExpansion.status = ExpansionStatus.FAILED;
-				for (FlowCandidate failedCandidate : failedExpansion.candidates) {
-					failedCandidate.status = CandidateStatus.FAILED;
-				}
-			}
-			reportCandidateError(candidate,
-					"Cyclic dependency between end to end flows involving " + ete.getQualifiedName());
-			traversal.connections.clear();
-			return;
-		}
-
-		// instantiate the nested ete if that hasn't been done already
-		if (!activeContext.expansions.containsKey(ete)) {
-			instantiateEndToEndFlow(ci, ete, null);
-		}
-		FlowExpansion nestedExpansion = activeContext.expansions.get(ete);
-		if (nestedExpansion.status == ExpansionStatus.FAILED) {
-			candidate.expansion.status = ExpansionStatus.FAILED;
-			for (FlowCandidate failedCandidate : candidate.expansion.candidates) {
-				failedCandidate.status = CandidateStatus.FAILED;
-			}
-			traversal.connections.clear();
-			return;
-		}
-		List<FlowCandidate> nestedETEs = nestedExpansion.candidates.stream()
-				.filter(nested -> nested.status == CandidateStatus.COMPLETE)
-				.toList();
-
-		if (nestedETEs.isEmpty()) {
-			reportCandidateError(candidate, "No nested end to end flows instantiated for " + ete.getQualifiedName());
-			traversal.connections.clear();
-			return;
-		}
-		// add connection(s), will be empty when starting the ETE
-		if (traversal.connections.isEmpty()) {
-			TraversalState stateClone = null;
-			Iterator<FlowCandidate> nestedIter = nestedETEs.iterator();
-
-			traversal.continuations.push(iter);
-			while (nestedIter.hasNext()) {
-				FlowCandidate nested = nestedIter.next();
-				boolean prepareNext = nestedIter.hasNext();
-
-				if (prepareNext) {
-					stateClone = forkState(getState(etei));
-					etei.setName(etei.getEndToEndFlow().getName());
-				}
-				TraversalState branchState = getState(etei);
-				FlowIterator continuation = branchState.continuations.pop();
-
-				etei.getFlowElements().add(nested.instance);
-
-				// prepare next connection filter
-				branchState.connections.clear();
-				branchState.connections.addAll(nested.postConnections);
-				if (continuation.hasNext()) {
-					Connection conn = getConnection(continuation.next());
-					if (conn != null) {
-						branchState.connections.add(conn);
-					}
-				}
-
-				continueFlow(ci, etei, continuation, ci);
-
-				if (prepareNext) {
-					activeState = stateClone;
-					etei = stateClone.candidate.instance;
-				}
-			}
-		} else {
-			List<ConnectionInstance> connis = collectConnectionInstances(ci, etei, traversal.connections);
-
-			if (connis.isEmpty()) {
-				reportCandidateError(candidate, "Incomplete end-to-end flow instance " + etei.getName()
-						+ ": Missing connection instance to " + ete.getName());
-				traversal.connections.clear();
-			} else {
-				record NestedMatch(ConnectionInstance connection, FlowCandidate nested) {
-				}
-				List<NestedMatch> matches = new ArrayList<>();
-				for (ConnectionInstance conni : connis) {
-					for (FlowCandidate nested : nestedETEs) {
-						if (isCompatibleNestedConnection(conni, nested)) {
-							matches.add(new NestedMatch(conni, nested));
-						}
-					}
-				}
-				if (matches.isEmpty()) {
-					reportCandidateError(candidate, "Incomplete end-to-end flow instance " + etei.getName()
-							+ ": No compatible nested end to end flow instance for " + ete.getName());
-					traversal.connections.clear();
-					return;
-				}
-
-				Iterator<NestedMatch> matchIter = matches.iterator();
-				traversal.continuations.push(iter);
-				while (matchIter.hasNext()) {
-					TraversalState stateClone = null;
-					NestedMatch match = matchIter.next();
-					boolean prepareNext = matchIter.hasNext();
-
-					if (prepareNext) {
-						stateClone = forkState(getState(etei));
-						etei.setName(etei.getEndToEndFlow().getName());
-					}
-					TraversalState branchState = getState(etei);
-					FlowIterator continuation = branchState.continuations.pop();
-
-					// Preserve path order: the incoming connection precedes the nested flow.
-					etei.getFlowElements().add(match.connection());
-					etei.getFlowElements().add(match.nested().instance);
-
-					// prepare next connection filter
-					branchState.connections.clear();
-					branchState.connections.addAll(match.nested().postConnections);
-					if (continuation.hasNext()) {
-						Connection nextConnection = getConnection(continuation.next());
-						if (nextConnection != null) {
-							branchState.connections.add(nextConnection);
-						}
-					}
-
-					continueFlow(ci, etei, continuation, ci);
-
-					if (prepareNext) {
-						activeState = stateClone;
-						etei = stateClone.candidate.instance;
-					}
-				}
-			}
-		}
-	}
-
-	/**
-	 * Check whether an incoming connection reaches the start of a nested end-to-end flow candidate.
-	 */
-	private boolean isCompatibleNestedConnection(ConnectionInstance connection, FlowCandidate nested) {
-		if (!containsConnectionPath(connection, nested.preConnections)) {
-			return false;
-		}
-
-		ConnectionInstanceEnd destination = connection.getDestination();
-		ConnectionInstanceEnd nestedStart = getFirstConnectionEnd(nested.instance);
-		if (destination instanceof FeatureInstance destinationFeature
-				&& nestedStart instanceof FeatureInstance nestedFeature) {
-			return isSameorContains(nestedFeature, destinationFeature);
-		}
-		if (nestedStart instanceof ComponentInstance nestedComponent) {
-			return destination == nestedComponent || destination.getComponentInstance() == nestedComponent;
-		}
-		return destination == nestedStart;
-	}
-
-	/**
-	 * Check whether a connection instance contains a declarative connection path as a contiguous sequence.
-	 */
-	private static boolean containsConnectionPath(ConnectionInstance connectionInstance,
-			List<Connection> connectionPath) {
-		if (connectionPath.isEmpty()) {
-			return true;
-		}
-
-		EList<ConnectionReference> references = connectionInstance.getConnectionReferences();
-		for (int start = 0; start <= references.size() - connectionPath.size(); start++) {
-			boolean match = true;
-			for (int offset = 0; match && offset < connectionPath.size(); offset++) {
-				match = references.get(start + offset).getConnection() == connectionPath.get(offset);
-			}
-			if (match) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	private ConnectionInstanceEnd getFirstConnectionEnd(EndToEndFlowInstance etei) {
-		EList<FlowElementInstance> elements = etei.getFlowElements();
-		if (elements.isEmpty()) {
-			return null;
-		}
-
-		return switch (elements.getFirst()) {
-		case EndToEndFlowInstance nested -> getFirstConnectionEnd(nested);
-		case FlowSpecificationInstance flowSpecification -> flowSpecification.getSource();
-		case ConnectionInstance connection -> connection.getSource();
-		case ComponentInstance component -> component;
-		case null, default -> null;
-		};
-	}
-
-	/**
-	 * Add the concrete instance object represented by a declarative leaf.
-	 *
-	 * @param ci the component instance containing the leaf
-	 * @param etei the candidate receiving the leaf
-	 * @param leaf a flow specification, flow implementation, or subcomponent
-	 * @return whether the leaf was added successfully
-	 */
-	private boolean addLeafElement(ComponentInstance ci, EndToEndFlowInstance etei, Element leaf) {
-		FlowCandidate candidate = getCandidate(etei);
-		FlowSpecification fs = switch (leaf) {
-		case FlowImplementation flowImplementation -> flowImplementation.getSpecification();
-		case FlowSpecification flowSpecification -> flowSpecification;
-		default -> null;
-		};
-		if (fs != null) {
-			// append a flow specification instance
-			FlowSpecificationInstance fsi = ci.findFlowSpecInstance(fs);
-			if (fsi != null) {
-				etei.getFlowElements().add(fsi);
-			} else {
-				reportOwnerError(candidate, "Incomplete end-to-end flow instance " + etei.getName()
-						+ ": Could not find flow spec " + fs.getName() + " of component " + ci.getName());
-				return false;
-			}
-		} else if (leaf instanceof Subcomponent) {
-			if (etei.getFlowElements().isEmpty()) {
-				// append a subcomponent instance
-				etei.getFlowElements().add(ci);
-			} else {
-				ConnectionInstance preConn = (ConnectionInstance) etei.getFlowElements().getLast();
-				ConnectionInstanceEnd end = preConn.getDestination();
-				ComponentInstance comp = end.getContainingComponentInstance();
-				if (end instanceof ComponentInstance || comp == ci) {
-					// append a subcomponent instance
-					etei.getFlowElements().add(ci);
-				} else {
-					reportOwnerError(candidate,
-							"Invalid end-to-end flow instance " + etei.getName() + ": Connection "
-									+ preConn.getComponentInstancePath() + " continues into component "
-									+ ci.getInstanceObjectPath());
-					return false;
-				}
-			}
-		}
-		return true;
-	}
-
-	/**
-	 * Resume traversal until the active candidate completes, aborts, switches to another branch, or reaches the system
-	 * boundary. Exhausted nested continuations move traversal back to the containing component.
-	 */
-	private void continueFlow(ComponentInstance ci, EndToEndFlowInstance etei, FlowIterator iter,
-			NamedElement errorElement) {
-		FlowCandidate candidate = getCandidate(etei);
-		while (true) {
-			if (monitor.isCanceled()) {
-				activeContext.canceled = true;
-				return;
-			}
-			if (candidate.status == CandidateStatus.ABORTED || candidate.status == CandidateStatus.FAILED) {
-				return;
-			}
-			if (activeState == null || activeState.candidate != candidate) {
-				return;
-			}
-			TraversalState traversal = activeState;
-			if (ci == null) {
-				reportExistingElementError(candidate, errorElement,
-						"Flow instance leaves system instance for flow " + getProspectivePath(candidate));
-				traversal.connections.clear();
-				return;
-			}
-			while (iter.hasNext()) {
-				Element e = iter.next();
-				processETESegment(ci, etei, e, iter, errorElement);
-				if (candidate.status == CandidateStatus.ABORTED || candidate.status == CandidateStatus.FAILED
-						|| activeState == null || activeState.candidate != candidate) {
-					return;
-				}
-			}
-			if (candidate.status == CandidateStatus.COMPLETE) {
-				return;
-			}
-			if (traversal.continuations.isEmpty()) {
-				if (candidate.status == CandidateStatus.ACTIVE) {
-					if (candidate.instance.getFlowElements().isEmpty()) {
-						traversal.connections.clear();
-						failCandidate(candidate);
-					} else {
-						candidate.postConnections.addAll(traversal.connections);
-						traversal.connections.clear();
-						candidate.status = CandidateStatus.COMPLETE;
-					}
-				}
-				break;
-			}
-			iter = traversal.continuations.pop();
-			ci = ci.getContainingComponentInstance();
-		}
-	}
-
-	// -------------------------------------------------------------------------
-	// Helper methods
-	// -------------------------------------------------------------------------
-
-	private static Connection getConnection(Element segment) {
-		if (segment instanceof FlowSegment fs) {
-			return fs.getFlowElement() instanceof Connection connection ? connection : null;
-		}
-		if (segment instanceof EndToEndFlowSegment eefs) {
-			return eefs.getFlowElement() instanceof Connection connection ? connection : null;
-		}
-		return null;
-	}
-
-	/**
-	 * Get all enclosing connection instances that pass through the given declarative connection sequence and continue
-	 * from the candidate's current endpoint.
-	 */
-	private List<ConnectionInstance> collectConnectionInstances(ComponentInstance ci, EndToEndFlowInstance etei,
-			List<Connection> connections) {
-		List<ConnectionInstance> result = new ArrayList<>();
-
-		for (ConnectionInstance conni : ci.allEnclosingConnectionInstances()) {
-			if (testConnection(conni, etei, connections)) {
-				result.add(conni);
-			}
-		}
-		return result;
-	}
-
-	/**
-	 * Match a connection instance against a contiguous sequence of declarative connections. Refined connections are
-	 * considered equivalent; single-connection paths are also checked for flow direction; feature-group expansion is
-	 * checked against the candidate's last feature.
-	 *
-	 * @param conni the connection instance to test
-	 * @param etei the candidate whose current endpoint constrains the match
-	 * @param connections the declarative connection sequence
-	 * @return whether the connection instance continues the candidate along the requested sequence
-	 */
-	private boolean testConnection(ConnectionInstance conni, EndToEndFlowInstance etei,
-			List<Connection> connections) {
-		Iterator<ConnectionReference> refIter = conni.getConnectionReferences().iterator();
-		boolean match = false;
-
-		while (refIter.hasNext()) {
-			if (isSameOrRefinedConnection(refIter.next().getConnection(), connections.get(0))) {
-				Iterator<Connection> connIter = connections.iterator();
-
-				connIter.next();
-				match = true;
-				while (match && refIter.hasNext() && connIter.hasNext()) {
-					match &= isSameOrRefinedConnection(refIter.next().getConnection(), connIter.next());
-				}
-				if (!refIter.hasNext() && connIter.hasNext()) {
-					match = false;
-				}
-			}
-		}
-		if (match && connections.size() == 1) {
-			// make sure connection instance goes in the same direction as the flow
-			ComponentInstance connci = conni.getSource().getComponentInstance();
-			FlowElementInstance fei = etei;
-
-			while (fei instanceof EndToEndFlowInstance nested) {
-				fei = nested.getFlowElements().getLast();
-			}
-			if (fei instanceof FlowSpecificationInstance flowSpecification) {
-				fei = flowSpecification.getComponentInstance();
-			}
-			ComponentInstance flowci = (ComponentInstance) fei;
-
-			match = false;
-			ComponentInstance ci = connci;
-			while (!(ci instanceof SystemInstance)) {
-				if (ci == flowci) {
-					match = true;
-					break;
-				}
-				ci = ci.getContainingComponentInstance();
-			}
-		}
-		if (match) {
-			// test if the connection instance is connected to the end of the ete instance
-			// relevant if the flow goes through a port of a feature group and the connection
-			// instance comes from an expanded fg connection
-			ConnectionInstanceEnd src = conni.getSource();
-
-			if (src instanceof FeatureInstance firstFeature) {
-				FeatureInstance lastFeature = getLastFeature(etei);
-				if (lastFeature != null) {
-					match = isSameorContains(lastFeature, firstFeature);
-				}
-			}
-		}
-		return match;
-	}
-
-	private boolean isSameOrRefinedConnection(Connection first, Connection second) {
-		for (Connection connection = first; connection != null; connection = connection.getRefined()) {
-			if (connection == second) {
-				return true;
-			}
-		}
-		for (Connection connection = second; connection != null; connection = connection.getRefined()) {
-			if (connection == first) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	private boolean isSameorContains(FeatureInstance flowFeature, FeatureInstance connFeature) {
-		EObject matchme = connFeature;
-		while (matchme instanceof FeatureInstance featureInstance) {
-			if (featureInstance == flowFeature) {
-				return true;
-			}
-			matchme = featureInstance.eContainer();
-		}
-		return false;
-	}
-
-	private FeatureInstance getLastFeature(EndToEndFlowInstance etei) {
-		EList<FlowElementInstance> feis = etei.getFlowElements();
-		if (feis.isEmpty()) {
-			return null;
-		}
-
-		return switch (feis.getLast()) {
-		case EndToEndFlowInstance nested -> getLastFeature(nested);
-		case FlowSpecificationInstance flowSpecification -> flowSpecification.getDestination();
-		case ConnectionInstance connection -> connection.getDestination() instanceof FeatureInstance featureInstance
-				? featureInstance
-				: null;
-		case null, default -> null;
-		};
+		session().processFlowStep(ci, etei, leaf, nextFlowImpl, iter);
 	}
 
 	// -------------------------------------------------------------------------
@@ -1525,84 +289,96 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 	 * @return list of mode instances
 	 */
 	protected EList<ModeInstance> getModeInstances(ComponentInstance ci, ModalElement e) {
-		EList<ModeInstance> mis = new BasicEList<>();
-		List<Mode> mlist = e.getAllInModes();
-
-		if (!mlist.isEmpty()) {
-			for (Mode m : mlist) {
-				ModeInstance mi = ci.findModeInstance(m);
-
-				if (mi != null) {
-					mis.add(mi);
-				}
-			}
-		} else {
-			// Get modes from the containment hierarchy.
-			while (!(ci instanceof SystemInstance)) {
-				if (ci.getInModes().isEmpty()) {
-					ci = ci.getContainingComponentInstance();
-				} else {
-					mis = ci.getInModes();
-					break;
-				}
-			}
-		}
-		return mis;
+		return EndToEndFlowModes.modeInstances(ci, e);
 	}
 
+	/**
+	 * Compute the system operation modes a committed flow instance is active in and consume its accumulated mode
+	 * constraints.
+	 *
+	 * @param etei the committed flow instance
+	 */
 	protected void fillinModes(EndToEndFlowInstance etei) {
-
-		if (etei.getSystemInstance().getSystemOperationModes().size() <= 1) {
-			return;
-		}
-
-		// first, calculate intersection of all connection and ete instance SOMs
-		EList<FlowElementInstance> feis = etei.getFlowElements();
-		List<SystemOperationMode> soms = new ArrayList<>(etei.getSystemInstance().getSystemOperationModes());
-
-		for (FlowElementInstance fei : feis) {
-			if (fei instanceof ConnectionInstance conni) {
-				if (!conni.getInSystemOperationModes().isEmpty()) {
-					soms.removeIf(som -> !conni.getInSystemOperationModes().contains(som));
-				}
-			} else if (fei instanceof EndToEndFlowInstance efi) {
-				if (!efi.getInSystemOperationModes().isEmpty()) {
-					soms.removeIf(som -> !efi.getInSystemOperationModes().contains(som));
-				}
-			}
-		}
-
-		// then, keep those SOMs where all other flow elements are active
-		for (FlowElementInstance fei : feis) {
-			if (fei instanceof FlowSpecificationInstance fsi) {
-				soms.removeIf(som -> !fsi.isActive(som));
-			} else if (fei instanceof ComponentInstance ci) {
-				soms.removeIf(som -> !ci.isActive(som));
-			}
-		}
-
-		// finally, keep those SOMs where the ete and used flow implementations are active
-		for (SystemOperationMode som : soms) {
-			if (containsModeInstances(som, etei.getModesList())) {
-				etei.getInSystemOperationModes().add(som);
-			}
-		}
-
-		etei.getModesList().clear();
+		EndToEndFlowModes.fillInModes(etei);
 	}
 
-	private boolean containsModeInstances(SystemOperationMode som, List<EList<ModeInstance>> modeLists) {
-		outer: for (List<ModeInstance> mis : modeLists) {
-			if (!mis.isEmpty()) {
-				for (ModeInstance mi : mis) {
-					if (som.getCurrentModes().contains(mi)) {
-						continue outer;
-					}
-				}
-				return false;
-			}
-		}
-		return true;
-	}
+	/**
+	 * Routes what a session needs back to this switch, so that discovery reaches the protected methods above and an
+	 * override of any of them stays in effect however deep in the traversal it is reached from.
+	 */
+	private final class SessionHost implements FlowInstantiationHost {
 
+		@Override
+		public boolean isCanceled() {
+			return monitor.isCanceled();
+		}
+
+		@Override
+		public ComponentImplementation componentImplementation(ComponentInstance ci) {
+			return getComponentImplementation(ci);
+		}
+
+		@Override
+		public void reportError(Element target, String message) {
+			error(target, message);
+		}
+
+		@Override
+		public void expandNestedFlow(ComponentInstance ci, EndToEndFlow ete) {
+			instantiateEndToEndFlow(ci, ete, null);
+		}
+
+		@Override
+		public void processETE(ComponentInstance ci, EndToEndFlowInstance etei, EndToEndFlow ete) {
+			CreateEndToEndFlowsSwitch.this.processETE(ci, etei, ete);
+		}
+
+		@Override
+		public void processETESegment(ComponentInstance ci, EndToEndFlowInstance etei, Element fs, FlowIterator iter,
+				NamedElement errorElement) {
+			CreateEndToEndFlowsSwitch.this.processETESegment(ci, etei, fs, iter, errorElement);
+		}
+
+		@Override
+		public void processSubcomponentFlow(ComponentInstance ci, EndToEndFlowInstance etei, FlowSpecification fs,
+				FlowIterator iter) {
+			CreateEndToEndFlowsSwitch.this.processSubcomponentFlow(ci, etei, fs, iter);
+		}
+
+		@Override
+		public boolean processFlowImpl(ComponentInstance ci, EndToEndFlowInstance etei, FlowImplementation flowImpl) {
+			return CreateEndToEndFlowsSwitch.this.processFlowImpl(ci, etei, flowImpl);
+		}
+
+		@Override
+		public void processFlowStep(ComponentInstance ci, EndToEndFlowInstance etei, Element leaf, FlowIterator iter) {
+			CreateEndToEndFlowsSwitch.this.processFlowStep(ci, etei, leaf, iter);
+		}
+
+		@Override
+		public void processFlowStep(ComponentInstance ci, EndToEndFlowInstance etei, Element leaf,
+				FlowImplementation nextFlowImpl, FlowIterator iter) {
+			CreateEndToEndFlowsSwitch.this.processFlowStep(ci, etei, leaf, nextFlowImpl, iter);
+		}
+
+		@Override
+		public void resetCloneCount() {
+			resetETECloneCount();
+		}
+
+		@Override
+		public void setCloneName(EndToEndFlowInstance etei) {
+			CreateEndToEndFlowsSwitch.this.setCloneName(etei);
+		}
+
+		@Override
+		public EList<ModeInstance> modeInstances(ComponentInstance ci, ModalElement element) {
+			return getModeInstances(ci, element);
+		}
+
+		@Override
+		public void fillInModes(EndToEndFlowInstance etei) {
+			fillinModes(etei);
+		}
+	}
 }

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CreateEndToEndFlowsSwitch.java
@@ -107,7 +107,7 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 
 	@Override
 	protected final void initSwitches() {
-		instanceSwitch = new InstanceSwitch<String>() {
+		instanceSwitch = new InstanceSwitch<>() {
 			@Override
 			public String caseComponentInstance(final ComponentInstance ci) {
 				if (monitor.isCanceled()) {
@@ -117,11 +117,11 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 				if (ci.getContainingComponentInstance() instanceof SystemInstance) {
 					monitor.subTask("Creating end-to-end flows in " + ci.getName());
 				}
-				EndToEndFlowSession previousSession = activeSession;
-				EndToEndFlowSession session = new EndToEndFlowSession(host, ci);
+				var previousSession = activeSession;
+				var session = new EndToEndFlowSession(host, ci);
 				activeSession = session;
 				try {
-					ComponentImplementation impl = getComponentImplementation(ci);
+					var impl = componentImplementation(ci);
 					if (impl != null) {
 						for (EndToEndFlow ete : impl.getAllEndToEndFlows()) {
 							if (monitor.isCanceled()) {
@@ -134,9 +134,8 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 							}
 						}
 					}
-					if (!session.isCanceled() && !monitor.isCanceled()) {
-						session.commit();
-					}
+					// The session itself refuses to attach anything once it has seen a cancellation.
+					session.commit();
 				} finally {
 					activeSession = previousSession;
 				}
@@ -148,7 +147,7 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 	/**
 	 * The implementation instantiated for a component instance, with prototypes resolved through the classifier cache.
 	 */
-	private ComponentImplementation getComponentImplementation(ComponentInstance ci) {
+	private ComponentImplementation componentImplementation(ComponentInstance ci) {
 		return InstanceUtil.getComponentImplementation(ci, 0, classifierCache);
 	}
 
@@ -184,8 +183,8 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 	 */
 	protected void instantiateEndToEndFlow(ComponentInstance ci, EndToEndFlow ete,
 			HashMap<EndToEndFlow, List<ETEInfo>> ete2info) {
-		EndToEndFlowSession previousSession = activeSession;
-		boolean standalone = activeSession == null;
+		var previousSession = activeSession;
+		var standalone = activeSession == null;
 		if (standalone) {
 			activeSession = new EndToEndFlowSession(host, ci);
 		} else if (activeSession.owner() != ci) {
@@ -194,12 +193,12 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 		}
 
 		try {
-			EndToEndFlowSession session = activeSession;
+			var session = activeSession;
 			session.expand(ete);
 			if (ete2info != null) {
 				ete2info.put(ete, session.compatibilityInfo(ete));
 			}
-			if (standalone && !session.isCanceled() && !monitor.isCanceled()) {
+			if (standalone) {
 				session.commit();
 			}
 		} finally {
@@ -219,13 +218,13 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 	 *
 	 * @param ci the component instance we're in
 	 * @param etei the current flow instance
-	 * @param fs the next flow segment
+	 * @param segment the next flow segment
 	 * @param iter the position in the current ETE declaration
 	 * @param errorElement the model element that we attach errors to
 	 */
-	protected void processETESegment(ComponentInstance ci, EndToEndFlowInstance etei, Element fs, FlowIterator iter,
-			NamedElement errorElement) {
-		session().processETESegment(ci, etei, fs, iter, errorElement);
+	protected void processETESegment(ComponentInstance ci, EndToEndFlowInstance etei, Element segment,
+			FlowIterator iter, NamedElement errorElement) {
+		session().processETESegment(ci, etei, segment, iter, errorElement);
 	}
 
 	/**
@@ -299,7 +298,7 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 	 * @param etei the committed flow instance
 	 */
 	protected void fillinModes(EndToEndFlowInstance etei) {
-		EndToEndFlowModes.fillInModes(etei);
+		EndToEndFlowModes.assignSystemOperationModes(etei);
 	}
 
 	/**
@@ -315,7 +314,7 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 
 		@Override
 		public ComponentImplementation componentImplementation(ComponentInstance ci) {
-			return getComponentImplementation(ci);
+			return CreateEndToEndFlowsSwitch.this.componentImplementation(ci);
 		}
 
 		@Override
@@ -334,9 +333,9 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 		}
 
 		@Override
-		public void processETESegment(ComponentInstance ci, EndToEndFlowInstance etei, Element fs, FlowIterator iter,
-				NamedElement errorElement) {
-			CreateEndToEndFlowsSwitch.this.processETESegment(ci, etei, fs, iter, errorElement);
+		public void processETESegment(ComponentInstance ci, EndToEndFlowInstance etei, Element segment,
+				FlowIterator iter, NamedElement errorElement) {
+			CreateEndToEndFlowsSwitch.this.processETESegment(ci, etei, segment, iter, errorElement);
 		}
 
 		@Override
@@ -377,7 +376,7 @@ public class CreateEndToEndFlowsSwitch extends AadlProcessingSwitchWithProgress 
 		}
 
 		@Override
-		public void fillInModes(EndToEndFlowInstance etei) {
+		public void assignSystemOperationModes(EndToEndFlowInstance etei) {
 			fillinModes(etei);
 		}
 	}

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/ETEInfo.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/ETEInfo.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.aadl2.instantiation.internal;
+
+import java.util.List;
+
+import org.osate.aadl2.Connection;
+import org.osate.aadl2.instance.EndToEndFlowInstance;
+
+/**
+ * One instantiated variant of an end-to-end flow declaration, in the shape end-to-end flow instantiation published
+ * before it kept candidates of its own.
+ * <p>
+ * This is the legacy view of a candidate: the flow instance together with the declarative connections that lead into
+ * its first and out of its last flow element. It is produced only when a caller of
+ * {@code CreateEndToEndFlowsSwitch.instantiateEndToEndFlow} supplies a map to fill in; the traversal itself works on
+ * the session's own candidates.
+ */
+public final class ETEInfo {
+	public final List<Connection> preConns;
+	public final EndToEndFlowInstance etei;
+	public final List<Connection> postConns;
+
+	public ETEInfo(List<Connection> preConns, EndToEndFlowInstance etei, List<Connection> postConns) {
+		this.preConns = preConns;
+		this.etei = etei;
+		this.postConns = postConns;
+	}
+}

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/EndToEndFlowModes.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/EndToEndFlowModes.java
@@ -47,8 +47,8 @@ import org.osate.aadl2.instance.SystemOperationMode;
  * {@code CreateEndToEndFlowsSwitch}, which remain the extension points a subclass overrides. Instantiation always calls
  * them through the switch, never the methods here directly, so an override still decides the outcome.
  * <p>
- * {@link #fillInModes} needs a committed flow instance: it navigates to the system instance and asks flow elements
- * whether they are active in a system operation mode.
+ * {@link #assignSystemOperationModes} needs a committed flow instance: it navigates to the system instance and asks flow
+ * elements whether they are active in a system operation mode.
  */
 public final class EndToEndFlowModes {
 
@@ -65,11 +65,11 @@ public final class EndToEndFlowModes {
 	 */
 	public static EList<ModeInstance> modeInstances(ComponentInstance ci, ModalElement e) {
 		EList<ModeInstance> mis = new BasicEList<>();
-		List<Mode> mlist = e.getAllInModes();
+		var mlist = e.getAllInModes();
 
 		if (!mlist.isEmpty()) {
-			for (Mode m : mlist) {
-				ModeInstance mi = ci.findModeInstance(m);
+			for (var m : mlist) {
+				var mi = ci.findModeInstance(m);
 
 				if (mi != null) {
 					mis.add(mi);
@@ -95,17 +95,17 @@ public final class EndToEndFlowModes {
 	 *
 	 * @param etei the committed flow instance
 	 */
-	public static void fillInModes(EndToEndFlowInstance etei) {
+	public static void assignSystemOperationModes(EndToEndFlowInstance etei) {
 
 		if (etei.getSystemInstance().getSystemOperationModes().size() <= 1) {
 			return;
 		}
 
 		// first, calculate intersection of all connection and ete instance SOMs
-		EList<FlowElementInstance> feis = etei.getFlowElements();
-		List<SystemOperationMode> soms = new ArrayList<>(etei.getSystemInstance().getSystemOperationModes());
+		var feis = etei.getFlowElements();
+		var soms = new ArrayList<>(etei.getSystemInstance().getSystemOperationModes());
 
-		for (FlowElementInstance fei : feis) {
+		for (var fei : feis) {
 			if (fei instanceof ConnectionInstance conni) {
 				if (!conni.getInSystemOperationModes().isEmpty()) {
 					soms.removeIf(som -> !conni.getInSystemOperationModes().contains(som));
@@ -118,7 +118,7 @@ public final class EndToEndFlowModes {
 		}
 
 		// then, keep those SOMs where all other flow elements are active
-		for (FlowElementInstance fei : feis) {
+		for (var fei : feis) {
 			if (fei instanceof FlowSpecificationInstance fsi) {
 				soms.removeIf(som -> !fsi.isActive(som));
 			} else if (fei instanceof ComponentInstance ci) {
@@ -127,7 +127,7 @@ public final class EndToEndFlowModes {
 		}
 
 		// finally, keep those SOMs where the ete and used flow implementations are active
-		for (SystemOperationMode som : soms) {
+		for (var som : soms) {
 			if (containsModeInstances(som, etei.getModesList())) {
 				etei.getInSystemOperationModes().add(som);
 			}
@@ -139,7 +139,7 @@ public final class EndToEndFlowModes {
 	private static boolean containsModeInstances(SystemOperationMode som, List<EList<ModeInstance>> modeLists) {
 		outer: for (List<ModeInstance> mis : modeLists) {
 			if (!mis.isEmpty()) {
-				for (ModeInstance mi : mis) {
+				for (var mi : mis) {
 					if (som.getCurrentModes().contains(mi)) {
 						continue outer;
 					}

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/EndToEndFlowModes.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/EndToEndFlowModes.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.aadl2.instantiation.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.emf.common.util.BasicEList;
+import org.eclipse.emf.common.util.EList;
+import org.osate.aadl2.ModalElement;
+import org.osate.aadl2.Mode;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.aadl2.instance.ConnectionInstance;
+import org.osate.aadl2.instance.EndToEndFlowInstance;
+import org.osate.aadl2.instance.FlowElementInstance;
+import org.osate.aadl2.instance.FlowSpecificationInstance;
+import org.osate.aadl2.instance.ModeInstance;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instance.SystemOperationMode;
+
+/**
+ * The mode arithmetic of end-to-end flow instantiation: which mode instances a declaration is constrained to, and which
+ * system operation modes a flow instance ends up active in.
+ * <p>
+ * Both computations are reached through the protected {@code getModeInstances} and {@code fillinModes} methods of
+ * {@code CreateEndToEndFlowsSwitch}, which remain the extension points a subclass overrides. Instantiation always calls
+ * them through the switch, never the methods here directly, so an override still decides the outcome.
+ * <p>
+ * {@link #fillInModes} needs a committed flow instance: it navigates to the system instance and asks flow elements
+ * whether they are active in a system operation mode.
+ */
+public final class EndToEndFlowModes {
+
+	private EndToEndFlowModes() {
+	}
+
+	/**
+	 * Resolve an element's mode constraints relative to a component instance. If the element has no explicit modes, use
+	 * the nearest containing component instance with inherited mode constraints.
+	 *
+	 * @param ci the component instance used to resolve modes
+	 * @param e the modal declarative element
+	 * @return list of mode instances
+	 */
+	public static EList<ModeInstance> modeInstances(ComponentInstance ci, ModalElement e) {
+		EList<ModeInstance> mis = new BasicEList<>();
+		List<Mode> mlist = e.getAllInModes();
+
+		if (!mlist.isEmpty()) {
+			for (Mode m : mlist) {
+				ModeInstance mi = ci.findModeInstance(m);
+
+				if (mi != null) {
+					mis.add(mi);
+				}
+			}
+		} else {
+			// Get modes from the containment hierarchy.
+			while (!(ci instanceof SystemInstance)) {
+				if (ci.getInModes().isEmpty()) {
+					ci = ci.getContainingComponentInstance();
+				} else {
+					mis = ci.getInModes();
+					break;
+				}
+			}
+		}
+		return mis;
+	}
+
+	/**
+	 * Compute the system operation modes a flow instance is active in from its elements and its accumulated mode
+	 * constraints, and consume those constraints.
+	 *
+	 * @param etei the committed flow instance
+	 */
+	public static void fillInModes(EndToEndFlowInstance etei) {
+
+		if (etei.getSystemInstance().getSystemOperationModes().size() <= 1) {
+			return;
+		}
+
+		// first, calculate intersection of all connection and ete instance SOMs
+		EList<FlowElementInstance> feis = etei.getFlowElements();
+		List<SystemOperationMode> soms = new ArrayList<>(etei.getSystemInstance().getSystemOperationModes());
+
+		for (FlowElementInstance fei : feis) {
+			if (fei instanceof ConnectionInstance conni) {
+				if (!conni.getInSystemOperationModes().isEmpty()) {
+					soms.removeIf(som -> !conni.getInSystemOperationModes().contains(som));
+				}
+			} else if (fei instanceof EndToEndFlowInstance efi) {
+				if (!efi.getInSystemOperationModes().isEmpty()) {
+					soms.removeIf(som -> !efi.getInSystemOperationModes().contains(som));
+				}
+			}
+		}
+
+		// then, keep those SOMs where all other flow elements are active
+		for (FlowElementInstance fei : feis) {
+			if (fei instanceof FlowSpecificationInstance fsi) {
+				soms.removeIf(som -> !fsi.isActive(som));
+			} else if (fei instanceof ComponentInstance ci) {
+				soms.removeIf(som -> !ci.isActive(som));
+			}
+		}
+
+		// finally, keep those SOMs where the ete and used flow implementations are active
+		for (SystemOperationMode som : soms) {
+			if (containsModeInstances(som, etei.getModesList())) {
+				etei.getInSystemOperationModes().add(som);
+			}
+		}
+
+		etei.getModesList().clear();
+	}
+
+	private static boolean containsModeInstances(SystemOperationMode som, List<EList<ModeInstance>> modeLists) {
+		outer: for (List<ModeInstance> mis : modeLists) {
+			if (!mis.isEmpty()) {
+				for (ModeInstance mi : mis) {
+					if (som.getCurrentModes().contains(mi)) {
+						continue outer;
+					}
+				}
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/EndToEndFlowSession.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/EndToEndFlowSession.java
@@ -1,0 +1,1118 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.aadl2.instantiation.internal;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.osate.aadl2.Access;
+import org.osate.aadl2.ComponentCategory;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.Connection;
+import org.osate.aadl2.DataAccess;
+import org.osate.aadl2.Element;
+import org.osate.aadl2.EndToEndFlow;
+import org.osate.aadl2.EndToEndFlowElement;
+import org.osate.aadl2.EndToEndFlowSegment;
+import org.osate.aadl2.FlowImplementation;
+import org.osate.aadl2.FlowSegment;
+import org.osate.aadl2.FlowSpecification;
+import org.osate.aadl2.NamedElement;
+import org.osate.aadl2.Subcomponent;
+import org.osate.aadl2.SubprogramAccess;
+import org.osate.aadl2.ThreadClassifier;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.aadl2.instance.ConnectionInstance;
+import org.osate.aadl2.instance.ConnectionInstanceEnd;
+import org.osate.aadl2.instance.EndToEndFlowInstance;
+import org.osate.aadl2.instance.FlowElementInstance;
+import org.osate.aadl2.instance.FlowSpecificationInstance;
+import org.osate.aadl2.instance.InstanceFactory;
+import org.osate.aadl2.instance.ModeInstance;
+import org.osate.aadl2.instance.SystemOperationMode;
+import org.osate.aadl2.modelsupport.util.AadlUtil;
+
+/**
+ * Instantiates the end-to-end flows declared by one component instance.
+ * <p>
+ * Flow discovery builds detached candidates with branch-local traversal state. A declaration may produce multiple
+ * candidates when several flow implementations, connection instances, access targets, or nested end-to-end flow
+ * variants match. Only completed candidates are attached to the component, in one commit after discovery finishes.
+ * Cancellation therefore leaves the component's existing end-to-end flows unchanged.
+ * <p>
+ * Nested end-to-end flows are expanded once per component context. Their leading and trailing declarative connection
+ * paths are retained so parent candidates can select compatible nested variants and continue after them.
+ * <p>
+ * A session belongs to one component instance and cannot be reused for another; the candidate, expansion, and traversal
+ * state it holds is meaningful only in that component context. Its traversal steps are reached from the adapter's
+ * protected methods and reach the adapter back through {@link FlowInstantiationHost}, so a subclass override remains in
+ * control of every step.
+ * <p>
+ * Internal consistency failures throw {@link IllegalStateException} intentionally. Continuing after an invariant has
+ * failed could publish an instance model whose flow graph cannot be trusted.
+ *
+ * @author lwrage
+ */
+public final class EndToEndFlowSession {
+
+	/**
+	 * Candidate discovery states. A failed candidate has no valid semantic continuation or belongs to a failed
+	 * declaration expansion. An aborted candidate could not append a resolved flow element because the instance model
+	 * did not satisfy the declaration.
+	 */
+	private enum CandidateStatus {
+		ACTIVE, COMPLETE, FAILED, ABORTED
+	}
+
+	private enum ExpansionStatus {
+		EXPANDING, COMPLETE, FAILED
+	}
+
+	private enum DiagnosticTarget {
+		OWNER, CANDIDATE, EXISTING_ELEMENT
+	}
+
+	private record PendingDiagnostic(long sequence, DiagnosticTarget target, FlowCandidate candidate,
+			Element existingElement, String message) {
+	}
+
+	/**
+	 * Expansion of one declarative end-to-end flow and all candidate paths derived from it.
+	 */
+	private static final class FlowExpansion {
+		private final EndToEndFlow declaration;
+		private final List<FlowCandidate> candidates = new ArrayList<>();
+		private ExpansionStatus status = ExpansionStatus.EXPANDING;
+
+		private FlowExpansion(EndToEndFlow declaration) {
+			this.declaration = declaration;
+		}
+	}
+
+	/**
+	 * A detached end-to-end flow instance under construction.
+	 */
+	private static final class FlowCandidate {
+		private final ComponentInstance owner;
+		private final FlowExpansion expansion;
+		private final EndToEndFlowInstance instance;
+		/*
+		 * Declarative connection paths before the first and after the last concrete flow element. Parent flows use these
+		 * paths to select compatible nested candidates and continue beyond them.
+		 */
+		private final List<Connection> preConnections;
+		private final List<Connection> postConnections = new ArrayList<>();
+		private final long sequence;
+		private CandidateStatus status = CandidateStatus.ACTIVE;
+
+		private FlowCandidate(ComponentInstance owner, FlowExpansion expansion, EndToEndFlowInstance instance,
+				List<Connection> preConnections, long sequence) {
+			this.owner = owner;
+			this.expansion = expansion;
+			this.instance = instance;
+			this.preConnections = preConnections;
+			this.sequence = sequence;
+		}
+	}
+
+	/**
+	 * Branch-local traversal data. Continuations resume enclosing declarations after descending into a flow
+	 * implementation or another nested construct; connections are the declarative path awaiting resolution to a
+	 * connection instance; flowImplementations constrain the source and destination features accepted for that
+	 * connection instance.
+	 */
+	private static final class TraversalState {
+		private final FlowCandidate candidate;
+		private final Deque<FlowIterator> continuations = new ArrayDeque<>();
+		private final List<Connection> connections = new ArrayList<>();
+		private final List<FlowImplementation> flowImplementations = new ArrayList<>();
+
+		private TraversalState(FlowCandidate candidate) {
+			this.candidate = candidate;
+		}
+
+		private TraversalState copy(FlowCandidate candidate) {
+			TraversalState copy = new TraversalState(candidate);
+			for (FlowIterator continuation : continuations) {
+				copy.continuations.addLast(continuation.copy());
+			}
+			copy.connections.addAll(connections);
+			copy.flowImplementations.addAll(flowImplementations);
+			return copy;
+		}
+	}
+
+	private final FlowInstantiationHost host;
+	private final ComponentInstance owner;
+	private final List<EndToEndFlowInstance> initialFlows;
+	private final Map<EndToEndFlow, FlowExpansion> expansions = new IdentityHashMap<>();
+	private final List<FlowExpansion> expansionOrder = new ArrayList<>();
+	private final List<FlowCandidate> candidates = new ArrayList<>();
+	private final Map<EndToEndFlowInstance, FlowCandidate> candidatesByInstance = new IdentityHashMap<>();
+	private final List<EndToEndFlow> activeDeclarations = new ArrayList<>();
+	private final List<PendingDiagnostic> diagnostics = new ArrayList<>();
+	private long nextCandidateSequence;
+	private long nextDiagnosticSequence;
+	private boolean canceled;
+
+	/** The branch currently advancing, or null while no branch is being traversed. */
+	private TraversalState activeState;
+
+	/**
+	 * Start instantiating the end-to-end flows of one component instance.
+	 *
+	 * @param host the traversal adapter that drives this session
+	 * @param owner the component instance whose declarations are instantiated
+	 */
+	public EndToEndFlowSession(FlowInstantiationHost host, ComponentInstance owner) {
+		this.host = host;
+		this.owner = owner;
+		initialFlows = List.copyOf(owner.getEndToEndFlows());
+	}
+
+	/** The component instance this session instantiates flows for. */
+	public ComponentInstance owner() {
+		return owner;
+	}
+
+	/** Whether a declaration has already been expanded in this component context. */
+	public boolean isExpanded(EndToEndFlow ete) {
+		return expansions.containsKey(ete);
+	}
+
+	/** Whether discovery was canceled, which keeps the component's flows unchanged. */
+	public boolean isCanceled() {
+		return canceled;
+	}
+
+	/** Record that discovery was canceled. */
+	public void cancel() {
+		canceled = true;
+	}
+
+	/**
+	 * The legacy view of a declaration's candidates, in creation order.
+	 */
+	public List<ETEInfo> compatibilityInfo(EndToEndFlow ete) {
+		FlowExpansion expansion = expansions.get(ete);
+		if (expansion == null) {
+			return List.of();
+		}
+		List<ETEInfo> infos = new ArrayList<>();
+		for (FlowCandidate candidate : expansion.candidates) {
+			infos.add(new ETEInfo(candidate.preConnections, candidate.instance, candidate.postConnections));
+		}
+		return infos;
+	}
+
+	/**
+	 * Expand one declaration into candidates, once per component context. The candidates stay detached until
+	 * {@link #commit()}.
+	 */
+	public void expand(EndToEndFlow ete) {
+		if (expansions.containsKey(ete)) {
+			return;
+		}
+
+		FlowExpansion expansion = new FlowExpansion(ete);
+		expansions.put(ete, expansion);
+		expansionOrder.add(expansion);
+		activeDeclarations.add(ete);
+
+		EndToEndFlowInstance etei = InstanceFactory.eINSTANCE.createEndToEndFlowInstance();
+		etei.setName(ete.getName());
+		etei.setEndToEndFlow(ete);
+		FlowCandidate candidate = createCandidate(expansion, etei, new ArrayList<>());
+		TraversalState previousState = activeState;
+		activeState = new TraversalState(candidate);
+		etei.getModesList().add(host.modeInstances(owner, ete));
+		try {
+			host.processETE(owner, etei, ete);
+		} finally {
+			activeDeclarations.removeLast();
+			if (host.isCanceled()) {
+				canceled = true;
+			}
+			if (expansion.status == ExpansionStatus.FAILED) {
+				for (FlowCandidate createdCandidate : expansion.candidates) {
+					createdCandidate.status = CandidateStatus.FAILED;
+				}
+			} else {
+				for (FlowCandidate createdCandidate : expansion.candidates) {
+					if (createdCandidate.status == CandidateStatus.ACTIVE) {
+						createdCandidate.status = createdCandidate.instance.getFlowElements().isEmpty()
+								? CandidateStatus.FAILED
+								: CandidateStatus.COMPLETE;
+					}
+				}
+				expansion.status = ExpansionStatus.COMPLETE;
+			}
+			activeState = previousState;
+		}
+	}
+
+	private FlowCandidate createCandidate(FlowExpansion expansion, EndToEndFlowInstance instance,
+			List<Connection> preConnections) {
+		FlowCandidate candidate = new FlowCandidate(owner, expansion, instance, preConnections,
+				nextCandidateSequence++);
+		expansion.candidates.add(candidate);
+		candidates.add(candidate);
+		candidatesByInstance.put(instance, candidate);
+		return candidate;
+	}
+
+	/**
+	 * Fork the active path before processing another alternative. Both the detached instance and every mutable traversal
+	 * structure must be copied so subsequent alternatives cannot modify one another.
+	 */
+	private TraversalState forkState(TraversalState source) {
+		EndToEndFlowInstance instance = EcoreUtil.copy(source.candidate.instance);
+		// Preserve accumulated mode constraints, which are not part of the copied flow-element containment tree.
+		instance.getModesList().addAll(source.candidate.instance.getModesList());
+		List<Connection> preConnections = source.candidate.instance.getFlowElements().isEmpty()
+				? new ArrayList<>()
+				: new ArrayList<>(source.candidate.preConnections);
+		FlowCandidate candidate = createCandidate(source.candidate.expansion, instance, preConnections);
+		return source.copy(candidate);
+	}
+
+	private FlowCandidate getCandidate(EndToEndFlowInstance etei) {
+		FlowCandidate candidate = candidatesByInstance.get(etei);
+		if (candidate == null) {
+			throw new IllegalStateException("End-to-end flow instance is not part of the active context");
+		}
+		return candidate;
+	}
+
+	private TraversalState getState(EndToEndFlowInstance etei) {
+		FlowCandidate candidate = getCandidate(etei);
+		if (activeState == null || activeState.candidate != candidate) {
+			throw new IllegalStateException("End-to-end flow branch is not active");
+		}
+		return activeState;
+	}
+
+	private void reportOwnerError(FlowCandidate candidate, String message) {
+		diagnostics.add(new PendingDiagnostic(nextDiagnosticSequence++, DiagnosticTarget.OWNER, candidate, null,
+				message));
+	}
+
+	private void reportCandidateError(FlowCandidate candidate, String message) {
+		diagnostics.add(new PendingDiagnostic(nextDiagnosticSequence++, DiagnosticTarget.CANDIDATE, candidate, null,
+				message));
+	}
+
+	private void reportExistingElementError(FlowCandidate candidate, Element element, String message) {
+		diagnostics.add(new PendingDiagnostic(nextDiagnosticSequence++, DiagnosticTarget.EXISTING_ELEMENT, candidate,
+				element, message));
+	}
+
+	private String getProspectivePath(FlowCandidate candidate) {
+		return candidate.owner.getInstanceObjectPath() + "." + candidate.instance.getName();
+	}
+
+	private void failCandidate(FlowCandidate candidate) {
+		if (candidate.status == CandidateStatus.ACTIVE) {
+			candidate.status = CandidateStatus.FAILED;
+		}
+	}
+
+	private void abortCandidate(FlowCandidate candidate) {
+		candidate.status = CandidateStatus.ABORTED;
+	}
+
+	// -------------------------------------------------------------------------
+	// Commit
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Publish all completed candidates for a component. Candidate names are assigned deterministically, nested
+	 * references are checked before attachment, and modes are finalized with nested flows before their parents. If mode
+	 * finalization fails, attachment and transient mode state are rolled back before the exception is propagated.
+	 * Diagnostics are emitted only after a successful commit. Diagnostics for completed candidates target the attached
+	 * flow instance; diagnostics for discarded candidates target the owning component instance.
+	 */
+	public void commit() {
+		if (canceled || host.isCanceled()) {
+			return;
+		}
+		if (!owner.getEndToEndFlows().equals(initialFlows)) {
+			throw new IllegalStateException("End-to-end flow list changed during candidate discovery");
+		}
+
+		for (FlowExpansion expansion : expansionOrder) {
+			List<FlowCandidate> successful = expansion.candidates.stream()
+					.filter(candidate -> candidate.status == CandidateStatus.COMPLETE)
+					.sorted(Comparator.comparingLong(candidate -> candidate.sequence))
+					.toList();
+			if (successful.size() == 1) {
+				successful.get(0).instance.setName(expansion.declaration.getName());
+			} else if (successful.size() > 1) {
+				host.resetCloneCount();
+				for (FlowCandidate candidate : successful) {
+					host.setCloneName(candidate.instance);
+				}
+			}
+		}
+
+		List<FlowCandidate> successful = candidates.stream()
+				.filter(candidate -> candidate.status == CandidateStatus.COMPLETE)
+				.sorted(Comparator.comparingLong(candidate -> candidate.sequence))
+				.toList();
+		for (FlowCandidate candidate : successful) {
+			for (FlowElementInstance element : candidate.instance.getFlowElements()) {
+				if (element instanceof EndToEndFlowInstance nested) {
+					FlowCandidate nestedCandidate = candidatesByInstance.get(nested);
+					if (nestedCandidate == null || nestedCandidate.status != CandidateStatus.COMPLETE) {
+						throw new IllegalStateException("Candidate references an unavailable end-to-end flow");
+					}
+				}
+			}
+		}
+
+		List<EndToEndFlowInstance> instances = successful.stream().map(candidate -> candidate.instance).toList();
+		Map<FlowCandidate, List<EList<ModeInstance>>> modeSnapshots = new IdentityHashMap<>();
+		Map<FlowCandidate, List<SystemOperationMode>> somSnapshots = new IdentityHashMap<>();
+		for (FlowCandidate candidate : successful) {
+			modeSnapshots.put(candidate, new ArrayList<>(candidate.instance.getModesList()));
+			somSnapshots.put(candidate, new ArrayList<>(candidate.instance.getInSystemOperationModes()));
+		}
+
+		owner.getEndToEndFlows().addAll(instances);
+		try {
+			Map<FlowCandidate, Boolean> finalized = new IdentityHashMap<>();
+			Map<FlowCandidate, Boolean> finalizing = new IdentityHashMap<>();
+			for (FlowCandidate candidate : successful) {
+				finalizeModes(candidate, finalized, finalizing);
+			}
+		} catch (RuntimeException | Error exception) {
+			owner.getEndToEndFlows().removeAll(instances);
+			for (FlowCandidate candidate : successful) {
+				candidate.instance.getModesList().clear();
+				candidate.instance.getModesList().addAll(modeSnapshots.get(candidate));
+				candidate.instance.getInSystemOperationModes().clear();
+				candidate.instance.getInSystemOperationModes().addAll(somSnapshots.get(candidate));
+			}
+			throw exception;
+		}
+
+		for (PendingDiagnostic diagnostic : diagnostics.stream()
+				.sorted(Comparator.comparingLong(PendingDiagnostic::sequence))
+				.toList()) {
+			switch (diagnostic.target()) {
+			case OWNER -> host.reportError(diagnostic.candidate().owner, diagnostic.message());
+			case CANDIDATE -> {
+				if (diagnostic.candidate().status == CandidateStatus.COMPLETE) {
+					host.reportError(diagnostic.candidate().instance, diagnostic.message());
+				} else {
+					host.reportError(diagnostic.candidate().owner,
+							diagnostic.candidate().instance.getName() + " could not be instantiated: "
+									+ diagnostic.message());
+				}
+			}
+			case EXISTING_ELEMENT -> host.reportError(diagnostic.existingElement(), diagnostic.message());
+			}
+		}
+	}
+
+	/**
+	 * Finalize a candidate's system operation modes after finalizing any nested candidates it references.
+	 */
+	private void finalizeModes(FlowCandidate candidate, Map<FlowCandidate, Boolean> finalized,
+			Map<FlowCandidate, Boolean> finalizing) {
+		if (finalized.containsKey(candidate)) {
+			return;
+		}
+		if (finalizing.put(candidate, Boolean.TRUE) != null) {
+			throw new IllegalStateException("Cyclic committed end-to-end flow graph");
+		}
+		for (FlowElementInstance element : candidate.instance.getFlowElements()) {
+			if (element instanceof EndToEndFlowInstance nested) {
+				FlowCandidate nestedCandidate = candidatesByInstance.get(nested);
+				if (nestedCandidate != null && nestedCandidate.status == CandidateStatus.COMPLETE) {
+					finalizeModes(nestedCandidate, finalized, finalizing);
+				}
+			}
+		}
+		host.fillInModes(candidate.instance);
+		candidate.instance.getModesList().clear();
+		finalizing.remove(candidate);
+		finalized.put(candidate, Boolean.TRUE);
+	}
+
+	// -------------------------------------------------------------------------
+	// Traversal
+	// -------------------------------------------------------------------------
+
+	public void processETE(final ComponentInstance ci, final EndToEndFlowInstance etei, final EndToEndFlow ete) {
+		FlowIterator iter = new FlowIterator(ete);
+		EndToEndFlowSegment fe = (EndToEndFlowSegment) iter.next();
+
+		host.processETESegment(ci, etei, fe, iter, ete);
+	}
+
+	/**
+	 * Consume one declarative flow segment. Connection declarations are accumulated until a concrete flow element
+	 * resolves them; other segment kinds delegate to their specialized traversal methods and may fork the candidate.
+	 *
+	 * @param ci the component instance we're in
+	 * @param etei the current flow instance
+	 * @param fs the next flow segment
+	 * @param iter the position in the current ETE declaration
+	 * @param errorElement the model element that we attach errors to
+	 */
+	public void processETESegment(ComponentInstance ci, EndToEndFlowInstance etei, Element fs, FlowIterator iter,
+			NamedElement errorElement) {
+		TraversalState traversal = getState(etei);
+		FlowCandidate candidate = traversal.candidate;
+		Element fe = switch (fs) {
+		case FlowSegment segment -> segment.getFlowElement();
+		case EndToEndFlowSegment segment -> segment.getFlowElement();
+		default -> throw new IllegalArgumentException("Unsupported flow segment " + fs.eClass().getName());
+		};
+
+		if (fe instanceof Connection connection) {
+			if (etei.getFlowElements().isEmpty()) {
+				candidate.preConnections.add(connection);
+			} else {
+				traversal.connections.add(connection);
+			}
+		} else if (fe instanceof FlowSpecification flowSpecification) {
+			Subcomponent sc = (Subcomponent) switch (fs) {
+			case FlowSegment segment -> segment.getContext();
+			case EndToEndFlowSegment segment -> segment.getContext();
+			default -> throw new IllegalArgumentException("Unsupported flow segment " + fs.eClass().getName());
+			};
+			ComponentInstance sci = ci.findSubcomponentInstance(sc);
+			if (sci != null) {
+				host.processSubcomponentFlow(sci, etei, flowSpecification, iter);
+			} else {
+				reportOwnerError(candidate,
+						"Incomplete End-to-end flow instance " + etei.getName()
+								+ ": Could not find component instance for subcomponent " + sc.getName()
+								+ " in flow implementation " + errorElement.getName());
+			}
+		} else if (fe instanceof Subcomponent subcomponent) {
+			ComponentInstance sci = ci.findSubcomponentInstance(subcomponent);
+			host.processFlowStep(sci, etei, fe, iter);
+		} else if (fe instanceof DataAccess dataAccess) {
+			processAccess(ci, etei, dataAccess, iter);
+		} else if (fe instanceof SubprogramAccess subprogramAccess) {
+			processAccess(ci, etei, subprogramAccess, iter);
+		} else if (fe instanceof EndToEndFlow endToEndFlow) {
+			processEndToEndFlow(ci, etei, endToEndFlow, iter);
+		}
+	}
+
+	/**
+	 * Instantiate a component flow specification. Each matching flow implementation creates an alternative path and is
+	 * followed recursively. If no implementation exists, the flow specification itself is added as a leaf step.
+	 *
+	 * @param ci the component whose flow specification is to be processed
+	 * @param etei the end to end flow instance
+	 * @param fs the flow specification to be processed
+	 * @param iter the continuation in the enclosing flow declaration
+	 */
+	public void processSubcomponentFlow(final ComponentInstance ci, EndToEndFlowInstance etei,
+			final FlowSpecification fs, FlowIterator iter) {
+		FlowCandidate candidate = getCandidate(etei);
+		final ComponentImplementation subImpl = host.componentImplementation(ci);
+		final List<FlowImplementation> flowImpls = new ArrayList<>();
+
+		// Collect flow impls for this flow spec
+		if (subImpl != null) {
+			for (FlowImplementation fl : subImpl.getAllFlowImplementations()) {
+				if (fl.getSpecification().getName().equalsIgnoreCase(fs.getName())) {
+					flowImpls.add(fl);
+				}
+			}
+		}
+
+		if (flowImpls.isEmpty()) {
+			// we are at a leaf
+			int errorsBefore = diagnostics.size();
+			host.processFlowStep(ci, etei, fs, iter);
+			if (subImpl != null && AadlUtil.hasPortComponents(subImpl) && diagnostics.size() == errorsBefore) {
+				reportOwnerError(candidate,
+						"Cannot create end to end flow '" + etei.getName() + "' because component '" + ci.getName()
+								+ "' has subcomponents but no flow implementation for flow '" + fs.getName() + "'");
+			}
+		} else {
+			Iterator<FlowImplementation> itt = flowImpls.iterator();
+
+			getState(etei).continuations.push(iter);
+			while (itt.hasNext()) {
+				TraversalState stateClone = null;
+				FlowIterator iterClone = null;
+				FlowImplementation flowImpl = itt.next();
+				boolean prepareNext = itt.hasNext();
+
+				if (prepareNext) {
+					stateClone = forkState(getState(etei));
+					iterClone = iter.copy();
+				}
+
+				/*
+				 * Issue 1953: Treat a thread flow implementation with owned segments as an atomic flow specification
+				 * instead of expanding its internal path, which prevents unnecessary instance-model combinations. An
+				 * empty implementation still follows the normal path because it may refine a feature-group endpoint to
+				 * one of its features.
+				 *
+				 * The flow implementation still contributes mode constraints even though its segments are ignored.
+				 */
+				if (subImpl instanceof ThreadClassifier && !flowImpl.getOwnedFlowSegments().isEmpty()) {
+					etei.getModesList().add(host.modeInstances(ci, flowImpl));
+					getState(etei).continuations.pop();
+
+					host.processFlowStep(ci, etei, fs, iter);
+				} else {
+					if (!host.processFlowImpl(ci, etei, flowImpl)) {
+						host.processFlowStep(ci, etei, fs, flowImpl, iter);
+					}
+				}
+
+				if (prepareNext) {
+					activeState = stateClone;
+					etei = stateClone.candidate.instance;
+					iter = iterClone;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Continue the current ETE instance with a flow implementation.
+	 *
+	 * @param ci the component instance whose flow implementation is being
+	 *            processed
+	 * @param etei the end to end flow instance
+	 * @param flowImpl the flow implementation to be processed
+	 * @return whether traversal entered the flow implementation; false if it has fewer than two segments
+	 */
+	public boolean processFlowImpl(ComponentInstance ci, EndToEndFlowInstance etei, FlowImplementation flowImpl) {
+		etei.getModesList().add(host.modeInstances(ci, flowImpl));
+
+		if (flowImpl.getOwnedFlowSegments().size() < 2) {
+			// the flow impl doesn't include a subcomponent, nothing to do
+			getState(etei).continuations.pop();
+			return false;
+		}
+
+		continueFlow(ci, etei, new FlowIterator(flowImpl), ci);
+		return true;
+	}
+
+	/**
+	 * Continue through a leaf flow element and constrain the incoming connection to the start of the next flow
+	 * implementation when one is known.
+	 *
+	 * @param ci the component instance containing the leaf
+	 * @param etei the current end to end flow instance
+	 * @param leaf the next ETE element
+	 * @param nextFlowImpl the flow implementation the incoming connection must reach, or null
+	 * @param iter the position in the current end to end flow declaration
+	 */
+	public void processFlowStep(ComponentInstance ci, EndToEndFlowInstance etei, Element leaf,
+			FlowImplementation nextFlowImpl, FlowIterator iter) {
+		TraversalState traversal = getState(etei);
+		FlowCandidate candidate = traversal.candidate;
+		// add connection(s), will be empty when starting the ETE
+		if (traversal.connections.isEmpty()) {
+			if (!addLeafElement(ci, etei, leaf)) {
+				abortCandidate(candidate);
+				return;
+			}
+			traversal.flowImplementations.add(nextFlowImpl);
+			continueFlow(ci.getContainingComponentInstance(), etei, iter, ci);
+			traversal.flowImplementations.removeLast();
+		} else {
+			List<ConnectionInstance> connis = FlowConnectionMatcher.collectConnectionInstances(ci, etei,
+					traversal.connections);
+
+			if (connis.isEmpty()) {
+				traversal.connections.clear();
+				failCandidate(candidate);
+
+				if (!traversal.flowImplementations.isEmpty()) {
+					FlowImplementation flowFilter = traversal.flowImplementations.getLast();
+					if (flowFilter != null) {
+						// A semantic connection was expected after the preceding flow implementation.
+						reportOwnerError(candidate,
+								"Cannot create end to end flow '" + etei.getName()
+										+ "' because there are no semantic connections that continue the flow '"
+										+ flowFilter.getSpecification().getName() + "' from feature '"
+										+ flowFilter.getOutEnd().getFeature().getName() + "'");
+					}
+				}
+			} else {
+				FlowImplementation flowFilter = traversal.flowImplementations.isEmpty()
+						? null
+						: traversal.flowImplementations.getLast();
+
+				/*
+				 * Issue 1984: isValidContinuation() is a filter, not an error reporter. Determine the applicable
+				 * connections first and report an error only when none of the candidates can continue this flow.
+				 */
+				final List<ConnectionInstance> connectionsToUse = new ArrayList<>();
+				for (final ConnectionInstance ciToCheck : connis) {
+					if ((flowFilter == null || FlowConnectionMatcher.isValidContinuation(flowFilter, ciToCheck))
+							&& (nextFlowImpl == null
+									? (leaf instanceof FlowSpecification flowSpecification
+											? FlowConnectionMatcher.isValidContinuation(ci, ciToCheck, flowSpecification)
+											: true)
+									: FlowConnectionMatcher.isValidContinuation(ciToCheck, nextFlowImpl))) {
+						connectionsToUse.add(ciToCheck);
+					}
+				}
+
+				if (connectionsToUse.isEmpty()) {
+					/*
+					 * Connections may bypass the start of the selected flow implementation: the declarative flow and the
+					 * actual component connections then describe different paths.
+					 */
+					if (flowFilter == null && nextFlowImpl == null) {
+						final FlowSpecification flowSpec = (FlowSpecification) leaf;
+						reportOwnerError(candidate, "Cannot create end to end flow '" + etei.getName()
+								+ "' because there are no semantic connections that connect to the start of the flow '"
+								+ flowSpec.getName() + "' at feature '" + flowSpec.getAllInEnd().getFeature().getName()
+								+ "'");
+					} else {
+						final FlowImplementation ff = flowFilter == null ? nextFlowImpl : flowFilter;
+						reportOwnerError(candidate, "Cannot create end to end flow '" + etei.getName()
+								+ "' because there are no semantic connections that connect to the start of the flow '"
+								+ ff.getSpecification().getName() + "' at feature '"
+								+ ff.getInEnd().getFeature().getName() + "'");
+					}
+					traversal.connections.clear();
+					failCandidate(candidate);
+				} else {
+					// continue the flow along each eligible connection instance
+					Iterator<ConnectionInstance> connIter = connectionsToUse.iterator();
+					while (connIter.hasNext()) {
+						final ConnectionInstance conni = connIter.next();
+						final boolean prepareNext = connIter.hasNext();
+						TraversalState branchState = getState(etei);
+						TraversalState stateClone = null;
+						FlowIterator iterClone = null;
+
+						if (prepareNext) {
+							stateClone = forkState(branchState);
+							iterClone = iter.copy();
+						}
+
+						branchState.flowImplementations.add(nextFlowImpl);
+						etei.getFlowElements().add(conni);
+						if (addLeafElement(ci, etei, leaf)) {
+							// prepare next connection filter
+							branchState.connections.clear();
+							if (iter.hasNext()) {
+								Connection conn = getConnection(iter.next());
+								if (conn != null) {
+									branchState.connections.add(conn);
+								}
+							}
+
+							continueFlow(ci.getContainingComponentInstance(), etei, iter, ci);
+						} else {
+							branchState.connections.clear();
+							abortCandidate(getCandidate(etei));
+						}
+
+						branchState.flowImplementations.removeLast();
+
+						if (prepareNext) {
+							activeState = stateClone;
+							etei = stateClone.candidate.instance;
+							iter = iterClone;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Continue through a data or subprogram access. The accessed component instance, rather than the access feature, is
+	 * added as the flow element. Multiple matching access connections create independent candidates.
+	 *
+	 * @param ci the component containing the access
+	 * @param etei the current end-to-end flow candidate
+	 * @param a the data or subprogram access
+	 * @param iter the continuation in the enclosing flow declaration
+	 */
+	private void processAccess(ComponentInstance ci, EndToEndFlowInstance etei, Access a, FlowIterator iter) {
+		TraversalState traversal = getState(etei);
+		FlowCandidate candidate = traversal.candidate;
+		// add connection(s), will be empty when starting the ETE
+		if (traversal.connections.isEmpty()) {
+			addLeafElement(ci, etei, a);
+			continueFlow(ci.getContainingComponentInstance(), etei, iter, ci);
+		} else {
+			List<ConnectionInstance> connis = FlowConnectionMatcher.collectConnectionInstances(ci, etei,
+					traversal.connections);
+
+			if (connis.isEmpty()) {
+				reportCandidateError(candidate, "Incomplete end-to-end flow instance " + etei.getName()
+						+ ": Missing connection instance to " + a.getName());
+				traversal.connections.clear();
+			} else {
+				record AccessMatch(ConnectionInstance connection, ComponentInstance target, EndToEndFlowElement leaf) {
+				}
+				List<AccessMatch> matches = new ArrayList<>();
+				boolean invalidTarget = false;
+				for (ConnectionInstance conni : connis) {
+					if (conni.getDestination() instanceof ComponentInstance target
+							&& (target.getCategory() == ComponentCategory.DATA
+									|| target.getCategory() == ComponentCategory.SUBPROGRAM)) {
+						matches.add(new AccessMatch(conni, target, target.getSubcomponent()));
+					} else {
+						invalidTarget = true;
+					}
+				}
+
+				if (invalidTarget) {
+					reportCandidateError(candidate, "Access feature " + a.getQualifiedName()
+							+ " is not a proxy for a data or subprogram component.");
+				}
+				if (matches.isEmpty()) {
+					traversal.connections.clear();
+					failCandidate(candidate);
+					return;
+				}
+
+				Iterator<AccessMatch> matchIter = matches.iterator();
+				traversal.continuations.push(iter);
+				while (matchIter.hasNext()) {
+					TraversalState branchState = getState(etei);
+					TraversalState stateClone = null;
+					AccessMatch match = matchIter.next();
+					boolean prepareNext = matchIter.hasNext();
+
+					if (prepareNext) {
+						stateClone = forkState(branchState);
+						etei.setName(etei.getEndToEndFlow().getName());
+					}
+					FlowIterator continuation = branchState.continuations.pop();
+
+					etei.getFlowElements().add(match.connection());
+					addLeafElement(match.target(), etei, match.leaf());
+
+					// prepare next connection filter
+					Connection lastConn = branchState.connections.getLast();
+					branchState.connections.clear();
+					if (continuation.hasNext()) {
+						Connection nextConn = getConnection(continuation.next());
+						if (nextConn != null) {
+							int i = match.connection().getConnectionReferences().size() - 1;
+							Connection preConn = null;
+
+							while (i > 0 && preConn != lastConn) {
+								preConn = match.connection().getConnectionReferences().get(i--).getConnection();
+								if (preConn != lastConn) {
+									branchState.connections.add(preConn);
+								}
+							}
+							branchState.connections.add(nextConn);
+						}
+					}
+
+					continueFlow(ci, etei, continuation, ci);
+
+					if (prepareNext) {
+						activeState = stateClone;
+						etei = stateClone.candidate.instance;
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Continue through a nested end-to-end flow. The nested declaration is expanded once per component context, and the
+	 * parent candidate is forked for every nested candidate whose leading connection path is compatible.
+	 */
+	private void processEndToEndFlow(ComponentInstance ci, EndToEndFlowInstance etei, EndToEndFlow ete,
+			FlowIterator iter) {
+		TraversalState traversal = getState(etei);
+		FlowCandidate candidate = traversal.candidate;
+
+		int cycleStart = activeDeclarations.indexOf(ete);
+		if (cycleStart >= 0) {
+			for (int i = cycleStart; i < activeDeclarations.size(); i++) {
+				FlowExpansion failedExpansion = expansions.get(activeDeclarations.get(i));
+				failedExpansion.status = ExpansionStatus.FAILED;
+				for (FlowCandidate failedCandidate : failedExpansion.candidates) {
+					failedCandidate.status = CandidateStatus.FAILED;
+				}
+			}
+			reportCandidateError(candidate,
+					"Cyclic dependency between end to end flows involving " + ete.getQualifiedName());
+			traversal.connections.clear();
+			return;
+		}
+
+		// instantiate the nested ete if that hasn't been done already
+		if (!expansions.containsKey(ete)) {
+			host.expandNestedFlow(ci, ete);
+		}
+		FlowExpansion nestedExpansion = expansions.get(ete);
+		if (nestedExpansion.status == ExpansionStatus.FAILED) {
+			candidate.expansion.status = ExpansionStatus.FAILED;
+			for (FlowCandidate failedCandidate : candidate.expansion.candidates) {
+				failedCandidate.status = CandidateStatus.FAILED;
+			}
+			traversal.connections.clear();
+			return;
+		}
+		List<FlowCandidate> nestedETEs = nestedExpansion.candidates.stream()
+				.filter(nested -> nested.status == CandidateStatus.COMPLETE)
+				.toList();
+
+		if (nestedETEs.isEmpty()) {
+			reportCandidateError(candidate, "No nested end to end flows instantiated for " + ete.getQualifiedName());
+			traversal.connections.clear();
+			return;
+		}
+		// add connection(s), will be empty when starting the ETE
+		if (traversal.connections.isEmpty()) {
+			TraversalState stateClone = null;
+			Iterator<FlowCandidate> nestedIter = nestedETEs.iterator();
+
+			traversal.continuations.push(iter);
+			while (nestedIter.hasNext()) {
+				FlowCandidate nested = nestedIter.next();
+				boolean prepareNext = nestedIter.hasNext();
+
+				if (prepareNext) {
+					stateClone = forkState(getState(etei));
+					etei.setName(etei.getEndToEndFlow().getName());
+				}
+				TraversalState branchState = getState(etei);
+				FlowIterator continuation = branchState.continuations.pop();
+
+				etei.getFlowElements().add(nested.instance);
+
+				// prepare next connection filter
+				branchState.connections.clear();
+				branchState.connections.addAll(nested.postConnections);
+				if (continuation.hasNext()) {
+					Connection conn = getConnection(continuation.next());
+					if (conn != null) {
+						branchState.connections.add(conn);
+					}
+				}
+
+				continueFlow(ci, etei, continuation, ci);
+
+				if (prepareNext) {
+					activeState = stateClone;
+					etei = stateClone.candidate.instance;
+				}
+			}
+		} else {
+			List<ConnectionInstance> connis = FlowConnectionMatcher.collectConnectionInstances(ci, etei,
+					traversal.connections);
+
+			if (connis.isEmpty()) {
+				reportCandidateError(candidate, "Incomplete end-to-end flow instance " + etei.getName()
+						+ ": Missing connection instance to " + ete.getName());
+				traversal.connections.clear();
+			} else {
+				record NestedMatch(ConnectionInstance connection, FlowCandidate nested) {
+				}
+				List<NestedMatch> matches = new ArrayList<>();
+				for (ConnectionInstance conni : connis) {
+					for (FlowCandidate nested : nestedETEs) {
+						if (FlowConnectionMatcher.isCompatibleNestedConnection(conni, nested.preConnections,
+								nested.instance)) {
+							matches.add(new NestedMatch(conni, nested));
+						}
+					}
+				}
+				if (matches.isEmpty()) {
+					reportCandidateError(candidate, "Incomplete end-to-end flow instance " + etei.getName()
+							+ ": No compatible nested end to end flow instance for " + ete.getName());
+					traversal.connections.clear();
+					return;
+				}
+
+				Iterator<NestedMatch> matchIter = matches.iterator();
+				traversal.continuations.push(iter);
+				while (matchIter.hasNext()) {
+					TraversalState stateClone = null;
+					NestedMatch match = matchIter.next();
+					boolean prepareNext = matchIter.hasNext();
+
+					if (prepareNext) {
+						stateClone = forkState(getState(etei));
+						etei.setName(etei.getEndToEndFlow().getName());
+					}
+					TraversalState branchState = getState(etei);
+					FlowIterator continuation = branchState.continuations.pop();
+
+					// Preserve path order: the incoming connection precedes the nested flow.
+					etei.getFlowElements().add(match.connection());
+					etei.getFlowElements().add(match.nested().instance);
+
+					// prepare next connection filter
+					branchState.connections.clear();
+					branchState.connections.addAll(match.nested().postConnections);
+					if (continuation.hasNext()) {
+						Connection nextConnection = getConnection(continuation.next());
+						if (nextConnection != null) {
+							branchState.connections.add(nextConnection);
+						}
+					}
+
+					continueFlow(ci, etei, continuation, ci);
+
+					if (prepareNext) {
+						activeState = stateClone;
+						etei = stateClone.candidate.instance;
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Add the concrete instance object represented by a declarative leaf.
+	 *
+	 * @param ci the component instance containing the leaf
+	 * @param etei the candidate receiving the leaf
+	 * @param leaf a flow specification, flow implementation, or subcomponent
+	 * @return whether the leaf was added successfully
+	 */
+	private boolean addLeafElement(ComponentInstance ci, EndToEndFlowInstance etei, Element leaf) {
+		FlowCandidate candidate = getCandidate(etei);
+		FlowSpecification fs = switch (leaf) {
+		case FlowImplementation flowImplementation -> flowImplementation.getSpecification();
+		case FlowSpecification flowSpecification -> flowSpecification;
+		default -> null;
+		};
+		if (fs != null) {
+			// append a flow specification instance
+			FlowSpecificationInstance fsi = ci.findFlowSpecInstance(fs);
+			if (fsi != null) {
+				etei.getFlowElements().add(fsi);
+			} else {
+				reportOwnerError(candidate, "Incomplete end-to-end flow instance " + etei.getName()
+						+ ": Could not find flow spec " + fs.getName() + " of component " + ci.getName());
+				return false;
+			}
+		} else if (leaf instanceof Subcomponent) {
+			if (etei.getFlowElements().isEmpty()) {
+				// append a subcomponent instance
+				etei.getFlowElements().add(ci);
+			} else {
+				ConnectionInstance preConn = (ConnectionInstance) etei.getFlowElements().getLast();
+				ConnectionInstanceEnd end = preConn.getDestination();
+				ComponentInstance comp = end.getContainingComponentInstance();
+				if (end instanceof ComponentInstance || comp == ci) {
+					// append a subcomponent instance
+					etei.getFlowElements().add(ci);
+				} else {
+					reportOwnerError(candidate,
+							"Invalid end-to-end flow instance " + etei.getName() + ": Connection "
+									+ preConn.getComponentInstancePath() + " continues into component "
+									+ ci.getInstanceObjectPath());
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Resume traversal until the active candidate completes, aborts, switches to another branch, or reaches the system
+	 * boundary. Exhausted nested continuations move traversal back to the containing component.
+	 */
+	private void continueFlow(ComponentInstance ci, EndToEndFlowInstance etei, FlowIterator iter,
+			NamedElement errorElement) {
+		FlowCandidate candidate = getCandidate(etei);
+		while (true) {
+			if (host.isCanceled()) {
+				canceled = true;
+				return;
+			}
+			if (candidate.status == CandidateStatus.ABORTED || candidate.status == CandidateStatus.FAILED) {
+				return;
+			}
+			if (activeState == null || activeState.candidate != candidate) {
+				return;
+			}
+			TraversalState traversal = activeState;
+			if (ci == null) {
+				reportExistingElementError(candidate, errorElement,
+						"Flow instance leaves system instance for flow " + getProspectivePath(candidate));
+				traversal.connections.clear();
+				return;
+			}
+			while (iter.hasNext()) {
+				Element e = iter.next();
+				host.processETESegment(ci, etei, e, iter, errorElement);
+				if (candidate.status == CandidateStatus.ABORTED || candidate.status == CandidateStatus.FAILED
+						|| activeState == null || activeState.candidate != candidate) {
+					return;
+				}
+			}
+			if (candidate.status == CandidateStatus.COMPLETE) {
+				return;
+			}
+			if (traversal.continuations.isEmpty()) {
+				if (candidate.status == CandidateStatus.ACTIVE) {
+					if (candidate.instance.getFlowElements().isEmpty()) {
+						traversal.connections.clear();
+						failCandidate(candidate);
+					} else {
+						candidate.postConnections.addAll(traversal.connections);
+						traversal.connections.clear();
+						candidate.status = CandidateStatus.COMPLETE;
+					}
+				}
+				break;
+			}
+			iter = traversal.continuations.pop();
+			ci = ci.getContainingComponentInstance();
+		}
+	}
+
+	private static Connection getConnection(Element segment) {
+		if (segment instanceof FlowSegment fs) {
+			return fs.getFlowElement() instanceof Connection connection ? connection : null;
+		}
+		if (segment instanceof EndToEndFlowSegment eefs) {
+			return eefs.getFlowElement() instanceof Connection connection ? connection : null;
+		}
+		return null;
+	}
+}

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/EndToEndFlowSession.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/EndToEndFlowSession.java
@@ -27,10 +27,12 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.util.EcoreUtil;
@@ -38,6 +40,7 @@ import org.osate.aadl2.Access;
 import org.osate.aadl2.ComponentCategory;
 import org.osate.aadl2.ComponentImplementation;
 import org.osate.aadl2.Connection;
+import org.osate.aadl2.Context;
 import org.osate.aadl2.DataAccess;
 import org.osate.aadl2.Element;
 import org.osate.aadl2.EndToEndFlow;
@@ -97,12 +100,26 @@ public final class EndToEndFlowSession {
 		EXPANDING, COMPLETE, FAILED
 	}
 
-	private enum DiagnosticTarget {
-		OWNER, CANDIDATE, EXISTING_ELEMENT
-	}
+	/**
+	 * A diagnostic held back until commit, because reporting resolves its reporter through the target's resource and a
+	 * candidate is not in one until it is attached. The sequence is the emission order they are replayed in.
+	 */
+	private sealed interface PendingDiagnostic {
+		long sequence();
 
-	private record PendingDiagnostic(long sequence, DiagnosticTarget target, FlowCandidate candidate,
-			Element existingElement, String message) {
+		String message();
+
+		/** Reported against the component instance that declares the flow, whether or not the candidate survived. */
+		record OwnerError(long sequence, FlowCandidate candidate, String message) implements PendingDiagnostic {
+		}
+
+		/** Reported against the flow instance when the candidate completed, against its owner when it did not. */
+		record CandidateError(long sequence, FlowCandidate candidate, String message) implements PendingDiagnostic {
+		}
+
+		/** Reported against a declarative element, which is in a resource already. */
+		record ElementError(long sequence, Element element, String message) implements PendingDiagnostic {
+		}
 	}
 
 	/**
@@ -161,8 +178,8 @@ public final class EndToEndFlowSession {
 		}
 
 		private TraversalState copy(FlowCandidate candidate) {
-			TraversalState copy = new TraversalState(candidate);
-			for (FlowIterator continuation : continuations) {
+			var copy = new TraversalState(candidate);
+			for (var continuation : continuations) {
 				copy.continuations.addLast(continuation.copy());
 			}
 			copy.connections.addAll(connections);
@@ -209,12 +226,10 @@ public final class EndToEndFlowSession {
 		return expansions.containsKey(ete);
 	}
 
-	/** Whether discovery was canceled, which keeps the component's flows unchanged. */
-	public boolean isCanceled() {
-		return canceled;
-	}
-
-	/** Record that discovery was canceled. */
+	/**
+	 * Record that discovery was canceled, which is sticky: a session that saw a cancellation attaches nothing, even if
+	 * the monitor is reset afterwards.
+	 */
 	public void cancel() {
 		canceled = true;
 	}
@@ -227,8 +242,8 @@ public final class EndToEndFlowSession {
 		if (expansion == null) {
 			return List.of();
 		}
-		List<ETEInfo> infos = new ArrayList<>();
-		for (FlowCandidate candidate : expansion.candidates) {
+		var infos = new ArrayList<ETEInfo>();
+		for (var candidate : expansion.candidates) {
 			infos.add(new ETEInfo(candidate.preConnections, candidate.instance, candidate.postConnections));
 		}
 		return infos;
@@ -243,16 +258,16 @@ public final class EndToEndFlowSession {
 			return;
 		}
 
-		FlowExpansion expansion = new FlowExpansion(ete);
+		var expansion = new FlowExpansion(ete);
 		expansions.put(ete, expansion);
 		expansionOrder.add(expansion);
 		activeDeclarations.add(ete);
 
-		EndToEndFlowInstance etei = InstanceFactory.eINSTANCE.createEndToEndFlowInstance();
+		var etei = InstanceFactory.eINSTANCE.createEndToEndFlowInstance();
 		etei.setName(ete.getName());
 		etei.setEndToEndFlow(ete);
-		FlowCandidate candidate = createCandidate(expansion, etei, new ArrayList<>());
-		TraversalState previousState = activeState;
+		var candidate = createCandidate(expansion, etei, new ArrayList<>());
+		var previousState = activeState;
 		activeState = new TraversalState(candidate);
 		etei.getModesList().add(host.modeInstances(owner, ete));
 		try {
@@ -263,11 +278,9 @@ public final class EndToEndFlowSession {
 				canceled = true;
 			}
 			if (expansion.status == ExpansionStatus.FAILED) {
-				for (FlowCandidate createdCandidate : expansion.candidates) {
-					createdCandidate.status = CandidateStatus.FAILED;
-				}
+				failExpansion(expansion);
 			} else {
-				for (FlowCandidate createdCandidate : expansion.candidates) {
+				for (var createdCandidate : expansion.candidates) {
 					if (createdCandidate.status == CandidateStatus.ACTIVE) {
 						createdCandidate.status = createdCandidate.instance.getFlowElements().isEmpty()
 								? CandidateStatus.FAILED
@@ -282,7 +295,7 @@ public final class EndToEndFlowSession {
 
 	private FlowCandidate createCandidate(FlowExpansion expansion, EndToEndFlowInstance instance,
 			List<Connection> preConnections) {
-		FlowCandidate candidate = new FlowCandidate(owner, expansion, instance, preConnections,
+		var candidate = new FlowCandidate(owner, expansion, instance, preConnections,
 				nextCandidateSequence++);
 		expansion.candidates.add(candidate);
 		candidates.add(candidate);
@@ -295,13 +308,13 @@ public final class EndToEndFlowSession {
 	 * structure must be copied so subsequent alternatives cannot modify one another.
 	 */
 	private TraversalState forkState(TraversalState source) {
-		EndToEndFlowInstance instance = EcoreUtil.copy(source.candidate.instance);
+		var instance = EcoreUtil.copy(source.candidate.instance);
 		// Preserve accumulated mode constraints, which are not part of the copied flow-element containment tree.
 		instance.getModesList().addAll(source.candidate.instance.getModesList());
 		List<Connection> preConnections = source.candidate.instance.getFlowElements().isEmpty()
 				? new ArrayList<>()
 				: new ArrayList<>(source.candidate.preConnections);
-		FlowCandidate candidate = createCandidate(source.candidate.expansion, instance, preConnections);
+		var candidate = createCandidate(source.candidate.expansion, instance, preConnections);
 		return source.copy(candidate);
 	}
 
@@ -314,7 +327,7 @@ public final class EndToEndFlowSession {
 	}
 
 	private TraversalState getState(EndToEndFlowInstance etei) {
-		FlowCandidate candidate = getCandidate(etei);
+		var candidate = getCandidate(etei);
 		if (activeState == null || activeState.candidate != candidate) {
 			throw new IllegalStateException("End-to-end flow branch is not active");
 		}
@@ -322,22 +335,15 @@ public final class EndToEndFlowSession {
 	}
 
 	private void reportOwnerError(FlowCandidate candidate, String message) {
-		diagnostics.add(new PendingDiagnostic(nextDiagnosticSequence++, DiagnosticTarget.OWNER, candidate, null,
-				message));
+		diagnostics.add(new PendingDiagnostic.OwnerError(nextDiagnosticSequence++, candidate, message));
 	}
 
 	private void reportCandidateError(FlowCandidate candidate, String message) {
-		diagnostics.add(new PendingDiagnostic(nextDiagnosticSequence++, DiagnosticTarget.CANDIDATE, candidate, null,
-				message));
+		diagnostics.add(new PendingDiagnostic.CandidateError(nextDiagnosticSequence++, candidate, message));
 	}
 
-	private void reportExistingElementError(FlowCandidate candidate, Element element, String message) {
-		diagnostics.add(new PendingDiagnostic(nextDiagnosticSequence++, DiagnosticTarget.EXISTING_ELEMENT, candidate,
-				element, message));
-	}
-
-	private String getProspectivePath(FlowCandidate candidate) {
-		return candidate.owner.getInstanceObjectPath() + "." + candidate.instance.getName();
+	private void reportExistingElementError(Element element, String message) {
+		diagnostics.add(new PendingDiagnostic.ElementError(nextDiagnosticSequence++, element, message));
 	}
 
 	private void failCandidate(FlowCandidate candidate) {
@@ -348,6 +354,17 @@ public final class EndToEndFlowSession {
 
 	private void abortCandidate(FlowCandidate candidate) {
 		candidate.status = CandidateStatus.ABORTED;
+	}
+
+	/**
+	 * Discard a whole declaration: no candidate of a failed expansion can be committed, and a candidate that referenced
+	 * one cannot either.
+	 */
+	private void failExpansion(FlowExpansion expansion) {
+		expansion.status = ExpansionStatus.FAILED;
+		for (var candidate : expansion.candidates) {
+			candidate.status = CandidateStatus.FAILED;
+		}
 	}
 
 	// -------------------------------------------------------------------------
@@ -369,27 +386,27 @@ public final class EndToEndFlowSession {
 			throw new IllegalStateException("End-to-end flow list changed during candidate discovery");
 		}
 
-		for (FlowExpansion expansion : expansionOrder) {
-			List<FlowCandidate> successful = expansion.candidates.stream()
+		for (var expansion : expansionOrder) {
+			var successful = expansion.candidates.stream()
 					.filter(candidate -> candidate.status == CandidateStatus.COMPLETE)
 					.sorted(Comparator.comparingLong(candidate -> candidate.sequence))
 					.toList();
 			if (successful.size() == 1) {
-				successful.get(0).instance.setName(expansion.declaration.getName());
+				successful.getFirst().instance.setName(expansion.declaration.getName());
 			} else if (successful.size() > 1) {
 				host.resetCloneCount();
-				for (FlowCandidate candidate : successful) {
+				for (var candidate : successful) {
 					host.setCloneName(candidate.instance);
 				}
 			}
 		}
 
-		List<FlowCandidate> successful = candidates.stream()
+		var successful = candidates.stream()
 				.filter(candidate -> candidate.status == CandidateStatus.COMPLETE)
 				.sorted(Comparator.comparingLong(candidate -> candidate.sequence))
 				.toList();
-		for (FlowCandidate candidate : successful) {
-			for (FlowElementInstance element : candidate.instance.getFlowElements()) {
+		for (var candidate : successful) {
+			for (var element : candidate.instance.getFlowElements()) {
 				if (element instanceof EndToEndFlowInstance nested) {
 					FlowCandidate nestedCandidate = candidatesByInstance.get(nested);
 					if (nestedCandidate == null || nestedCandidate.status != CandidateStatus.COMPLETE) {
@@ -400,46 +417,54 @@ public final class EndToEndFlowSession {
 		}
 
 		List<EndToEndFlowInstance> instances = successful.stream().map(candidate -> candidate.instance).toList();
-		Map<FlowCandidate, List<EList<ModeInstance>>> modeSnapshots = new IdentityHashMap<>();
-		Map<FlowCandidate, List<SystemOperationMode>> somSnapshots = new IdentityHashMap<>();
-		for (FlowCandidate candidate : successful) {
-			modeSnapshots.put(candidate, new ArrayList<>(candidate.instance.getModesList()));
-			somSnapshots.put(candidate, new ArrayList<>(candidate.instance.getInSystemOperationModes()));
+		record ModeSnapshot(List<EList<ModeInstance>> modes, List<SystemOperationMode> systemOperationModes) {
+		}
+		var snapshots = new IdentityHashMap<FlowCandidate, ModeSnapshot>();
+		for (var candidate : successful) {
+			snapshots.put(candidate, new ModeSnapshot(new ArrayList<>(candidate.instance.getModesList()),
+					new ArrayList<>(candidate.instance.getInSystemOperationModes())));
 		}
 
 		owner.getEndToEndFlows().addAll(instances);
 		try {
-			Map<FlowCandidate, Boolean> finalized = new IdentityHashMap<>();
-			Map<FlowCandidate, Boolean> finalizing = new IdentityHashMap<>();
-			for (FlowCandidate candidate : successful) {
+			var finalized = new HashSet<FlowCandidate>();
+			var finalizing = new HashSet<FlowCandidate>();
+			for (var candidate : successful) {
 				finalizeModes(candidate, finalized, finalizing);
 			}
 		} catch (RuntimeException | Error exception) {
 			owner.getEndToEndFlows().removeAll(instances);
-			for (FlowCandidate candidate : successful) {
+			for (var candidate : successful) {
+				var snapshot = snapshots.get(candidate);
 				candidate.instance.getModesList().clear();
-				candidate.instance.getModesList().addAll(modeSnapshots.get(candidate));
+				candidate.instance.getModesList().addAll(snapshot.modes());
 				candidate.instance.getInSystemOperationModes().clear();
-				candidate.instance.getInSystemOperationModes().addAll(somSnapshots.get(candidate));
+				candidate.instance.getInSystemOperationModes().addAll(snapshot.systemOperationModes());
 			}
 			throw exception;
 		}
 
-		for (PendingDiagnostic diagnostic : diagnostics.stream()
+		/*
+		 * Diagnostics are appended in emission order, so the sort only states the invariant that the order they are
+		 * reported in is the order discovery found them in.
+		 */
+		for (var diagnostic : diagnostics.stream()
 				.sorted(Comparator.comparingLong(PendingDiagnostic::sequence))
 				.toList()) {
-			switch (diagnostic.target()) {
-			case OWNER -> host.reportError(diagnostic.candidate().owner, diagnostic.message());
-			case CANDIDATE -> {
-				if (diagnostic.candidate().status == CandidateStatus.COMPLETE) {
-					host.reportError(diagnostic.candidate().instance, diagnostic.message());
+			switch (diagnostic) {
+			case PendingDiagnostic.OwnerError ownerError ->
+				host.reportError(ownerError.candidate().owner, ownerError.message());
+			case PendingDiagnostic.CandidateError candidateError -> {
+				var target = candidateError.candidate();
+				if (target.status == CandidateStatus.COMPLETE) {
+					host.reportError(target.instance, candidateError.message());
 				} else {
-					host.reportError(diagnostic.candidate().owner,
-							diagnostic.candidate().instance.getName() + " could not be instantiated: "
-									+ diagnostic.message());
+					host.reportError(target.owner,
+							target.instance.getName() + " could not be instantiated: " + candidateError.message());
 				}
 			}
-			case EXISTING_ELEMENT -> host.reportError(diagnostic.existingElement(), diagnostic.message());
+			case PendingDiagnostic.ElementError elementError ->
+				host.reportError(elementError.element(), elementError.message());
 			}
 		}
 	}
@@ -447,15 +472,15 @@ public final class EndToEndFlowSession {
 	/**
 	 * Finalize a candidate's system operation modes after finalizing any nested candidates it references.
 	 */
-	private void finalizeModes(FlowCandidate candidate, Map<FlowCandidate, Boolean> finalized,
-			Map<FlowCandidate, Boolean> finalizing) {
-		if (finalized.containsKey(candidate)) {
+	private void finalizeModes(FlowCandidate candidate, Set<FlowCandidate> finalized,
+			Set<FlowCandidate> finalizing) {
+		if (finalized.contains(candidate)) {
 			return;
 		}
-		if (finalizing.put(candidate, Boolean.TRUE) != null) {
+		if (!finalizing.add(candidate)) {
 			throw new IllegalStateException("Cyclic committed end-to-end flow graph");
 		}
-		for (FlowElementInstance element : candidate.instance.getFlowElements()) {
+		for (var element : candidate.instance.getFlowElements()) {
 			if (element instanceof EndToEndFlowInstance nested) {
 				FlowCandidate nestedCandidate = candidatesByInstance.get(nested);
 				if (nestedCandidate != null && nestedCandidate.status == CandidateStatus.COMPLETE) {
@@ -463,10 +488,10 @@ public final class EndToEndFlowSession {
 				}
 			}
 		}
-		host.fillInModes(candidate.instance);
+		host.assignSystemOperationModes(candidate.instance);
 		candidate.instance.getModesList().clear();
 		finalizing.remove(candidate);
-		finalized.put(candidate, Boolean.TRUE);
+		finalized.add(candidate);
 	}
 
 	// -------------------------------------------------------------------------
@@ -474,10 +499,10 @@ public final class EndToEndFlowSession {
 	// -------------------------------------------------------------------------
 
 	public void processETE(final ComponentInstance ci, final EndToEndFlowInstance etei, final EndToEndFlow ete) {
-		FlowIterator iter = new FlowIterator(ete);
-		EndToEndFlowSegment fe = (EndToEndFlowSegment) iter.next();
+		var iter = new FlowIterator(ete);
+		var firstSegment = (EndToEndFlowSegment) iter.next();
 
-		host.processETESegment(ci, etei, fe, iter, ete);
+		host.processETESegment(ci, etei, firstSegment, iter, ete);
 	}
 
 	/**
@@ -486,33 +511,33 @@ public final class EndToEndFlowSession {
 	 *
 	 * @param ci the component instance we're in
 	 * @param etei the current flow instance
-	 * @param fs the next flow segment
+	 * @param segment the next flow segment
 	 * @param iter the position in the current ETE declaration
 	 * @param errorElement the model element that we attach errors to
 	 */
-	public void processETESegment(ComponentInstance ci, EndToEndFlowInstance etei, Element fs, FlowIterator iter,
+	public void processETESegment(ComponentInstance ci, EndToEndFlowInstance etei, Element segment, FlowIterator iter,
 			NamedElement errorElement) {
-		TraversalState traversal = getState(etei);
-		FlowCandidate candidate = traversal.candidate;
-		Element fe = switch (fs) {
-		case FlowSegment segment -> segment.getFlowElement();
-		case EndToEndFlowSegment segment -> segment.getFlowElement();
-		default -> throw new IllegalArgumentException("Unsupported flow segment " + fs.eClass().getName());
+		var traversal = getState(etei);
+		var candidate = traversal.candidate;
+		record SegmentParts(Element flowElement, Context context) {
+		}
+		var parts = switch (segment) {
+		case FlowSegment flowSegment -> new SegmentParts(flowSegment.getFlowElement(), flowSegment.getContext());
+		case EndToEndFlowSegment eteSegment -> new SegmentParts(eteSegment.getFlowElement(), eteSegment.getContext());
+		default -> throw new IllegalArgumentException("Unsupported flow segment " + segment.eClass().getName());
 		};
 
-		if (fe instanceof Connection connection) {
+		switch (parts.flowElement()) {
+		case Connection connection -> {
 			if (etei.getFlowElements().isEmpty()) {
 				candidate.preConnections.add(connection);
 			} else {
 				traversal.connections.add(connection);
 			}
-		} else if (fe instanceof FlowSpecification flowSpecification) {
-			Subcomponent sc = (Subcomponent) switch (fs) {
-			case FlowSegment segment -> segment.getContext();
-			case EndToEndFlowSegment segment -> segment.getContext();
-			default -> throw new IllegalArgumentException("Unsupported flow segment " + fs.eClass().getName());
-			};
-			ComponentInstance sci = ci.findSubcomponentInstance(sc);
+		}
+		case FlowSpecification flowSpecification -> {
+			var sc = (Subcomponent) parts.context();
+			var sci = ci.findSubcomponentInstance(sc);
 			if (sci != null) {
 				host.processSubcomponentFlow(sci, etei, flowSpecification, iter);
 			} else {
@@ -521,15 +546,18 @@ public final class EndToEndFlowSession {
 								+ ": Could not find component instance for subcomponent " + sc.getName()
 								+ " in flow implementation " + errorElement.getName());
 			}
-		} else if (fe instanceof Subcomponent subcomponent) {
-			ComponentInstance sci = ci.findSubcomponentInstance(subcomponent);
-			host.processFlowStep(sci, etei, fe, iter);
-		} else if (fe instanceof DataAccess dataAccess) {
-			processAccess(ci, etei, dataAccess, iter);
-		} else if (fe instanceof SubprogramAccess subprogramAccess) {
-			processAccess(ci, etei, subprogramAccess, iter);
-		} else if (fe instanceof EndToEndFlow endToEndFlow) {
-			processEndToEndFlow(ci, etei, endToEndFlow, iter);
+		}
+		case Subcomponent subcomponent ->
+			host.processFlowStep(ci.findSubcomponentInstance(subcomponent), etei, subcomponent, iter);
+		/*
+		 * Only data and subprogram accesses are traversed. Another access kind, a bus access for instance, is not a
+		 * proxy for a component the flow passes through, and neither is any remaining flow element kind.
+		 */
+		case DataAccess dataAccess -> processAccess(ci, etei, dataAccess, iter);
+		case SubprogramAccess subprogramAccess -> processAccess(ci, etei, subprogramAccess, iter);
+		case EndToEndFlow endToEndFlow -> processEndToEndFlow(ci, etei, endToEndFlow, iter);
+		case null, default -> {
+		}
 		}
 	}
 
@@ -544,13 +572,13 @@ public final class EndToEndFlowSession {
 	 */
 	public void processSubcomponentFlow(final ComponentInstance ci, EndToEndFlowInstance etei,
 			final FlowSpecification fs, FlowIterator iter) {
-		FlowCandidate candidate = getCandidate(etei);
-		final ComponentImplementation subImpl = host.componentImplementation(ci);
-		final List<FlowImplementation> flowImpls = new ArrayList<>();
+		var candidate = getCandidate(etei);
+		final var subImpl = host.componentImplementation(ci);
+		final var flowImpls = new ArrayList<FlowImplementation>();
 
 		// Collect flow impls for this flow spec
 		if (subImpl != null) {
-			for (FlowImplementation fl : subImpl.getAllFlowImplementations()) {
+			for (var fl : subImpl.getAllFlowImplementations()) {
 				if (fl.getSpecification().getName().equalsIgnoreCase(fs.getName())) {
 					flowImpls.add(fl);
 				}
@@ -567,13 +595,13 @@ public final class EndToEndFlowSession {
 								+ "' has subcomponents but no flow implementation for flow '" + fs.getName() + "'");
 			}
 		} else {
-			Iterator<FlowImplementation> itt = flowImpls.iterator();
+			var itt = flowImpls.iterator();
 
 			getState(etei).continuations.push(iter);
 			while (itt.hasNext()) {
 				TraversalState stateClone = null;
 				FlowIterator iterClone = null;
-				FlowImplementation flowImpl = itt.next();
+				var flowImpl = itt.next();
 				boolean prepareNext = itt.hasNext();
 
 				if (prepareNext) {
@@ -643,8 +671,8 @@ public final class EndToEndFlowSession {
 	 */
 	public void processFlowStep(ComponentInstance ci, EndToEndFlowInstance etei, Element leaf,
 			FlowImplementation nextFlowImpl, FlowIterator iter) {
-		TraversalState traversal = getState(etei);
-		FlowCandidate candidate = traversal.candidate;
+		var traversal = getState(etei);
+		var candidate = traversal.candidate;
 		// add connection(s), will be empty when starting the ETE
 		if (traversal.connections.isEmpty()) {
 			if (!addLeafElement(ci, etei, leaf)) {
@@ -655,7 +683,7 @@ public final class EndToEndFlowSession {
 			continueFlow(ci.getContainingComponentInstance(), etei, iter, ci);
 			traversal.flowImplementations.removeLast();
 		} else {
-			List<ConnectionInstance> connis = FlowConnectionMatcher.collectConnectionInstances(ci, etei,
+			var connis = FlowConnectionMatcher.collectConnectionInstances(ci, etei,
 					traversal.connections);
 
 			if (connis.isEmpty()) {
@@ -663,7 +691,7 @@ public final class EndToEndFlowSession {
 				failCandidate(candidate);
 
 				if (!traversal.flowImplementations.isEmpty()) {
-					FlowImplementation flowFilter = traversal.flowImplementations.getLast();
+					var flowFilter = traversal.flowImplementations.getLast();
 					if (flowFilter != null) {
 						// A semantic connection was expected after the preceding flow implementation.
 						reportOwnerError(candidate,
@@ -674,22 +702,22 @@ public final class EndToEndFlowSession {
 					}
 				}
 			} else {
-				FlowImplementation flowFilter = traversal.flowImplementations.isEmpty()
+				var flowFilter = traversal.flowImplementations.isEmpty()
 						? null
 						: traversal.flowImplementations.getLast();
 
 				/*
-				 * Issue 1984: isValidContinuation() is a filter, not an error reporter. Determine the applicable
+				 * Issue 1984: the endpoint predicates are a filter, not an error reporter. Determine the applicable
 				 * connections first and report an error only when none of the candidates can continue this flow.
 				 */
-				final List<ConnectionInstance> connectionsToUse = new ArrayList<>();
-				for (final ConnectionInstance ciToCheck : connis) {
-					if ((flowFilter == null || FlowConnectionMatcher.isValidContinuation(flowFilter, ciToCheck))
+				final var connectionsToUse = new ArrayList<ConnectionInstance>();
+				for (var ciToCheck : connis) {
+					if ((flowFilter == null || FlowConnectionMatcher.startsAtFlowOutput(flowFilter, ciToCheck))
 							&& (nextFlowImpl == null
 									? (leaf instanceof FlowSpecification flowSpecification
-											? FlowConnectionMatcher.isValidContinuation(ci, ciToCheck, flowSpecification)
+											? FlowConnectionMatcher.endsAtFlowSource(ci, ciToCheck, flowSpecification)
 											: true)
-									: FlowConnectionMatcher.isValidContinuation(ciToCheck, nextFlowImpl))) {
+									: FlowConnectionMatcher.endsAtFlowInput(ciToCheck, nextFlowImpl))) {
 						connectionsToUse.add(ciToCheck);
 					}
 				}
@@ -700,13 +728,13 @@ public final class EndToEndFlowSession {
 					 * actual component connections then describe different paths.
 					 */
 					if (flowFilter == null && nextFlowImpl == null) {
-						final FlowSpecification flowSpec = (FlowSpecification) leaf;
+						final var flowSpec = (FlowSpecification) leaf;
 						reportOwnerError(candidate, "Cannot create end to end flow '" + etei.getName()
 								+ "' because there are no semantic connections that connect to the start of the flow '"
 								+ flowSpec.getName() + "' at feature '" + flowSpec.getAllInEnd().getFeature().getName()
 								+ "'");
 					} else {
-						final FlowImplementation ff = flowFilter == null ? nextFlowImpl : flowFilter;
+						final var ff = flowFilter == null ? nextFlowImpl : flowFilter;
 						reportOwnerError(candidate, "Cannot create end to end flow '" + etei.getName()
 								+ "' because there are no semantic connections that connect to the start of the flow '"
 								+ ff.getSpecification().getName() + "' at feature '"
@@ -716,11 +744,11 @@ public final class EndToEndFlowSession {
 					failCandidate(candidate);
 				} else {
 					// continue the flow along each eligible connection instance
-					Iterator<ConnectionInstance> connIter = connectionsToUse.iterator();
+					var connIter = connectionsToUse.iterator();
 					while (connIter.hasNext()) {
-						final ConnectionInstance conni = connIter.next();
+						final var conni = connIter.next();
 						final boolean prepareNext = connIter.hasNext();
-						TraversalState branchState = getState(etei);
+						var branchState = getState(etei);
 						TraversalState stateClone = null;
 						FlowIterator iterClone = null;
 
@@ -735,7 +763,7 @@ public final class EndToEndFlowSession {
 							// prepare next connection filter
 							branchState.connections.clear();
 							if (iter.hasNext()) {
-								Connection conn = getConnection(iter.next());
+								var conn = getConnection(iter.next());
 								if (conn != null) {
 									branchState.connections.add(conn);
 								}
@@ -770,14 +798,14 @@ public final class EndToEndFlowSession {
 	 * @param iter the continuation in the enclosing flow declaration
 	 */
 	private void processAccess(ComponentInstance ci, EndToEndFlowInstance etei, Access a, FlowIterator iter) {
-		TraversalState traversal = getState(etei);
-		FlowCandidate candidate = traversal.candidate;
+		var traversal = getState(etei);
+		var candidate = traversal.candidate;
 		// add connection(s), will be empty when starting the ETE
 		if (traversal.connections.isEmpty()) {
 			addLeafElement(ci, etei, a);
 			continueFlow(ci.getContainingComponentInstance(), etei, iter, ci);
 		} else {
-			List<ConnectionInstance> connis = FlowConnectionMatcher.collectConnectionInstances(ci, etei,
+			var connis = FlowConnectionMatcher.collectConnectionInstances(ci, etei,
 					traversal.connections);
 
 			if (connis.isEmpty()) {
@@ -787,9 +815,9 @@ public final class EndToEndFlowSession {
 			} else {
 				record AccessMatch(ConnectionInstance connection, ComponentInstance target, EndToEndFlowElement leaf) {
 				}
-				List<AccessMatch> matches = new ArrayList<>();
+				var matches = new ArrayList<AccessMatch>();
 				boolean invalidTarget = false;
-				for (ConnectionInstance conni : connis) {
+				for (var conni : connis) {
 					if (conni.getDestination() instanceof ComponentInstance target
 							&& (target.getCategory() == ComponentCategory.DATA
 									|| target.getCategory() == ComponentCategory.SUBPROGRAM)) {
@@ -809,28 +837,27 @@ public final class EndToEndFlowSession {
 					return;
 				}
 
-				Iterator<AccessMatch> matchIter = matches.iterator();
+				var matchIter = matches.iterator();
 				traversal.continuations.push(iter);
 				while (matchIter.hasNext()) {
-					TraversalState branchState = getState(etei);
+					var branchState = getState(etei);
 					TraversalState stateClone = null;
-					AccessMatch match = matchIter.next();
+					var match = matchIter.next();
 					boolean prepareNext = matchIter.hasNext();
 
 					if (prepareNext) {
 						stateClone = forkState(branchState);
-						etei.setName(etei.getEndToEndFlow().getName());
 					}
-					FlowIterator continuation = branchState.continuations.pop();
+					var continuation = branchState.continuations.pop();
 
 					etei.getFlowElements().add(match.connection());
 					addLeafElement(match.target(), etei, match.leaf());
 
 					// prepare next connection filter
-					Connection lastConn = branchState.connections.getLast();
+					var lastConn = branchState.connections.getLast();
 					branchState.connections.clear();
 					if (continuation.hasNext()) {
-						Connection nextConn = getConnection(continuation.next());
+						var nextConn = getConnection(continuation.next());
 						if (nextConn != null) {
 							int i = match.connection().getConnectionReferences().size() - 1;
 							Connection preConn = null;
@@ -862,17 +889,13 @@ public final class EndToEndFlowSession {
 	 */
 	private void processEndToEndFlow(ComponentInstance ci, EndToEndFlowInstance etei, EndToEndFlow ete,
 			FlowIterator iter) {
-		TraversalState traversal = getState(etei);
-		FlowCandidate candidate = traversal.candidate;
+		var traversal = getState(etei);
+		var candidate = traversal.candidate;
 
 		int cycleStart = activeDeclarations.indexOf(ete);
 		if (cycleStart >= 0) {
 			for (int i = cycleStart; i < activeDeclarations.size(); i++) {
-				FlowExpansion failedExpansion = expansions.get(activeDeclarations.get(i));
-				failedExpansion.status = ExpansionStatus.FAILED;
-				for (FlowCandidate failedCandidate : failedExpansion.candidates) {
-					failedCandidate.status = CandidateStatus.FAILED;
-				}
+				failExpansion(expansions.get(activeDeclarations.get(i)));
 			}
 			reportCandidateError(candidate,
 					"Cyclic dependency between end to end flows involving " + ete.getQualifiedName());
@@ -886,14 +909,11 @@ public final class EndToEndFlowSession {
 		}
 		FlowExpansion nestedExpansion = expansions.get(ete);
 		if (nestedExpansion.status == ExpansionStatus.FAILED) {
-			candidate.expansion.status = ExpansionStatus.FAILED;
-			for (FlowCandidate failedCandidate : candidate.expansion.candidates) {
-				failedCandidate.status = CandidateStatus.FAILED;
-			}
+			failExpansion(candidate.expansion);
 			traversal.connections.clear();
 			return;
 		}
-		List<FlowCandidate> nestedETEs = nestedExpansion.candidates.stream()
+		var nestedETEs = nestedExpansion.candidates.stream()
 				.filter(nested -> nested.status == CandidateStatus.COMPLETE)
 				.toList();
 
@@ -905,19 +925,18 @@ public final class EndToEndFlowSession {
 		// add connection(s), will be empty when starting the ETE
 		if (traversal.connections.isEmpty()) {
 			TraversalState stateClone = null;
-			Iterator<FlowCandidate> nestedIter = nestedETEs.iterator();
+			var nestedIter = nestedETEs.iterator();
 
 			traversal.continuations.push(iter);
 			while (nestedIter.hasNext()) {
-				FlowCandidate nested = nestedIter.next();
+				var nested = nestedIter.next();
 				boolean prepareNext = nestedIter.hasNext();
 
 				if (prepareNext) {
 					stateClone = forkState(getState(etei));
-					etei.setName(etei.getEndToEndFlow().getName());
 				}
-				TraversalState branchState = getState(etei);
-				FlowIterator continuation = branchState.continuations.pop();
+				var branchState = getState(etei);
+				var continuation = branchState.continuations.pop();
 
 				etei.getFlowElements().add(nested.instance);
 
@@ -925,7 +944,7 @@ public final class EndToEndFlowSession {
 				branchState.connections.clear();
 				branchState.connections.addAll(nested.postConnections);
 				if (continuation.hasNext()) {
-					Connection conn = getConnection(continuation.next());
+					var conn = getConnection(continuation.next());
 					if (conn != null) {
 						branchState.connections.add(conn);
 					}
@@ -939,7 +958,7 @@ public final class EndToEndFlowSession {
 				}
 			}
 		} else {
-			List<ConnectionInstance> connis = FlowConnectionMatcher.collectConnectionInstances(ci, etei,
+			var connis = FlowConnectionMatcher.collectConnectionInstances(ci, etei,
 					traversal.connections);
 
 			if (connis.isEmpty()) {
@@ -949,9 +968,9 @@ public final class EndToEndFlowSession {
 			} else {
 				record NestedMatch(ConnectionInstance connection, FlowCandidate nested) {
 				}
-				List<NestedMatch> matches = new ArrayList<>();
-				for (ConnectionInstance conni : connis) {
-					for (FlowCandidate nested : nestedETEs) {
+				var matches = new ArrayList<NestedMatch>();
+				for (var conni : connis) {
+					for (var nested : nestedETEs) {
 						if (FlowConnectionMatcher.isCompatibleNestedConnection(conni, nested.preConnections,
 								nested.instance)) {
 							matches.add(new NestedMatch(conni, nested));
@@ -965,19 +984,18 @@ public final class EndToEndFlowSession {
 					return;
 				}
 
-				Iterator<NestedMatch> matchIter = matches.iterator();
+				var matchIter = matches.iterator();
 				traversal.continuations.push(iter);
 				while (matchIter.hasNext()) {
 					TraversalState stateClone = null;
-					NestedMatch match = matchIter.next();
+					var match = matchIter.next();
 					boolean prepareNext = matchIter.hasNext();
 
 					if (prepareNext) {
 						stateClone = forkState(getState(etei));
-						etei.setName(etei.getEndToEndFlow().getName());
 					}
-					TraversalState branchState = getState(etei);
-					FlowIterator continuation = branchState.continuations.pop();
+					var branchState = getState(etei);
+					var continuation = branchState.continuations.pop();
 
 					// Preserve path order: the incoming connection precedes the nested flow.
 					etei.getFlowElements().add(match.connection());
@@ -987,7 +1005,7 @@ public final class EndToEndFlowSession {
 					branchState.connections.clear();
 					branchState.connections.addAll(match.nested().postConnections);
 					if (continuation.hasNext()) {
-						Connection nextConnection = getConnection(continuation.next());
+						var nextConnection = getConnection(continuation.next());
 						if (nextConnection != null) {
 							branchState.connections.add(nextConnection);
 						}
@@ -1013,7 +1031,7 @@ public final class EndToEndFlowSession {
 	 * @return whether the leaf was added successfully
 	 */
 	private boolean addLeafElement(ComponentInstance ci, EndToEndFlowInstance etei, Element leaf) {
-		FlowCandidate candidate = getCandidate(etei);
+		var candidate = getCandidate(etei);
 		FlowSpecification fs = switch (leaf) {
 		case FlowImplementation flowImplementation -> flowImplementation.getSpecification();
 		case FlowSpecification flowSpecification -> flowSpecification;
@@ -1021,7 +1039,7 @@ public final class EndToEndFlowSession {
 		};
 		if (fs != null) {
 			// append a flow specification instance
-			FlowSpecificationInstance fsi = ci.findFlowSpecInstance(fs);
+			var fsi = ci.findFlowSpecInstance(fs);
 			if (fsi != null) {
 				etei.getFlowElements().add(fsi);
 			} else {
@@ -1034,9 +1052,9 @@ public final class EndToEndFlowSession {
 				// append a subcomponent instance
 				etei.getFlowElements().add(ci);
 			} else {
-				ConnectionInstance preConn = (ConnectionInstance) etei.getFlowElements().getLast();
+				var preConn = (ConnectionInstance) etei.getFlowElements().getLast();
 				ConnectionInstanceEnd end = preConn.getDestination();
-				ComponentInstance comp = end.getContainingComponentInstance();
+				var comp = end.getContainingComponentInstance();
 				if (end instanceof ComponentInstance || comp == ci) {
 					// append a subcomponent instance
 					etei.getFlowElements().add(ci);
@@ -1058,7 +1076,7 @@ public final class EndToEndFlowSession {
 	 */
 	private void continueFlow(ComponentInstance ci, EndToEndFlowInstance etei, FlowIterator iter,
 			NamedElement errorElement) {
-		FlowCandidate candidate = getCandidate(etei);
+		var candidate = getCandidate(etei);
 		while (true) {
 			if (host.isCanceled()) {
 				canceled = true;
@@ -1070,16 +1088,17 @@ public final class EndToEndFlowSession {
 			if (activeState == null || activeState.candidate != candidate) {
 				return;
 			}
-			TraversalState traversal = activeState;
+			var traversal = activeState;
 			if (ci == null) {
-				reportExistingElementError(candidate, errorElement,
-						"Flow instance leaves system instance for flow " + getProspectivePath(candidate));
+				// The path the candidate would have had, since it is not attached and has no path of its own yet.
+				reportExistingElementError(errorElement, "Flow instance leaves system instance for flow "
+						+ candidate.owner.getInstanceObjectPath() + "." + candidate.instance.getName());
 				traversal.connections.clear();
 				return;
 			}
 			while (iter.hasNext()) {
-				Element e = iter.next();
-				host.processETESegment(ci, etei, e, iter, errorElement);
+				var segment = iter.next();
+				host.processETESegment(ci, etei, segment, iter, errorElement);
 				if (candidate.status == CandidateStatus.ABORTED || candidate.status == CandidateStatus.FAILED
 						|| activeState == null || activeState.candidate != candidate) {
 					return;
@@ -1107,12 +1126,11 @@ public final class EndToEndFlowSession {
 	}
 
 	private static Connection getConnection(Element segment) {
-		if (segment instanceof FlowSegment fs) {
-			return fs.getFlowElement() instanceof Connection connection ? connection : null;
-		}
-		if (segment instanceof EndToEndFlowSegment eefs) {
-			return eefs.getFlowElement() instanceof Connection connection ? connection : null;
-		}
-		return null;
+		return switch (segment) {
+		case FlowSegment flowSegment when flowSegment.getFlowElement() instanceof Connection connection -> connection;
+		case EndToEndFlowSegment eteSegment when eteSegment.getFlowElement() instanceof Connection connection ->
+			connection;
+		case null, default -> null;
+		};
 	}
 }

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/FlowConnectionMatcher.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/FlowConnectionMatcher.java
@@ -30,7 +30,6 @@ import java.util.List;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.osate.aadl2.Connection;
-import org.osate.aadl2.Feature;
 import org.osate.aadl2.FlowImplementation;
 import org.osate.aadl2.FlowSpecification;
 import org.osate.aadl2.instance.ComponentInstance;
@@ -48,7 +47,7 @@ import org.osate.aadl2.instance.SystemInstance;
  * <p>
  * Every method here is a pure question about a connection instance and asks nothing about how the flow was reached.
  * Discovery uses them in two ways: {@link #collectConnectionInstances} looks up the connection instances that carry a
- * pending declarative path, and the {@code isValidContinuation} predicates plus
+ * pending declarative path, and {@link #endsAtFlowInput}, {@link #endsAtFlowSource}, {@link #startsAtFlowOutput}, and
  * {@link #isCompatibleNestedConnection} decide which of those can continue the flow.
  */
 public final class FlowConnectionMatcher {
@@ -62,10 +61,10 @@ public final class FlowConnectionMatcher {
 	 */
 	public static List<ConnectionInstance> collectConnectionInstances(ComponentInstance ci, EndToEndFlowInstance etei,
 			List<Connection> connections) {
-		List<ConnectionInstance> result = new ArrayList<>();
+		var result = new ArrayList<ConnectionInstance>();
 
-		for (ConnectionInstance conni : ci.allEnclosingConnectionInstances()) {
-			if (testConnection(conni, etei, connections)) {
+		for (var conni : ci.allEnclosingConnectionInstances()) {
+			if (carriesConnectionPath(conni, etei, connections)) {
 				result.add(conni);
 			}
 		}
@@ -79,15 +78,9 @@ public final class FlowConnectionMatcher {
 	 * @param fimpl the flow implementation that must follow the connection
 	 * @return whether the connection destination is the flow input
 	 */
-	public static boolean isValidContinuation(ConnectionInstance conni, FlowImplementation fimpl) {
-		boolean result = false;
-		ConnectionInstanceEnd dst = conni.getDestination();
-		if (dst instanceof FeatureInstance featureInstance) {
-			Feature flowIn = fimpl.getInEnd().getFeature();
-			Feature connDst = featureInstance.getFeature();
-			result = flowIn == connDst;
-		}
-		return result;
+	public static boolean endsAtFlowInput(ConnectionInstance conni, FlowImplementation fimpl) {
+		return conni.getDestination() instanceof FeatureInstance destination
+				&& fimpl.getInEnd().getFeature() == destination.getFeature();
 	}
 
 	/**
@@ -99,7 +92,7 @@ public final class FlowConnectionMatcher {
 	 * @param fspec the flow specification that must follow the connection
 	 * @return whether the connection destination reaches the flow source
 	 */
-	public static boolean isValidContinuation(ComponentInstance flowComponent, ConnectionInstance conni,
+	public static boolean endsAtFlowSource(ComponentInstance flowComponent, ConnectionInstance conni,
 			FlowSpecification fspec) {
 		ConnectionInstanceEnd cie = conni.getDestination();
 		if (cie instanceof FeatureInstance conniFi) {
@@ -125,15 +118,9 @@ public final class FlowConnectionMatcher {
 	 * @param conni the connection instance
 	 * @return whether the connection source is the flow output
 	 */
-	public static boolean isValidContinuation(FlowImplementation fimpl, ConnectionInstance conni) {
-		boolean result = false;
-		ConnectionInstanceEnd src = conni.getSource();
-		if (src instanceof FeatureInstance featureInstance) {
-			Feature flowOut = fimpl.getOutEnd().getFeature();
-			Feature connSrc = featureInstance.getFeature();
-			result = flowOut == connSrc;
-		}
-		return result;
+	public static boolean startsAtFlowOutput(FlowImplementation fimpl, ConnectionInstance conni) {
+		return conni.getSource() instanceof FeatureInstance source
+				&& fimpl.getOutEnd().getFeature() == source.getFeature();
 	}
 
 	/**
@@ -150,11 +137,11 @@ public final class FlowConnectionMatcher {
 			return false;
 		}
 
-		ConnectionInstanceEnd destination = connection.getDestination();
-		ConnectionInstanceEnd nestedStart = getFirstConnectionEnd(nestedInstance);
+		var destination = connection.getDestination();
+		var nestedStart = getFirstConnectionEnd(nestedInstance);
 		if (destination instanceof FeatureInstance destinationFeature
 				&& nestedStart instanceof FeatureInstance nestedFeature) {
-			return isSameorContains(nestedFeature, destinationFeature);
+			return isSameOrContains(nestedFeature, destinationFeature);
 		}
 		if (nestedStart instanceof ComponentInstance nestedComponent) {
 			return destination == nestedComponent || destination.getComponentInstance() == nestedComponent;
@@ -172,14 +159,14 @@ public final class FlowConnectionMatcher {
 	 * @param connections the declarative connection sequence
 	 * @return whether the connection instance continues the candidate along the requested sequence
 	 */
-	private static boolean testConnection(ConnectionInstance conni, EndToEndFlowInstance etei,
+	private static boolean carriesConnectionPath(ConnectionInstance conni, EndToEndFlowInstance etei,
 			List<Connection> connections) {
-		Iterator<ConnectionReference> refIter = conni.getConnectionReferences().iterator();
-		boolean match = false;
+		var refIter = conni.getConnectionReferences().iterator();
+		var match = false;
 
 		while (refIter.hasNext()) {
-			if (isSameOrRefinedConnection(refIter.next().getConnection(), connections.get(0))) {
-				Iterator<Connection> connIter = connections.iterator();
+			if (isSameOrRefinedConnection(refIter.next().getConnection(), connections.getFirst())) {
+				var connIter = connections.iterator();
 
 				connIter.next();
 				match = true;
@@ -193,7 +180,7 @@ public final class FlowConnectionMatcher {
 		}
 		if (match && connections.size() == 1) {
 			// make sure connection instance goes in the same direction as the flow
-			ComponentInstance connci = conni.getSource().getComponentInstance();
+			var connci = conni.getSource().getComponentInstance();
 			FlowElementInstance fei = etei;
 
 			while (fei instanceof EndToEndFlowInstance nested) {
@@ -202,10 +189,10 @@ public final class FlowConnectionMatcher {
 			if (fei instanceof FlowSpecificationInstance flowSpecification) {
 				fei = flowSpecification.getComponentInstance();
 			}
-			ComponentInstance flowci = (ComponentInstance) fei;
+			var flowci = (ComponentInstance) fei;
 
 			match = false;
-			ComponentInstance ci = connci;
+			var ci = connci;
 			while (!(ci instanceof SystemInstance)) {
 				if (ci == flowci) {
 					match = true;
@@ -218,12 +205,12 @@ public final class FlowConnectionMatcher {
 			// test if the connection instance is connected to the end of the ete instance
 			// relevant if the flow goes through a port of a feature group and the connection
 			// instance comes from an expanded fg connection
-			ConnectionInstanceEnd src = conni.getSource();
+			var src = conni.getSource();
 
 			if (src instanceof FeatureInstance firstFeature) {
-				FeatureInstance lastFeature = getLastFeature(etei);
+				var lastFeature = getLastFeature(etei);
 				if (lastFeature != null) {
-					match = isSameorContains(lastFeature, firstFeature);
+					match = isSameOrContains(lastFeature, firstFeature);
 				}
 			}
 		}
@@ -239,9 +226,9 @@ public final class FlowConnectionMatcher {
 			return true;
 		}
 
-		EList<ConnectionReference> references = connectionInstance.getConnectionReferences();
+		var references = connectionInstance.getConnectionReferences();
 		for (int start = 0; start <= references.size() - connectionPath.size(); start++) {
-			boolean match = true;
+			var match = true;
 			for (int offset = 0; match && offset < connectionPath.size(); offset++) {
 				match = references.get(start + offset).getConnection() == connectionPath.get(offset);
 			}
@@ -266,7 +253,7 @@ public final class FlowConnectionMatcher {
 		return false;
 	}
 
-	private static boolean isSameorContains(FeatureInstance flowFeature, FeatureInstance connFeature) {
+	private static boolean isSameOrContains(FeatureInstance flowFeature, FeatureInstance connFeature) {
 		EObject matchme = connFeature;
 		while (matchme instanceof FeatureInstance featureInstance) {
 			if (featureInstance == flowFeature) {
@@ -278,7 +265,7 @@ public final class FlowConnectionMatcher {
 	}
 
 	private static FeatureInstance getLastFeature(EndToEndFlowInstance etei) {
-		EList<FlowElementInstance> feis = etei.getFlowElements();
+		var feis = etei.getFlowElements();
 		if (feis.isEmpty()) {
 			return null;
 		}
@@ -294,7 +281,7 @@ public final class FlowConnectionMatcher {
 	}
 
 	private static ConnectionInstanceEnd getFirstConnectionEnd(EndToEndFlowInstance etei) {
-		EList<FlowElementInstance> elements = etei.getFlowElements();
+		var elements = etei.getFlowElements();
 		if (elements.isEmpty()) {
 			return null;
 		}

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/FlowConnectionMatcher.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/FlowConnectionMatcher.java
@@ -1,0 +1,310 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.aadl2.instantiation.internal;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EObject;
+import org.osate.aadl2.Connection;
+import org.osate.aadl2.Feature;
+import org.osate.aadl2.FlowImplementation;
+import org.osate.aadl2.FlowSpecification;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.aadl2.instance.ConnectionInstance;
+import org.osate.aadl2.instance.ConnectionInstanceEnd;
+import org.osate.aadl2.instance.ConnectionReference;
+import org.osate.aadl2.instance.EndToEndFlowInstance;
+import org.osate.aadl2.instance.FeatureInstance;
+import org.osate.aadl2.instance.FlowElementInstance;
+import org.osate.aadl2.instance.FlowSpecificationInstance;
+import org.osate.aadl2.instance.SystemInstance;
+
+/**
+ * Matches the declarative connections of an end-to-end flow against the semantic connections of an instance model.
+ * <p>
+ * Every method here is a pure question about a connection instance and asks nothing about how the flow was reached.
+ * Discovery uses them in two ways: {@link #collectConnectionInstances} looks up the connection instances that carry a
+ * pending declarative path, and the {@code isValidContinuation} predicates plus
+ * {@link #isCompatibleNestedConnection} decide which of those can continue the flow.
+ */
+public final class FlowConnectionMatcher {
+
+	private FlowConnectionMatcher() {
+	}
+
+	/**
+	 * Get all enclosing connection instances that pass through the given declarative connection sequence and continue
+	 * from the candidate's current endpoint.
+	 */
+	public static List<ConnectionInstance> collectConnectionInstances(ComponentInstance ci, EndToEndFlowInstance etei,
+			List<Connection> connections) {
+		List<ConnectionInstance> result = new ArrayList<>();
+
+		for (ConnectionInstance conni : ci.allEnclosingConnectionInstances()) {
+			if (testConnection(conni, etei, connections)) {
+				result.add(conni);
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Check whether a connection instance ends at the input feature of a flow implementation.
+	 *
+	 * @param conni the connection instance
+	 * @param fimpl the flow implementation that must follow the connection
+	 * @return whether the connection destination is the flow input
+	 */
+	public static boolean isValidContinuation(ConnectionInstance conni, FlowImplementation fimpl) {
+		boolean result = false;
+		ConnectionInstanceEnd dst = conni.getDestination();
+		if (dst instanceof FeatureInstance featureInstance) {
+			Feature flowIn = fimpl.getInEnd().getFeature();
+			Feature connDst = featureInstance.getFeature();
+			result = flowIn == connDst;
+		}
+		return result;
+	}
+
+	/**
+	 * Check whether a connection instance ends at a flow specification's source feature. A connection to the source
+	 * feature itself or to a feature nested within it is accepted by walking up the feature-instance containment chain.
+	 *
+	 * @param flowComponent the component that owns the flow specification instance
+	 * @param conni the connection instance
+	 * @param fspec the flow specification that must follow the connection
+	 * @return whether the connection destination reaches the flow source
+	 */
+	public static boolean isValidContinuation(ComponentInstance flowComponent, ConnectionInstance conni,
+			FlowSpecification fspec) {
+		ConnectionInstanceEnd cie = conni.getDestination();
+		if (cie instanceof FeatureInstance conniFi) {
+			FlowSpecificationInstance fsi = flowComponent.findFlowSpecInstance(fspec);
+			if (fsi != null) {
+				FeatureInstance fsSrcFi = fsi.getSource();
+				EObject e = conniFi;
+				while (e instanceof FeatureInstance fi) {
+					if (fi == fsSrcFi) {
+						return true;
+					}
+					e = fi.eContainer();
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Check whether a connection instance starts at the output feature of a flow implementation.
+	 *
+	 * @param fimpl the flow implementation that must precede the connection
+	 * @param conni the connection instance
+	 * @return whether the connection source is the flow output
+	 */
+	public static boolean isValidContinuation(FlowImplementation fimpl, ConnectionInstance conni) {
+		boolean result = false;
+		ConnectionInstanceEnd src = conni.getSource();
+		if (src instanceof FeatureInstance featureInstance) {
+			Feature flowOut = fimpl.getOutEnd().getFeature();
+			Feature connSrc = featureInstance.getFeature();
+			result = flowOut == connSrc;
+		}
+		return result;
+	}
+
+	/**
+	 * Check whether an incoming connection reaches the start of a nested end-to-end flow variant.
+	 *
+	 * @param connection the connection instance that would precede the nested flow
+	 * @param nestedPreConnections the declarative connections the nested variant expects before its first element
+	 * @param nestedInstance the nested flow instance
+	 * @return whether the connection can continue into that nested variant
+	 */
+	public static boolean isCompatibleNestedConnection(ConnectionInstance connection,
+			List<Connection> nestedPreConnections, EndToEndFlowInstance nestedInstance) {
+		if (!containsConnectionPath(connection, nestedPreConnections)) {
+			return false;
+		}
+
+		ConnectionInstanceEnd destination = connection.getDestination();
+		ConnectionInstanceEnd nestedStart = getFirstConnectionEnd(nestedInstance);
+		if (destination instanceof FeatureInstance destinationFeature
+				&& nestedStart instanceof FeatureInstance nestedFeature) {
+			return isSameorContains(nestedFeature, destinationFeature);
+		}
+		if (nestedStart instanceof ComponentInstance nestedComponent) {
+			return destination == nestedComponent || destination.getComponentInstance() == nestedComponent;
+		}
+		return destination == nestedStart;
+	}
+
+	/**
+	 * Match a connection instance against a contiguous sequence of declarative connections. Refined connections are
+	 * considered equivalent; single-connection paths are also checked for flow direction; feature-group expansion is
+	 * checked against the candidate's last feature.
+	 *
+	 * @param conni the connection instance to test
+	 * @param etei the candidate whose current endpoint constrains the match
+	 * @param connections the declarative connection sequence
+	 * @return whether the connection instance continues the candidate along the requested sequence
+	 */
+	private static boolean testConnection(ConnectionInstance conni, EndToEndFlowInstance etei,
+			List<Connection> connections) {
+		Iterator<ConnectionReference> refIter = conni.getConnectionReferences().iterator();
+		boolean match = false;
+
+		while (refIter.hasNext()) {
+			if (isSameOrRefinedConnection(refIter.next().getConnection(), connections.get(0))) {
+				Iterator<Connection> connIter = connections.iterator();
+
+				connIter.next();
+				match = true;
+				while (match && refIter.hasNext() && connIter.hasNext()) {
+					match &= isSameOrRefinedConnection(refIter.next().getConnection(), connIter.next());
+				}
+				if (!refIter.hasNext() && connIter.hasNext()) {
+					match = false;
+				}
+			}
+		}
+		if (match && connections.size() == 1) {
+			// make sure connection instance goes in the same direction as the flow
+			ComponentInstance connci = conni.getSource().getComponentInstance();
+			FlowElementInstance fei = etei;
+
+			while (fei instanceof EndToEndFlowInstance nested) {
+				fei = nested.getFlowElements().getLast();
+			}
+			if (fei instanceof FlowSpecificationInstance flowSpecification) {
+				fei = flowSpecification.getComponentInstance();
+			}
+			ComponentInstance flowci = (ComponentInstance) fei;
+
+			match = false;
+			ComponentInstance ci = connci;
+			while (!(ci instanceof SystemInstance)) {
+				if (ci == flowci) {
+					match = true;
+					break;
+				}
+				ci = ci.getContainingComponentInstance();
+			}
+		}
+		if (match) {
+			// test if the connection instance is connected to the end of the ete instance
+			// relevant if the flow goes through a port of a feature group and the connection
+			// instance comes from an expanded fg connection
+			ConnectionInstanceEnd src = conni.getSource();
+
+			if (src instanceof FeatureInstance firstFeature) {
+				FeatureInstance lastFeature = getLastFeature(etei);
+				if (lastFeature != null) {
+					match = isSameorContains(lastFeature, firstFeature);
+				}
+			}
+		}
+		return match;
+	}
+
+	/**
+	 * Check whether a connection instance contains a declarative connection path as a contiguous sequence.
+	 */
+	private static boolean containsConnectionPath(ConnectionInstance connectionInstance,
+			List<Connection> connectionPath) {
+		if (connectionPath.isEmpty()) {
+			return true;
+		}
+
+		EList<ConnectionReference> references = connectionInstance.getConnectionReferences();
+		for (int start = 0; start <= references.size() - connectionPath.size(); start++) {
+			boolean match = true;
+			for (int offset = 0; match && offset < connectionPath.size(); offset++) {
+				match = references.get(start + offset).getConnection() == connectionPath.get(offset);
+			}
+			if (match) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean isSameOrRefinedConnection(Connection first, Connection second) {
+		for (Connection connection = first; connection != null; connection = connection.getRefined()) {
+			if (connection == second) {
+				return true;
+			}
+		}
+		for (Connection connection = second; connection != null; connection = connection.getRefined()) {
+			if (connection == first) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean isSameorContains(FeatureInstance flowFeature, FeatureInstance connFeature) {
+		EObject matchme = connFeature;
+		while (matchme instanceof FeatureInstance featureInstance) {
+			if (featureInstance == flowFeature) {
+				return true;
+			}
+			matchme = featureInstance.eContainer();
+		}
+		return false;
+	}
+
+	private static FeatureInstance getLastFeature(EndToEndFlowInstance etei) {
+		EList<FlowElementInstance> feis = etei.getFlowElements();
+		if (feis.isEmpty()) {
+			return null;
+		}
+
+		return switch (feis.getLast()) {
+		case EndToEndFlowInstance nested -> getLastFeature(nested);
+		case FlowSpecificationInstance flowSpecification -> flowSpecification.getDestination();
+		case ConnectionInstance connection -> connection.getDestination() instanceof FeatureInstance featureInstance
+				? featureInstance
+				: null;
+		case null, default -> null;
+		};
+	}
+
+	private static ConnectionInstanceEnd getFirstConnectionEnd(EndToEndFlowInstance etei) {
+		EList<FlowElementInstance> elements = etei.getFlowElements();
+		if (elements.isEmpty()) {
+			return null;
+		}
+
+		return switch (elements.getFirst()) {
+		case EndToEndFlowInstance nested -> getFirstConnectionEnd(nested);
+		case FlowSpecificationInstance flowSpecification -> flowSpecification.getSource();
+		case ConnectionInstance connection -> connection.getSource();
+		case ComponentInstance component -> component;
+		case null, default -> null;
+		};
+	}
+}

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/FlowInstantiationHost.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/FlowInstantiationHost.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.aadl2.instantiation.internal;
+
+import org.eclipse.emf.common.util.EList;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.Element;
+import org.osate.aadl2.EndToEndFlow;
+import org.osate.aadl2.FlowImplementation;
+import org.osate.aadl2.FlowSpecification;
+import org.osate.aadl2.ModalElement;
+import org.osate.aadl2.NamedElement;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.aadl2.instance.EndToEndFlowInstance;
+import org.osate.aadl2.instance.ModeInstance;
+
+/**
+ * What an {@link EndToEndFlowSession} needs from the traversal adapter that drives it.
+ * <p>
+ * {@code CreateEndToEndFlowsSwitch} is that adapter. It owns the progress monitor, the error manager, the classifier
+ * cache, and the clone counter, and it declares the protected methods a subclass may override. Every one of those
+ * methods appears here, and the session reaches its own traversal only through this interface, so an overridden step
+ * still takes effect no matter how deep in the traversal it is reached from.
+ * <p>
+ * The methods that mirror a protected step of the adapter are expected to come back into the session that called them.
+ * The remaining ones — cancellation, classifier lookup, and error reporting — are services the session cannot provide
+ * for itself.
+ */
+public interface FlowInstantiationHost {
+
+	/** Whether the user has canceled instantiation. */
+	boolean isCanceled();
+
+	/** The implementation instantiated for a component instance, with prototypes resolved, or null if there is none. */
+	ComponentImplementation componentImplementation(ComponentInstance ci);
+
+	/** Report an error against an element of a resource, which excludes candidates that are still detached. */
+	void reportError(Element target, String message);
+
+	/** Expand a nested end-to-end flow declaration in the component context that declares it. */
+	void expandNestedFlow(ComponentInstance ci, EndToEndFlow ete);
+
+	void processETE(ComponentInstance ci, EndToEndFlowInstance etei, EndToEndFlow ete);
+
+	void processETESegment(ComponentInstance ci, EndToEndFlowInstance etei, Element fs, FlowIterator iter,
+			NamedElement errorElement);
+
+	void processSubcomponentFlow(ComponentInstance ci, EndToEndFlowInstance etei, FlowSpecification fs,
+			FlowIterator iter);
+
+	boolean processFlowImpl(ComponentInstance ci, EndToEndFlowInstance etei, FlowImplementation flowImpl);
+
+	void processFlowStep(ComponentInstance ci, EndToEndFlowInstance etei, Element leaf, FlowIterator iter);
+
+	void processFlowStep(ComponentInstance ci, EndToEndFlowInstance etei, Element leaf, FlowImplementation nextFlowImpl,
+			FlowIterator iter);
+
+	/** Restart clone numbering before the variants of one declaration are named. */
+	void resetCloneCount();
+
+	/** Name one variant of a declaration that produced more than one flow instance. */
+	void setCloneName(EndToEndFlowInstance etei);
+
+	/** The mode instances a declarative element is constrained to in a component instance. */
+	EList<ModeInstance> modeInstances(ComponentInstance ci, ModalElement element);
+
+	/** Compute the system operation modes of a committed flow instance. */
+	void fillInModes(EndToEndFlowInstance etei);
+}

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/FlowInstantiationHost.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/FlowInstantiationHost.java
@@ -63,7 +63,7 @@ public interface FlowInstantiationHost {
 
 	void processETE(ComponentInstance ci, EndToEndFlowInstance etei, EndToEndFlow ete);
 
-	void processETESegment(ComponentInstance ci, EndToEndFlowInstance etei, Element fs, FlowIterator iter,
+	void processETESegment(ComponentInstance ci, EndToEndFlowInstance etei, Element segment, FlowIterator iter,
 			NamedElement errorElement);
 
 	void processSubcomponentFlow(ComponentInstance ci, EndToEndFlowInstance etei, FlowSpecification fs,
@@ -86,5 +86,5 @@ public interface FlowInstantiationHost {
 	EList<ModeInstance> modeInstances(ComponentInstance ci, ModalElement element);
 
 	/** Compute the system operation modes of a committed flow instance. */
-	void fillInModes(EndToEndFlowInstance etei);
+	void assignSystemOperationModes(EndToEndFlowInstance etei);
 }

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/FlowIterator.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/FlowIterator.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.aadl2.instantiation.internal;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.osate.aadl2.Element;
+import org.osate.aadl2.EndToEndFlow;
+import org.osate.aadl2.FlowImplementation;
+
+/**
+ * A cursor over the declarative segments of one end-to-end flow or one flow implementation.
+ * <p>
+ * The cursor is the position an end-to-end flow candidate has reached in a declaration. Because a candidate can fork,
+ * the cursor has to be copyable: {@link #copy()} returns a second cursor over the same segments at the same position,
+ * which is how a fork resumes exactly where its sibling was.
+ */
+public final class FlowIterator implements Iterator<Element> {
+
+	private final List<? extends Element> segments;
+
+	private int index;
+
+	public FlowIterator(EndToEndFlow ete) {
+		this(ete.getAllFlowSegments(), 0);
+	}
+
+	public FlowIterator(FlowImplementation flowImpl) {
+		this(flowImpl.getOwnedFlowSegments(), 0);
+	}
+
+	private FlowIterator(List<? extends Element> segments, int index) {
+		this.segments = segments;
+		this.index = index;
+	}
+
+	@Override
+	public boolean hasNext() {
+		return index < segments.size();
+	}
+
+	@Override
+	public Element next() {
+		if (!hasNext()) {
+			throw new NoSuchElementException();
+		}
+		return segments.get(index++);
+	}
+
+	FlowIterator copy() {
+		return new FlowIterator(segments, index);
+	}
+}

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/package-info.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/package-info.java
@@ -23,7 +23,8 @@
  */
 /**
  * The internals of instance model creation: the across-first enumeration of connection instances,
- * the expansion of connection arrays, and the enumeration of system operation modes.
+ * the expansion of connection arrays, the enumeration of system operation modes, and the discovery
+ * of end-to-end flow instances.
  *
  * <p>
  * {@link org.osate.aadl2.instantiation.internal.ConnectionArrayExpander} expands the connection
@@ -31,7 +32,8 @@
  * {@link org.osate.aadl2.instantiation.internal.SystemOperationModeBuilder} enumerates the system
  * operation modes of a system instance. Both are phases of {@code InstantiateModel}, which is the
  * entry point that carries the compatibility promise for them. The rest of the package is the
- * connection instance traversal described below.
+ * connection instance traversal described below, and the end-to-end flow discovery described after
+ * it.
  * </p>
  *
  * <p>
@@ -54,9 +56,31 @@
  * </p>
  *
  * <p>
+ * An end-to-end flow instance is discovered detached and attached once.
+ * </p>
+ *
+ * <p>
+ * {@link org.osate.aadl2.instantiation.internal.EndToEndFlowSession} instantiates the end-to-end
+ * flows declared by one component instance. A declaration resolves against the instance model one
+ * segment at a time and can fork wherever several flow implementations, connection instances,
+ * access targets, or nested flow variants match, so the session keeps a candidate per branch, none
+ * of them in the instance model, and attaches the ones that completed in a single commit. It uses
+ * {@link org.osate.aadl2.instantiation.internal.FlowIterator} as the branch-local cursor over a
+ * declaration, {@link org.osate.aadl2.instantiation.internal.FlowConnectionMatcher} for the
+ * stateless questions about which semantic connections carry a declarative connection path, and
+ * {@link org.osate.aadl2.instantiation.internal.EndToEndFlowModes} for the mode arithmetic.
+ * {@link org.osate.aadl2.instantiation.internal.ETEInfo} is the legacy view of a candidate, built
+ * only for a caller that asks for it. {@code CreateEndToEndFlowsSwitch} is the entry point that
+ * carries the compatibility promise, and it is also the only thing a session talks to:
+ * {@link org.osate.aadl2.instantiation.internal.FlowInstantiationHost} is the switch's protected
+ * extension points seen from inside, so an override still decides every step. Issue #3055 separated
+ * these responsibilities; {@code doc/e2e_instantiation.md} describes the result.
+ * </p>
+ *
+ * <p>
  * The package is not exported. Its types are the internal vocabulary of the phases above and carry
- * no compatibility promise; for the traversal, {@code CreateConnectionsSwitch} is the entry point
- * that does.
+ * no compatibility promise; for the connection traversal, {@code CreateConnectionsSwitch} is the
+ * entry point that does, and for end-to-end flows, {@code CreateEndToEndFlowsSwitch}.
  * </p>
  *
  * <p>

--- a/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/flows/ExtensionHookEndToEndFlowInstantiationTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/instantiation/flows/ExtensionHookEndToEndFlowInstantiationTest.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.instantiation.flows;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.EndToEndFlow;
+import org.osate.aadl2.FlowImplementation;
+import org.osate.aadl2.ModalElement;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.aadl2.instance.EndToEndFlowInstance;
+import org.osate.aadl2.instance.InstanceFactory;
+import org.osate.aadl2.instance.ModeInstance;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.CreateEndToEndFlowsSwitch;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.testsupport.Aadl2InjectorProvider;
+
+/**
+ * Pins the extension points {@code CreateEndToEndFlowsSwitch} exposes to subclasses. Instantiation is delegated to
+ * collaborators, so every hook has to be routed back through the switch to stay overridable, and calling a hook
+ * without an instantiation in progress has to fail rather than corrupt an unrelated component.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class ExtensionHookEndToEndFlowInstantiationTest extends AbstractEndToEndFlowInstantiationTest {
+	private static final String FILE = "BasicAndBranching.aadl";
+
+	@Test
+	public void testFlowImplementationHookIsCalledForEveryDescent() throws Exception {
+		SystemInstance instance = instantiate(FILE, "BranchingTop.i");
+		instance.getEndToEndFlows().clear();
+		List<String> descents = new ArrayList<>();
+
+		new CreateEndToEndFlowsSwitch(new NullProgressMonitor(), AnalysisErrorReporterManager.NULL_ERROR_MANANGER,
+				null) {
+			@Override
+			protected boolean processFlowImpl(ComponentInstance component, EndToEndFlowInstance flowInstance,
+					FlowImplementation flowImplementation) {
+				descents.add(component.getName() + "." + flowImplementation.getSpecification().getName());
+				return super.processFlowImpl(component, flowInstance, flowImplementation);
+			}
+		}.processPreOrderAll(instance);
+
+		assertEquals(List.of("branched_1", "branched_2"), flowNames(instance));
+		assertEquals(List.of("choice.fpath", "choice.fpath"), descents);
+	}
+
+	@Test
+	public void testCloneNamingHooksNameBranchedFlows() throws Exception {
+		SystemInstance instance = instantiate(FILE, "BranchingTop.i");
+		instance.getEndToEndFlows().clear();
+		List<String> calls = new ArrayList<>();
+
+		new CreateEndToEndFlowsSwitch(new NullProgressMonitor(), AnalysisErrorReporterManager.NULL_ERROR_MANANGER,
+				null) {
+			private int count;
+
+			@Override
+			protected void resetETECloneCount() {
+				calls.add("reset");
+				count = 0;
+				super.resetETECloneCount();
+			}
+
+			@Override
+			protected void setCloneName(EndToEndFlowInstance flowInstance) {
+				calls.add("name");
+				flowInstance.setName(flowInstance.getEndToEndFlow().getName() + "_variant" + ++count);
+			}
+		}.processPreOrderAll(instance);
+
+		assertEquals(List.of("branched_variant1", "branched_variant2"), flowNames(instance));
+		assertEquals(List.of("reset", "name", "name"), calls);
+	}
+
+	@Test
+	public void testModeHooksApplyToEveryCommittedFlow() throws Exception {
+		SystemInstance instance = instantiate(FILE, "BranchingTop.i");
+		instance.getEndToEndFlows().clear();
+		List<String> resolved = new ArrayList<>();
+		List<String> finalized = new ArrayList<>();
+
+		new CreateEndToEndFlowsSwitch(new NullProgressMonitor(), AnalysisErrorReporterManager.NULL_ERROR_MANANGER,
+				null) {
+			@Override
+			protected EList<ModeInstance> getModeInstances(ComponentInstance component, ModalElement element) {
+				resolved.add(element.eClass().getName());
+				return super.getModeInstances(component, element);
+			}
+
+			@Override
+			protected void fillinModes(EndToEndFlowInstance flowInstance) {
+				finalized.add(flowInstance.getName());
+				super.fillinModes(flowInstance);
+			}
+		}.processPreOrderAll(instance);
+
+		assertEquals(List.of("branched_1", "branched_2"), flowNames(instance));
+		assertEquals(List.of("EndToEndFlow", "FlowImplementation", "FlowImplementation"), resolved);
+		assertEquals(List.of("branched_1", "branched_2"), finalized);
+	}
+
+	@Test
+	public void testTraversalHookWithoutActiveInstantiationFails() throws Exception {
+		SystemInstance instance = instantiate(FILE, "BasicTop.i");
+		EndToEndFlow declaration = flow(instance, "explicit").getEndToEndFlow();
+		EndToEndFlowInstance detached = InstanceFactory.eINSTANCE.createEndToEndFlowInstance();
+		detached.setName(declaration.getName());
+		detached.setEndToEndFlow(declaration);
+		HookAccess hookAccess = new HookAccess();
+
+		IllegalStateException exception = assertThrows(IllegalStateException.class,
+				() -> hookAccess.callProcessETE(instance, detached, declaration));
+
+		assertEquals("No active end-to-end flow instantiation context", exception.getMessage());
+	}
+
+	private static final class HookAccess extends CreateEndToEndFlowsSwitch {
+		HookAccess() {
+			super(new NullProgressMonitor(), AnalysisErrorReporterManager.NULL_ERROR_MANANGER, null);
+		}
+
+		void callProcessETE(ComponentInstance component, EndToEndFlowInstance flowInstance, EndToEndFlow flow) {
+			processETE(component, flowInstance, flow);
+		}
+	}
+}


### PR DESCRIPTION
Fixes #3055

## Cause and correction

`CreateEndToEndFlowsSwitch` was about 1600 lines and combined the instance traversal, per-component candidate discovery, nested-flow expansion, diagnostics, atomic commit, connection matching, and mode computation. The traversal and atomicity invariants introduced by #3005 could not be reviewed in isolation from the connection matching around them.

The switch stays the public entry point and keeps every protected extension point with its current signature. It visits component instances, resolves their implementation through the classifier cache, watches the progress monitor, reports errors, counts clone names, and holds the active session. The new collaborators live in the existing non-exported `org.osate.aadl2.instantiation.internal` package, next to the connection traversal from #3037:

| Type | Owns |
|---|---|
| `EndToEndFlowSession` | one component instance's discovery: candidates, traversal state, expansion, deferred diagnostics, and the single atomic commit — the former `FlowInstantiationContext` merged with the traversal |
| `FlowConnectionMatcher` | the stateless connection lookup and endpoint predicates |
| `EndToEndFlowModes` | mode resolution and system-operation-mode computation |
| `FlowInstantiationHost` | the switch's protected extension points as the session sees them |
| `FlowIterator`, `ETEInfo` | moved out of the switch |

Extension behavior is preserved structurally rather than reimplemented. The session never calls its own traversal steps or the mode computation directly; both leave through `FlowInstantiationHost`, implemented by a private inner class of the switch that forwards to the protected methods. An override therefore still decides every step, at any traversal depth, and resolving the session for a protected step fails with the same `IllegalStateException` as before when no instantiation is in progress.

The moved method bodies were diffed mechanically against the original and are unchanged apart from reading session fields directly, dropping the context parameter, taking the nested candidate's connections and instance instead of the candidate, and collecting flow implementations in an `ArrayList` instead of a `BasicEList`.

The third commit is a quality pass over the result: `failExpansion` replaces three copies of failing a whole declaration, `processETESegment` resolves the flow element and the context in one switch, the rollback snapshots become one map to a record, `PendingDiagnostic` becomes a sealed interface with one record per target so the replay switch is exhaustive without a default, two `instanceof` chains become pattern switches that keep an explicit null case, `var` replaces types their initializer already names, and the three `isValidContinuation` overloads — which differed only in argument order — become `endsAtFlowInput`, `startsAtFlowOutput`, and `endsAtFlowSource`. It also removes three `setName` calls in the fork idiom that assigned the name a candidate already had, since a candidate's name is its declaration's name throughout discovery.

## Tests

`ExtensionHookEndToEndFlowInstantiationTest` is committed first and asserts, against the pre-refactoring implementation, the extension behavior that has to survive:

- a `processFlowImpl` override sees every descent into a flow implementation (`BranchingTop.i`, both `Choice.two_paths` implementations)
- `resetETECloneCount` and `setCloneName` drive the naming of branched flows, in that order
- `getModeInstances` is consulted for the declaration and for each flow implementation, and `fillinModes` for each committed flow
- `processETE` without an instantiation in progress throws `IllegalStateException("No active end-to-end flow instantiation context")` instead of touching an unrelated component

The existing suites in `core/org.osate.core.tests/src/org/osate/core/tests/instantiation/flows/` and the flow issue tests are the behavioral net for the rest; no existing test or expected message changed.

## Validation

All run outside the sandbox.

- `mvn -s releng/osate.releng/settings.xml -Plocal -pl :org.osate.core.tests -Dtycho.localArtifacts=default -Dpr.build=true -DfailIfNoTests=false -Dtest=*EndToEndFlowInstantiationTest,Issue612Test,Issue1936Test,Issue1953Test,Issue1984Test,Issue2606Test,Issue2780Test,Issue2872Test,Issue2985Test,Issue2986Test,Issue2987Test,Issue2988Test,Issue2991Test,Issue3032Test,Issue3037ModeAndFlowTest clean install` — 22 classes selected, all green, non-zero counts in every Surefire report.
- Whole `org.osate.core.tests` bundle: 793 tests, 0 failures, 0 errors.
- `-Dspotbugs=true` on `org.osate.aadl2.instantiation`: 0 bug instances.
- Clean root reactor, `mvn -s releng/osate.releng/settings.xml -Plocal -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -DfailIfNoTests=false clean install` — 137 modules SUCCESS, 1388 tests, 0 failures, 0 errors, clean worktree.

## Documented API change

`ETEInfo` and `FlowIterator` moved to the non-exported `internal` package, so the protected members naming them — `instantiateEndToEndFlow`, `processETESegment`, `processSubcomponentFlow`, and both `processFlowStep` overloads — remain overridable only from inside the bundle. That was already true when both types were package-private members of the switch, and `org.osate.core.tests` compiles subclasses of the switch without access to `internal`. The hooks reachable from another bundle are unchanged: `processETE`, `processFlowImpl`, `setCloneName`, `resetETECloneCount`, `getModeInstances`, and `fillinModes`. `fillinModes` keeps its historical name deliberately: renaming an overridable method would silently stop calling an existing subclass's override.

`doc/e2e_instantiation.md` gains the type/package table and a §4.1 on the ownership boundaries, and the internal `package-info.java` gains the flow-discovery paragraph.

## Dependencies and residual risk

Depends on #3005, which is merged; this branch is based on current `master` and stacks on nothing unmerged.

Residual risk is concentrated in the fork idiom, which is repeated at five sites and was deliberately **not** factored out: the sites differ in whether they copy the iterator or pop a continuation, so a shared driver would need flags threaded through the traversal's most delicate control flow. #3055 explicitly warns against that restructuring, so it is left for a separate change. Discovery order, naming, diagnostic text and targets, cancellation, and commit and rollback semantics are all unchanged, and the characterization suites assert them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)