### PR TITLE
Reject connection patterns with too few dimensions 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/ConnectionArrayExpander.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/ConnectionArrayExpander.java
@@ -398,10 +398,17 @@ public final class ConnectionArrayExpander {
 		 * Create the connection instances of the dimension the expansion is at and of every dimension
 		 * inside it.
 		 *
-		 * @return whether the connection instance was expanded, which means that it has to be deleted; a
-		 *         reported failure leaves it in place, because it has no replacement then
+		 * @return whether the provisional connection instance has to be deleted; a short pattern is rejected
+		 *         without a replacement, while failures that may still describe one scalar connection leave it
+		 *         in place
 		 */
 		private boolean expand() {
+			if (patterns != null && offset == 0
+					&& patterns.size() < Math.max(srcSizes.size(), dstSizes.size())) {
+				errManager.error(conni.getContainingComponentInstance(),
+						"Connection pattern has fewer dimensions than its array ends");
+				return true;
+			}
 			if (patterns != null ? offset >= patterns.size()
 					: srcOffset == srcSizes.size() && dstOffset == dstSizes.size()) {
 				createNewConnection(conni, srcIndices, dstIndices);

--- a/core/org.osate.core.tests/models/issue3052/.gitignore
+++ b/core/org.osate.core.tests/models/issue3052/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3052/.project
+++ b/core/org.osate.core.tests/models/issue3052/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3052</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3052/Issue3052.aadl
+++ b/core/org.osate.core.tests/models/issue3052/Issue3052.aadl
@@ -1,0 +1,25 @@
+package Issue3052
+public
+	thread Producer
+	features
+		outp: out data port;
+	end Producer;
+
+	thread Consumer
+	features
+		inp: in data port;
+	end Consumer;
+
+	process Top
+	end Top;
+
+	process implementation Top.i
+	subcomponents
+		producers: thread Producer[2][2];
+		consumers: thread Consumer[2][2];
+	connections
+		c: port producers.outp -> consumers.inp {
+			Communication_Properties::Connection_Pattern => ((One_To_One));
+		};
+	end Top.i;
+end Issue3052;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3037StructuralFailureTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3037StructuralFailureTest.java
@@ -86,34 +86,16 @@ public class Issue3037StructuralFailureTest extends XtextTest {
 	 * A pattern with fewer dimensions than the arrays it has to replicate over.
 	 *
 	 * <p>
-	 * Expansion neither replicates nor gives up: it reports the mismatch, falls back to the
-	 * first array element for each end, and leaves two connection instances that are identical
-	 * in name and endpoints, which validation then reports as more than one connection ending
-	 * at the same data port. Thirteen of the sixteen element pairs the arrays could have are
-	 * absent. This is what 2.18.0 produced too, so it is structural expansion's behavior and
-	 * not the traversal's; it is recorded here so that a change to it shows up as a failure,
-	 * and fixing it is separate work.
+	 * Expansion rejects the incomplete pattern with one diagnostic and leaves no connection instances.
+	 * This used to fall back to the first element of each end twice, which issue #3052 corrected.
 	 * </p>
 	 */
 	@Test
-	public void aPatternWithTooFewIndicesAgrees() throws Exception {
-		assertConnections("TooFewIndices.i", "producers[1][1].outp --> consumers[1][1].inp",
-				"producers[1][1].outp --> consumers[1][1].inp");
-		assertConnections("Top.tooFewIndices", "producers[1][1].outp --> consumers[1][1].inp",
-				"producers[1][1].outp --> consumers[1][1].inp");
+	public void aPatternWithTooFewIndicesIsRejected() throws Exception {
+		assertConnections("TooFewIndices.i");
+		assertConnections("Top.tooFewIndices");
 
-		assertEquals(List.of(
-				"Error | For c : producers[1][1].outp -> consumers[1][1].inp,"
-						+ " destination indices [1] do not match destination dimension 2",
-				"Error | For c : producers[1][1].outp -> consumers[1][1].inp,"
-						+ " destination indices [2] do not match destination dimension 2",
-				"Error | More than one connection instance ends at data port",
-				"Error | More than one connection instance ends at data port"
-						+ " TooFewIndices_i_Instance.consumers[1][1].inp",
-				"Error | Source indices [1] do not match source dimension 2",
-				"Error | Source indices [2] do not match source dimension 2",
-				"Warning | There is already another connection between the same endpoints",
-				"Warning | Too few indices for connection end, using first array element"),
+		assertEquals(List.of("Error | Connection pattern has fewer dimensions than its array ends"),
 				messages("TooFewIndices.i"));
 	}
 

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3052Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3052Test.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.core.tests.instantiation.InstanceCharacterization;
+import org.osate.core.tests.instantiation.InstanceReport;
+import org.osate.core.tests.instantiation.InstanceSnapshot;
+import org.osate.core.tests.instantiation.IsolatedInstantiation;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3052Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3052/Issue3052.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Inject
+	private IsolatedInstantiation isolated;
+
+	@Test
+	public void shortConnectionPatternCreatesNoConnections() throws Exception {
+		validationHelper.assertNoIssues(testHelper.parseFile(MODEL));
+		InstanceCharacterization.assertConnections(isolated, MODEL, "Top.i");
+
+		var run = isolated.run(MODEL, "Top.i");
+		assertEquals(List.of("Error | Connection pattern has fewer dimensions than its array ends"),
+				InstanceReport.diagnosticSet(InstanceSnapshot.of(run.instance(), run.errorManager()))
+						.stream()
+						.map(line -> line.substring(0, line.indexOf(" | at ")))
+						.distinct()
+						.sorted()
+						.toList());
+	}
+}


### PR DESCRIPTION
## Summary

- Reject a connection pattern whose declared dimensions do not cover either endpoint array.
- Report one diagnostic against the surviving component instance and remove the invalid provisional connection.
- Preserve valid One_To_All and All_To_One expansion behavior.

Fixes #3052

## Cause and correction

PatternExpansion.expand() treated exhaustion of the explicit pattern list as a successful base case even when an endpoint still had dimensions. The resulting partial index lists were resolved through the first array element, producing duplicate connections.

The expansion now compares the declared pattern count with the larger endpoint dimension count before recursion. An underspecified pattern produces one error and deletes the provisional connection without replacements. This entry check avoids rejecting valid fan patterns, where one endpoint intentionally does not consume an index for a dimension.

## Regression

Issue3052Test uses a separate valid AADL model project with two-dimensional producer and consumer arrays and a one-dimensional One_To_One pattern. Before the fix, it observed two identical [1][1] connections. It now asserts zero connections and exactly one dimension-mismatch diagnostic.

The existing issue #3037 structural-failure characterization was updated for the rejected result, while its feature-array fan-out tests remain unchanged and passing.

## Validation

All Maven commands ran offline.

- Issue3052Test: 1 test, 0 failures
- Issue3037StructuralFailureTest: 4 tests, 0 failures
- Issue3037FeatureArrayTest: 4 tests, 0 failures
- ConnectionPatternInstantiationTest: 19 tests, 0 failures
- Clean root-reactor install with -Dtycho.localArtifacts=ignore: BUILD SUCCESS across all 137 projects

Root validation command:

    mvn -o -s releng/osate.releng/settings.xml -Plocal -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -DfailIfNoTests=false clean install

## Dependencies and residual risk

The prerequisite issue #3037 was merged by PR #3053, so this PR has no outstanding merge dependency.

The selected behavior is to reject the incomplete mapping rather than infer missing dimensions. The diagnostic is attached to the containing component instance because the invalid connection instance is removed.