### PR TITLE
Skip connections and end-to-end flows in referenced classifiers 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/doc/connection_instantiation.md
+++ b/core/org.osate.aadl2.instantiation/doc/connection_instantiation.md
@@ -91,8 +91,9 @@ InstantiateModel.fillSystemInstance(root)
  └────────────────────────────────────────────────────────────────────────┘
 ```
 
-`InstantiateModel.finalizeConnections()` runs steps 3 to 5 for every root of the instance
-resource, the system instance and any instance of a referenced classifier.
+`InstantiateModel.prepareForAnnexes()` runs steps 3 to 7 for the system instance. Additional roots
+that represent referenced classifiers skip connection and end-to-end-flow instantiation; only their
+properties and annexes are instantiated because they have no system operation modes.
 
 `CreateConnectionsSwitch` extends `AadlProcessingSwitchWithProgress` with
 `PROCESS_PRE_ORDER_ALL`, so its `caseComponentInstance` fires for every component instance.

--- a/core/org.osate.aadl2.instantiation/doc/e2e_instantiation.md
+++ b/core/org.osate.aadl2.instantiation/doc/e2e_instantiation.md
@@ -70,8 +70,8 @@ InstantiateModel.fillSystemInstance(root)
 ```
 
 `InstantiateModel` invokes the switch as `new CreateEndToEndFlowsSwitch(...).processPreOrderAll(root)`
-from two places: once for the system instance, and once again when instantiating sub-instances of
-referenced classifiers.
+for the system instance. Additional roots that represent referenced classifiers bypass this phase
+because they have no system operation modes.
 
 The switch extends `AadlProcessingSwitchWithProgress` and is constructed with
 `PROCESS_PRE_ORDER_ALL`, so its `InstanceSwitch.caseComponentInstance` fires for **every**

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
@@ -160,8 +160,8 @@ public class InstantiateModel {
 	 * The roots of the instance model in the order they were discovered. The first one is the system
 	 * instance, the others are the instances of referenced classifiers created by
 	 * {@link #instantiateFeatureClassifier(FeatureInstance, FeatureClassifier)}, which is the only place
-	 * that adds a root to the instance resource. All of them go through the same phases, see
-	 * {@link #fillSystemInstance(SystemInstance)}.
+	 * that adds a root to the instance resource. The system root goes through connection and end to end
+	 * flow instantiation; referenced roots retain only their hierarchy, properties and annex instances.
 	 * <p>
 	 * The list is emptied at the start of every {@link #fillSystemInstance(SystemInstance)} call. It has
 	 * to be a field rather than a local because
@@ -172,15 +172,15 @@ public class InstantiateModel {
 	private final List<InstantiationRoot> roots = new ArrayList<>();
 
 	/**
-	 * A root of the instance model, and whether it still has to be brought to its final connections. A
-	 * root is populated as soon as it is discovered, because that is what discovers further roots, but
-	 * the remaining phases run from the queue, and the flag keeps a root that is discovered late from
-	 * being processed twice. Which roots still need their annexes is tracked by the index into
+	 * A root of the instance model, and whether it has been prepared for annex instantiation. A root is
+	 * populated as soon as it is discovered, because that is what discovers further roots, but the
+	 * remaining phases run from the queue, and the flag keeps a root that is discovered late from being
+	 * prepared twice. Which roots still need their annexes is tracked by the index into
 	 * {@link #roots} in {@link #fillSystemInstance(SystemInstance)}.
 	 */
 	private static final class InstantiationRoot {
 		private final ComponentInstance root;
-		private boolean connectionsFinalized;
+		private boolean preparedForAnnexes;
 
 		private InstantiationRoot(ComponentInstance root) {
 			this.root = root;
@@ -469,16 +469,16 @@ public class InstantiateModel {
 		createSystemOperationModes(root, somLimit);
 
 		/*
-		 * Bring every root to its final connections and cached properties before any annex is
-		 * instantiated. Otherwise an annex on one root could observe another root whose connections are
-		 * still the provisional ones created before expansion. The queue can grow while we work on it, so
-		 * use indexed access and re-establish the barrier if annex instantiation discovers another root.
+		 * Finalize the system root's connections and cache every root's properties before any annex is
+		 * instantiated. Otherwise an annex on one root could observe the system root while its connections
+		 * are still the provisional ones created before expansion. The queue can grow while we work on it,
+		 * so use indexed access and re-establish the barrier if annex instantiation discovers another root.
 		 */
 		AnnexInstantiationController aic = new AnnexInstantiationController(errManager);
 		int annexed = 0;
 		while (annexed < roots.size()) {
 			for (int i = 0; i < roots.size(); i++) {
-				finalizeConnections(roots.get(i));
+				prepareForAnnexes(roots.get(i));
 			}
 			final int fixedPoint = roots.size();
 			monitor.subTask("Instantiating annexes");
@@ -490,8 +490,11 @@ public class InstantiateModel {
 	}
 
 	/**
-	 * Create the connection instances of a root, expand them into the final connection set, then
-	 * validate the result, build the end to end flows over it, and cache the properties on it.
+	 * Prepare one instance-resource root for annex instantiation. For the system instance, create the
+	 * connection instances, expand them into the final connection set, validate the result, build the
+	 * end to end flows over it, and cache its properties. For a referenced classifier root, cache its
+	 * properties without instantiating connections or end to end flows: those semantic instances belong
+	 * to a system instance and depend on its system operation modes.
 	 * <p>
 	 * The expansion of arrays, {@code Connection_Pattern} and {@code Connection_Set} replaces the
 	 * provisional connection instances and deletes them. It has to happen before validation and before
@@ -500,12 +503,16 @@ public class InstantiateModel {
 	 * <p>
 	 * Does nothing if the root already went through this phase.
 	 */
-	private void finalizeConnections(InstantiationRoot pending) throws InterruptedException {
-		if (pending.connectionsFinalized) {
+	private void prepareForAnnexes(InstantiationRoot pending) throws InterruptedException {
+		if (pending.preparedForAnnexes) {
 			return;
 		}
-		pending.connectionsFinalized = true;
+		pending.preparedForAnnexes = true;
 		final ComponentInstance root = pending.root;
+		if (!(root instanceof SystemInstance)) {
+			cacheProperties(root);
+			return;
+		}
 
 		new CreateConnectionsSwitch(monitor, errManager, classifierCache).processPreOrderAll(root);
 		checkCanceled();
@@ -1316,9 +1323,8 @@ public class InstantiateModel {
 				fi.setType(newInstance);
 				/*
 				 * Only establish the hierarchy, which is what discovers further referenced classifiers, and
-				 * hand the new root to the common pipeline. Creating its connections, validating them,
-				 * building its flows, or instantiating its annexes here would run those phases for this root
-				 * before any root has its final connections.
+				 * hand the new root to the common property and annex pipeline. Connections and end to end flows
+				 * are not instantiated for a referenced root because it has no system operation modes.
 				 */
 				populateComponentInstance(newInstance, 0);
 				roots.add(new InstantiationRoot(newInstance));

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/SeedDiscovery.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/SeedDiscovery.java
@@ -139,7 +139,7 @@ public final class SeedDiscovery {
 	 * <p>
 	 * A declaration inside an array of components is enumerated once, for the first
 	 * element, and the connection instance it produces is replicated to the other elements
-	 * by {@code InstantiateModel.finalizeConnections()}. Seeding every element instead
+	 * by the connection-expansion phase in {@code InstantiateModel}. Seeding every element instead
 	 * would look equivalent but is not: a replica is named with {@code " --> "} and has its
 	 * reference contexts relocated, so enumerating it directly changes an externally
 	 * visible name.

--- a/core/org.osate.core.tests/models/issue3033/.gitignore
+++ b/core/org.osate.core.tests/models/issue3033/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3033/.project
+++ b/core/org.osate.core.tests/models/issue3033/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3033</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3033/Issue3033.aadl
+++ b/core/org.osate.core.tests/models/issue3033/Issue3033.aadl
@@ -1,0 +1,52 @@
+package Issue3033
+public
+	abstract Producer
+	features
+		outp: out data port;
+	flows
+		fsrc: flow source outp;
+	end Producer;
+
+	abstract Consumer
+	features
+		inp: in data port;
+	flows
+		fsnk: flow sink inp;
+	end Consumer;
+
+	abstract Inner
+	end Inner;
+
+	-- The classifier of a feature is instantiated as a root beside the system instance. Connections and
+	-- end to end flows in that root must not be instantiated because it has no system operation modes.
+	abstract implementation Inner.i
+	subcomponents
+		producer: abstract Producer;
+		consumer: abstract Consumer;
+	connections
+		c: port producer.outp -> consumer.inp;
+	flows
+		etef: end to end flow producer.fsrc -> c -> consumer.fsnk;
+	end Inner.i;
+
+	thread Holder
+	features
+		af: feature Inner.i;
+	end Holder;
+
+	process Wrapper
+	end Wrapper;
+
+	process implementation Wrapper.i
+	subcomponents
+		holder: thread Holder;
+	end Wrapper.i;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+	subcomponents
+		wrapper: process Wrapper.i;
+	end Top.i;
+end Issue3033;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3033Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3033Test.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such separate license file distributed with such Third Party Software. The parties who
+ * own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries to this license with
+ * respect to the terms applicable to such Third Party Software. Third Party Software licenses only apply to the Third
+ * Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.aadl2.instance.EndToEndFlowInstance;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.core.tests.instantiation.InstanceRoots;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * Connections and end to end flows belong to a system instance. Referenced feature classifiers are
+ * represented by additional component-instance roots, but those roots have no system operation modes
+ * in which connections or flows could be instantiated.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3033Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3033/Issue3033.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void referencedClassifierHasNoConnectionsOrEndToEndFlows() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+		ComponentImplementation implementation = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		var errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+
+		SystemInstance instance = InstantiateModel.instantiate(implementation, errorManager);
+
+		assertNotNull(instance);
+		ComponentInstance referenced = InstanceRoots.referenced(instance)
+				.stream()
+				.filter(root -> root.getName().equals("Issue3033::Inner.i"))
+				.findFirst()
+				.orElseThrow();
+		assertEquals(List.of("consumer", "producer"),
+				referenced.getComponentInstances().stream().map(ComponentInstance::getName).sorted().toList());
+		assertEquals(List.of(), referenced.getAllConnectionInstances());
+		assertEquals(List.of(), collectEndToEndFlows(referenced, new ArrayList<>()));
+		assertEquals(List.of(),
+				((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource())).getErrors());
+	}
+
+	private static List<EndToEndFlowInstance> collectEndToEndFlows(ComponentInstance component,
+			List<EndToEndFlowInstance> result) {
+		result.addAll(component.getEndToEndFlows());
+		component.getComponentInstances().forEach(child -> collectEndToEndFlows(child, result));
+		return result;
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3037ReferencedRootTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3037ReferencedRootTest.java
@@ -51,18 +51,16 @@ import com.itemis.xtext.testing.XtextTest;
  * <p>
  * A feature whose classifier resolves to a component classifier makes instantiation create
  * that classifier as a further root beside the system instance. Every model whose ports have
- * a data classifier has one, and since the Plan 1 pipeline change those roots go through the
- * same phases as the system instance, so the characterization harness snapshots every root of
- * the instance resource rather than the system instance alone. Before that it compared
- * nothing inside a referenced root at all.
+ * a data classifier has one. The characterization harness snapshots every root of the instance
+ * resource rather than the system instance alone, so it also compares the populated hierarchy of
+ * each referenced classifier. Before that it compared nothing inside a referenced root at all.
  * </p>
  *
  * <p>
- * A referenced root with connections inside it is deliberately not covered: instantiation
- * crashes on that shape, and it did before issue #3037 as well, so it is follow-on work rather
- * than something this test can hold. What is covered here is that the roots exist, that they
- * carry their subcomponents and features, and what a system whose ports are typed by such a
- * classifier produces.
+ * Connections and end to end flows declared inside a referenced root are covered by
+ * {@code Issue3033Test}: they are not instantiated because the referenced root has no system
+ * operation modes. What is covered here is that the roots exist, that they carry their subcomponents
+ * and features, and what a system whose ports are typed by such a classifier produces.
  * </p>
  */
 @RunWith(XtextRunner.class)
@@ -104,7 +102,7 @@ public class Issue3037ReferencedRootTest extends XtextTest {
 		assertEquals(List.of("feeder.worker.outp -> drain.worker.inp"), connectionNames(run.instance()));
 		assertEquals(List.of("ReferencedClassifiers::Element", "ReferencedClassifiers::Payload.i"),
 				referencedRootNames(run));
-		assertEquals("a referenced root with connections is excluded from characterization", List.of(),
+		assertEquals("the referenced classifier declares no connections", List.of(),
 				connectionNames(referencedRoot(run)));
 	}
 


### PR DESCRIPTION
Fixes #3033

## Cause and correction

`InstantiateModel` sent every instance-resource root through connection creation, expansion, validation, and end-to-end-flow creation. Referenced classifier roots are plain `ComponentInstance` objects and have no system operation modes, so connection mode resolution walked beyond the root and dereferenced `null`.

`prepareForAnnexes()` now runs the connection and end-to-end-flow pipeline only for the actual `SystemInstance`. Referenced classifier roots still populate their component hierarchy and retain property caching and annex instantiation.

## Regression

`Issue3033Test` instantiates a valid model whose referenced feature classifier declares both a connection and an end-to-end flow. It asserts that instantiation succeeds, the referenced root retains its producer and consumer, no connection or end-to-end-flow instances are created there, and no diagnostics are reported.

Before the fix, the regression failed in `CreateConnectionsSwitch.getComponentModes()` with the reported `NullPointerException`.

## Validation

- Focused offline `Issue3033Test`: 1 test passed.
- Related offline `Issue3032Test`: 6 tests passed.
- Referenced-root `Issue3037ReferencedRootTest`: 3 tests passed.
- Clean offline root reactor with `-Dtycho.localArtifacts=ignore`: 137 modules and 1,389 tests passed with zero failures, errors, or skips.

## Dependencies and residual risk

No dependent PRs or required merge order. The deliberate semantic change is that declarative connections and end-to-end flows inside referenced classifier roots are not instantiated; their hierarchy, properties, and annexes remain available.