### PR TITLE
Expand flow specification instances over feature arrays 🤖

### DIFF
--- a/core/org.osate.aadl2.instance.textual.tests/src/org/osate/aadl2/instance/textual/tests/Serializer1Test.java
+++ b/core/org.osate.aadl2.instance.textual.tests/src/org/osate/aadl2/instance/textual/tests/Serializer1Test.java
@@ -719,6 +719,13 @@ public class Serializer1Test extends AbstractSerializerTest {
 		//@formatter:on
 	}
 
+	/**
+	 * {@code f4} is a flow sink on a feature array, so it has one flow specification instance per array
+	 * element, named {@code f4_1} and {@code f4_2} (issue #2787). {@code f6} and {@code f7} are not
+	 * expanded: {@code p5} is an array declared inside a feature group type, where an array is not allowed
+	 * and is instantiated as a single feature, and {@code f7}'s end is a feature reached through an array
+	 * feature group rather than an array feature itself.
+	 */
 	@Test
 	public void testFlowSpecification() throws Exception {
 		var pkg1 = testHelper.parseString("""
@@ -793,7 +800,8 @@ public class Serializer1Test extends AbstractSerializerTest {
 					flow f1 ( -> p2 ) : pkg1::s:f1
 					flow f2 ( p1 -> ) : pkg1::s:f2
 					flow f3 ( p1 -> p2 ) : pkg1::s:f3
-					flow f4 ( p3[1] -> ) : pkg1::s:f4
+					flow f4_1 ( p3[1] -> ) : pkg1::s:f4
+					flow f4_2 ( p3[2] -> ) : pkg1::s:f4
 					flow f5 ( fg1.p4 -> ) : pkg1::s:f5
 					flow f6 ( fg1.p5 -> ) : pkg1::s:f6
 					flow f7 ( fg2[1].p6 -> ) : pkg1::s:f7

--- a/core/org.osate.aadl2.instantiation/doc/connection_instantiation.md
+++ b/core/org.osate.aadl2.instantiation/doc/connection_instantiation.md
@@ -82,18 +82,20 @@ InstantiateModel.fillSystemInstance(root)
  │ 2. createSystemOperationModes()  → SystemOperationMode list            │
  │ 3. CreateConnectionsSwitch       → ConnectionInstances            ◄── us│
  │      seeds → legs → paths → expansion → materialization → modes/SOMs   │
- │ 4. cacheStructuralConnectionProperties() + processConnections()         │
+ │ 4. cacheStructuralProperties() + processConnections()                   │
  │      → array replication, Connection_Pattern, Connection_Set           │
- │ 5. ValidateConnectionsSwitch     → direction, classifier and           │
+ │ 5. processFlowSpecifications()    → one flow specification instance per │
+ │                                     pair of feature array elements     │
+ │ 6. ValidateConnectionsSwitch     → direction, classifier and           │
  │                                    duplicate-destination checks        │
- │ 6. CreateEndToEndFlowsSwitch     → EndToEndFlowInstances               │
- │ 7. cacheProperties(), annex instantiation                              │
+ │ 7. CreateEndToEndFlowsSwitch     → EndToEndFlowInstances               │
+ │ 8. cacheProperties(), annex instantiation                              │
  └────────────────────────────────────────────────────────────────────────┘
 ```
 
-`InstantiateModel.prepareForAnnexes()` runs steps 3 to 7 for the system instance. Additional roots
-that represent referenced classifiers skip connection and end-to-end-flow instantiation; only their
-properties and annexes are instantiated because they have no system operation modes.
+`InstantiateModel.prepareForAnnexes()` runs steps 3 to 8 for the system instance. Additional roots
+that represent referenced classifiers skip connection and end-to-end-flow instantiation, because
+they have no system operation modes; they do go through steps 4, 5 and 8.
 
 `CreateConnectionsSwitch` extends `AadlProcessingSwitchWithProgress` with
 `PROCESS_PRE_ORDER_ALL`, so its `caseComponentInstance` fires for every component instance.
@@ -256,7 +258,9 @@ path.
   *provisional* until `InstantiateModel.processConnections()` replicates it across arrays and
   applies the structural properties, deleting the provisional instances it replaces. Those
   properties are cached on connection instances, so they cannot constrain a join that happens
-  before any instance exists.
+  before any instance exists. Which elements the properties pair up is `ArrayPatternExpansion`,
+  shared with the flow specification expansion, which reads the same two properties with the same
+  meaning; `StructuralProperty` is where the two are identified and their values decoded.
 - **Mode and SOM assignment.** A topologically valid path is materialized even when its modes
   have no compatible system operation mode; `fillInModes` then finds none, warns and deletes
   it. A `ModeConstraint` is carried through the traversal for identity and diagnostics, not as

--- a/core/org.osate.aadl2.instantiation/doc/e2e_instantiation.md
+++ b/core/org.osate.aadl2.instantiation/doc/e2e_instantiation.md
@@ -58,20 +58,31 @@ InstantiateModel.fillSystemInstance(root)
  ┌────────────────────────────────────────────────────────────────────────┐
  │ 1. populateComponentInstance()                                         │
  │      → ComponentInstance tree, FeatureInstances, ModeInstances,        │
- │        FlowSpecificationInstances (via instantiateFlowSpecs)           │
+ │        provisional FlowSpecificationInstances (instantiateFlowSpecs)   │
  │ 2. createSystemOperationModes()      → SystemOperationMode list        │
- │ 3. CreateConnectionsSwitch           → ConnectionInstances, each with  │
- │                                        an ordered ConnectionReference  │
- │                                        chain of declarative Connections│
- │ 4. ValidateConnectionsSwitch                                           │
- │ 5. CreateEndToEndFlowsSwitch         → EndToEndFlowInstances   ◄── us  │
- │ 6. cacheProperties(), annex instantiation                              │
+ │ 3. CreateConnectionsSwitch           → provisional ConnectionInstances,│
+ │                                        each with an ordered            │
+ │                                        ConnectionReference chain of    │
+ │                                        declarative Connections         │
+ │ 4. cacheStructuralProperties()       → Connection_Pattern and          │
+ │                                        Connection_Set on both kinds of │
+ │                                        provisional instance            │
+ │ 5. ConnectionArrayExpander           → final ConnectionInstances       │
+ │ 6. FlowSpecArrayExpander             → final FlowSpecificationInstances│
+ │ 7. ValidateConnectionsSwitch                                           │
+ │ 8. CreateEndToEndFlowsSwitch         → EndToEndFlowInstances   ◄── us  │
+ │ 9. cacheProperties(), annex instantiation                              │
  └────────────────────────────────────────────────────────────────────────┘
 ```
 
+Steps 5 and 6 are why a flow sees only final instances. Both replace the provisional instances
+they expand, and a flow refers to connection instances and flow specification instances without
+containing them, so a flow built before either expansion would keep instances that no longer exist.
+
 `InstantiateModel` invokes the switch as `new CreateEndToEndFlowsSwitch(...).processPreOrderAll(root)`
-for the system instance. Additional roots that represent referenced classifiers bypass this phase
-because they have no system operation modes.
+for the system instance. Additional roots that represent referenced classifiers bypass steps 3, 5, 7
+and 8 because they have no system operation modes; they do go through steps 4, 6 and 9, so their flow
+specification instances mean the same thing as the system instance's.
 
 The switch extends `AadlProcessingSwitchWithProgress` and is constructed with
 `PROCESS_PRE_ORDER_ALL`, so its `InstanceSwitch.caseComponentInstance` fires for **every**
@@ -112,7 +123,7 @@ end to end flow
   consumer.fsnk
 ```
 
-Four sources of multiplicity:
+Five sources of multiplicity:
 
 1. **Multiple flow implementations** for one flow specification — in the test model
    `BasicAndBranching.aadl`, `Choice.two_paths` declares `fpath` twice, once through `upper` and
@@ -121,6 +132,10 @@ Four sources of multiplicity:
    group expansion, arrays, fan-out.
 3. **Multiple access targets** behind one data or subprogram access.
 4. **Multiple instances of a nested ETE** referenced by an outer ETE.
+5. **Multiple flow specification instances** for one flow specification — a specification whose in or
+   out end is a feature array was expanded by `FlowSpecArrayExpander` into one instance per pair of
+   array elements that `Connection_Pattern`, `Connection_Set` or the default `One_To_One` pairs up
+   (issue #2787).
 
 Each multiplicity point **forks** the traversal. Surviving branches are named `<flow>_1`,
 `<flow>_2`, … at commit time.
@@ -416,11 +431,16 @@ elements accumulate in `traversal.connections`; when the next flow element arriv
 ```text
 processFlowStep(ci, etei, leaf, nextFlowImpl, iter)
  │
+ │  flowSpecs = flowSpecInstances(ci, leaf)      ← every instance of the leaf's spec
+ │
  ├─ pending connections EMPTY  (start of the flow)
- │    addLeafElement(ci, etei, leaf) == false → abortCandidate, return
- │    push nextFlowImpl onto flowImplementations
- │    continueFlow(ci.getContainingComponentInstance(), …)
- │    pop flowImplementations
+ │    FORK PER FLOW SPECIFICATION INSTANCE:      (one step when the leaf has none)
+ │       if addLeafElement(ci, etei, leaf, flowSpec):
+ │           push nextFlowImpl onto flowImplementations
+ │           continueFlow(ci.getContainingComponentInstance(), …)
+ │           pop flowImplementations
+ │       else:
+ │           abortCandidate
  │
  └─ pending connections NON-EMPTY
       connis = collectConnectionInstances(ci, etei, traversal.connections)
@@ -430,20 +450,24 @@ processFlowStep(ci, etei, leaf, nextFlowImpl, iter)
       │                   "… no semantic connections that continue the flow 'f'
       │                    from feature 'x'"
       │
-      └─ filter each conni — issue 1984: filter first, report only if none survive
+      └─ build the match list — issue 1984: filter first, report only if none survive
            flowFilter (previous impl's out end) → startsAtFlowOutput(fimpl, conni)
-           nextFlowImpl known                  → endsAtFlowInput(conni, fimpl)
-           plain flow-spec leaf                → endsAtFlowSource(ci, conni, fspec)
+           subcomponent leaf                   → matches with no flow spec
+           otherwise, per flow spec instance   → reaches(conni, flowSpec, nextFlowImpl, …)
+                nextFlowImpl known → endsAtFlowInput(conni, fimpl), and
+                                     endsAtFlowSource(conni, flowSpec) when the spec
+                                     has more than one instance
+                otherwise          → endsAtFlowSource(conni, flowSpec)
            │
-           ├─ none survive → owner error
-           │                 "… no semantic connections that connect to the start of
-           │                  the flow 'f' at feature 'x'"
-           │                 clear pending; failCandidate
+           ├─ no match → owner error
+           │             "… no semantic connections that connect to the start of
+           │              the flow 'f' at feature 'x'"
+           │             clear pending; failCandidate
            │
-           └─ FORK PER SURVIVING CONNECTION INSTANCE:
+           └─ FORK PER MATCH (connection instance × flow specification instance):
                  push nextFlowImpl onto flowImplementations
-                 etei.getFlowElements() += conni
-                 if addLeafElement(ci, etei, leaf):
+                 etei.getFlowElements() += match.connection()
+                 if addLeafElement(ci, etei, leaf, match.flowSpec()):
                      clear pending; peek `iter` for the next Connection → pending
                      continueFlow(ci.getContainingComponentInstance(), …)
                  else:
@@ -458,7 +482,15 @@ reached. Its three endpoint predicates are pure:
 |---|---|
 | `endsAtFlowInput(conni, fimpl)` | does the connection end at the implementation's in-end feature? |
 | `startsAtFlowOutput(fimpl, conni)` | does the connection start at the implementation's out-end feature? |
-| `endsAtFlowSource(ci, conni, fspec)` | does the connection end at the flow specification's source feature, or at a feature nested inside it? (walks up the `FeatureInstance` containment chain) |
+| `endsAtFlowSource(conni, fsi)` | does the connection end at *this* flow specification instance's source feature, or at a feature nested inside it? (walks up the `FeatureInstance` containment chain) |
+
+`endsAtFlowSource` takes the instance, not the specification, because a specification over feature
+arrays has one instance per pair of array elements and each has a source feature instance of its own.
+Asking about one of them is what decides which array element a flow goes through. The **outgoing**
+side of a hop needs no element test of its own: `carriesConnectionPath` already requires the next
+connection instance to start exactly at the previous element's destination feature instance, so a
+branch that entered `inp[2]` cannot leave through `outp[1]`. That holds inside a flow implementation
+too, which is why descent needs nothing added (issue #2787).
 
 `collectConnectionInstances` iterates `ci.allEnclosingConnectionInstances()` and keeps those for
 which `carriesConnectionPath` holds. That test matches the pending declarative sequence against the
@@ -493,9 +525,11 @@ calls `collectConnectionInstances`, the three endpoint predicates, and
 `addLeafElement` maps a declarative leaf to a concrete instance object and returns whether it
 succeeded:
 
-- `FlowImplementation` → its specification; `FlowSpecification` → itself. Either way, append
-  `ci.findFlowSpecInstance(fs)`. If there is no such instance, queue an owner error
-  ("Could not find flow spec …") and return false.
+- `FlowImplementation` → its specification; `FlowSpecification` → itself. Either way, append the
+  `FlowSpecificationInstance` the caller chose among the instances of that specification. If the caller
+  had none to choose from, queue an owner error ("Could not find flow spec …") and return false.
+  `flowSpecInstances(ci, leaf)` is the plural lookup, matching `findFlowSpecInstance`'s
+  `isSameOrRefined` test so that a refined specification still resolves.
 - `Subcomponent` → append `ci` itself. If the candidate already has elements, the preceding element
   must be a `ConnectionInstance` whose destination is a component instance, or whose destination
   lies inside `ci`; otherwise queue an owner error ("Connection … continues into component …") and
@@ -868,4 +902,5 @@ attributions in this document can be checked without relying on the source comme
 | [#2986](https://github.com/osate/osate2/issues/2986) | Nested end-to-end flow composition combines incompatible path variants | §6.7, §10 — `containsConnectionPath` pairing |
 | [#2987](https://github.com/osate/osate2/issues/2987) | Cyclic nested end-to-end flows create cyclic instance graphs | §6.7, §10 — `activeDeclarations` cycle check |
 | [#2988](https://github.com/osate/osate2/issues/2988) | End-to-end flow connection matching ignores declarative connection context | §6.4 — `isSameOrRefinedConnection` |
+| [#2787](https://github.com/osate/osate2/issues/2787) | Flow specifications need to be able to reference features in a feature array | §2, §3, §6.4, §6.5 — one flow specification instance per pair of array elements, and the fork over them |
 | [#3055](https://github.com/osate/osate2/issues/3055) | Refactor `CreateEndToEndFlowsSwitch` into focused collaborators | §1, §4.1 — where each type lives and what it owns |

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
@@ -102,6 +102,7 @@ import org.osate.aadl2.instance.SystemOperationMode;
 import org.osate.aadl2.instance.util.InstanceUtil;
 import org.osate.aadl2.instance.util.InstanceUtil.InstantiatedClassifier;
 import org.osate.aadl2.instantiation.internal.ConnectionArrayExpander;
+import org.osate.aadl2.instantiation.internal.FlowSpecArrayExpander;
 import org.osate.aadl2.instantiation.internal.SystemOperationModeBuilder;
 import org.osate.aadl2.modelsupport.AadlConstants;
 import org.osate.aadl2.modelsupport.FileNameConstants;
@@ -491,15 +492,17 @@ public class InstantiateModel {
 
 	/**
 	 * Prepare one instance-resource root for annex instantiation. For the system instance, create the
-	 * connection instances, expand them into the final connection set, validate the result, build the
-	 * end to end flows over it, and cache its properties. For a referenced classifier root, cache its
-	 * properties without instantiating connections or end to end flows: those semantic instances belong
-	 * to a system instance and depend on its system operation modes.
+	 * connection instances, expand them and the flow specification instances, validate the result, build
+	 * the end to end flows over it, and cache its properties. For a referenced classifier root, expand its
+	 * flow specification instances and cache its properties, but instantiate no connections and no end to
+	 * end flows: those semantic instances belong to a system instance and depend on its system operation
+	 * modes.
 	 * <p>
 	 * The expansion of arrays, {@code Connection_Pattern} and {@code Connection_Set} replaces the
 	 * provisional connection instances and deletes them. It has to happen before validation and before
 	 * end to end flow creation, because a flow refers to connection instances without containing them
-	 * and would silently lose a deleted one.
+	 * and would silently lose a deleted one. The flow specification instances are expanded in the same
+	 * window and for the same reason: an end to end flow is built over them.
 	 * <p>
 	 * Does nothing if the root already went through this phase.
 	 */
@@ -509,19 +512,12 @@ public class InstantiateModel {
 		}
 		pending.preparedForAnnexes = true;
 		final ComponentInstance root = pending.root;
-		if (!(root instanceof SystemInstance)) {
-			cacheProperties(root);
-			return;
-		}
-
-		new CreateConnectionsSwitch(monitor, errManager, classifierCache).processPreOrderAll(root);
-		checkCanceled();
 
 		/*
-		 * The expansion needs Connection_Pattern and Connection_Set on the provisional connections, but
-		 * the remaining properties have to be cached on the final connections. Split the used property
-		 * definitions and run the same caching mechanism twice, so that the values the expansion sees are
-		 * the ones full property caching would have produced for them.
+		 * An expansion needs Connection_Pattern and Connection_Set on the provisional instances, but the
+		 * remaining properties have to be cached on the final ones. Split the used property definitions and
+		 * run the same caching mechanism twice, so that the values an expansion sees are the ones full
+		 * property caching would have produced for them.
 		 */
 		final EList<Property> usedProperties = getAllUsedPropertyDefinitions(root);
 		final List<Property> structuralProperties = new ArrayList<>();
@@ -534,9 +530,24 @@ public class InstantiateModel {
 			}
 		}
 
-		cacheStructuralConnectionProperties(root, structuralProperties);
+		if (!(root instanceof SystemInstance)) {
+			cacheStructuralProperties(root, structuralProperties);
+			new FlowSpecArrayExpander(monitor, errManager).processFlowSpecifications(root);
+			checkCanceled();
+
+			cacheProperties(root, remainingProperties);
+			return;
+		}
+
+		new CreateConnectionsSwitch(monitor, errManager, classifierCache).processPreOrderAll(root);
+		checkCanceled();
+
+		cacheStructuralProperties(root, structuralProperties);
 		// handle arrays, connection patterns, and connection sets
 		new ConnectionArrayExpander(monitor, errManager).processConnections(root);
+		checkCanceled();
+
+		new FlowSpecArrayExpander(monitor, errManager).processFlowSpecifications(root);
 		checkCanceled();
 
 		final ValidateConnectionsSwitch vcs = new ValidateConnectionsSwitch(monitor, errManager, classifierCache);
@@ -597,16 +608,16 @@ public class InstantiateModel {
 	}
 
 	/**
-	 * Cache {@code Connection_Pattern} and {@code Connection_Set} on the provisional connection
-	 * instances of a root. {@link ConnectionArrayExpander} reads them from there to expand the
-	 * connections into the final connection set.
+	 * Cache {@code Connection_Pattern} and {@code Connection_Set} on the provisional connection instances
+	 * and flow specification instances of a root. {@link ConnectionArrayExpander} and
+	 * {@link FlowSpecArrayExpander} read them from there to expand those instances into the final sets.
 	 * <p>
 	 * This uses the same two switches and the same lookup contexts as full property caching, restricted
 	 * to those two property definitions, so the resolved values are the ones full property caching would
 	 * have produced. The contained associations go into a separate cache because the one used by full
-	 * caching must not hold associations recorded for connection instances that the expansion deletes.
+	 * caching must not hold associations recorded for instances that an expansion replaces.
 	 */
-	private void cacheStructuralConnectionProperties(ComponentInstance root, List<Property> structuralProperties)
+	private void cacheStructuralProperties(ComponentInstance root, List<Property> structuralProperties)
 			throws InterruptedException {
 		if (structuralProperties.isEmpty()) {
 			return;

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/ArrayPatternExpansion.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/ArrayPatternExpansion.java
@@ -1,0 +1,368 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.aadl2.instantiation.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.LongBinaryOperator;
+
+import org.osate.aadl2.Element;
+import org.osate.aadl2.EnumerationLiteral;
+import org.osate.aadl2.NamedValue;
+import org.osate.aadl2.PropertyExpression;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+
+/**
+ * One expansion of a source array and a destination array into the pairs of elements that their
+ * dimensions, a {@code Connection_Pattern} value or the default pattern pair up. The expansion walks the
+ * dimensions of the two ends outside in, one pattern per dimension, and hands every combination of
+ * indices the patterns pair up to a {@link Pairing}.
+ * <p>
+ * Two things are expanded this way, because both read the same property with the same meaning: a
+ * connection between arrays of features or of components (see {@link ConnectionArrayExpander}), and a
+ * flow specification between feature arrays (see {@link FlowSpecArrayExpander}). What differs is only
+ * what a pair of indices is turned into and how the two are named in a report, which is why the subject
+ * of a report is supplied by the caller rather than derived here.
+ * <p>
+ * The sizes and the patterns do not change; the three cursors and the two index lists are where the
+ * expansion is. A cursor is advanced by {@link #expandNextDimension(int, int)} only, which also restores
+ * it, so every level of the recursion sees the cursors and indices it established itself.
+ * <p>
+ * Patterns are read in the declarative frame: {@code isOpposite} means that the declared source is the
+ * destination of what is being expanded, so a pattern that keeps the declared source fixed varies the
+ * index of the destination.
+ */
+final class ArrayPatternExpansion {
+	/**
+	 * What an expansion hands each pair of paired-up element indices to.
+	 */
+	interface Pairing {
+		/**
+		 * @param srcIndices the index of the source element in every source dimension, outside in
+		 * @param dstIndices the index of the destination element in every destination dimension, outside in
+		 */
+		void pair(List<Long> srcIndices, List<Long> dstIndices);
+	}
+
+	/**
+	 * The values of the standard {@code Connection_Pattern} property, which are also the patterns the
+	 * default expansion of an array uses. The name of a literal is the name of the constant, up to case,
+	 * which is how {@link #parse(String)} looks a pattern of the model up.
+	 * <p>
+	 * Eleven of the patterns pair up the elements of a source dimension and a destination dimension of
+	 * the same size, and differ only in which source elements take part and which destination element
+	 * each of them is paired with. Those four numbers are the state of such a pattern: the first source
+	 * index, how many elements at the end of the dimension are left out, the step from one source index
+	 * to the next, and the destination index of a source index. The other three patterns have a shape of
+	 * their own and carry none of it.
+	 */
+	private enum ConnectionPattern {
+		/** Every element of the source dimension to every element of the destination dimension. */
+		ALL_TO_ALL,
+
+		/** The one element of the scalar declared source to every element of the destination dimension. */
+		ONE_TO_ALL,
+
+		/** Every element of the source dimension to the one element of the scalar declared destination. */
+		ALL_TO_ONE,
+
+		ONE_TO_ONE(1, 0, 1, (i, size) -> i),
+		NEXT(1, 1, 1, (i, size) -> i + 1),
+		PREVIOUS(2, 0, 1, (i, size) -> i - 1),
+		CYCLIC_NEXT(1, 0, 1, (i, size) -> i == size ? 1 : i + 1),
+		CYCLIC_PREVIOUS(1, 0, 1, (i, size) -> i == 1 ? size : i - 1),
+		NEXT_NEXT(1, 2, 1, (i, size) -> i + 2),
+		PREVIOUS_PREVIOUS(3, 0, 1, (i, size) -> i - 2),
+		CYCLIC_NEXT_NEXT(1, 0, 1, (i, size) -> (i + 1) % size + 1),
+		CYCLIC_PREVIOUS_PREVIOUS(1, 0, 1, (i, size) -> (i + size - 3) % size + 1),
+		EVEN_TO_EVEN(2, 0, 2, (i, size) -> i),
+		ODD_TO_ODD(1, 0, 2, (i, size) -> i);
+
+		/** The first index of the source dimension that takes part. */
+		private final long firstIndex;
+
+		/** How many elements at the end of the source dimension do not take part. */
+		private final int lastIndexOffset;
+
+		/** The distance from one participating source index to the next. */
+		private final long step;
+
+		/** The destination index a source index is paired with, given the size of the dimension. */
+		private final LongBinaryOperator destinationIndex;
+
+		ConnectionPattern() {
+			this(0, 0, 0, null);
+		}
+
+		ConnectionPattern(long firstIndex, int lastIndexOffset, long step, LongBinaryOperator destinationIndex) {
+			this.firstIndex = firstIndex;
+			this.lastIndexOffset = lastIndexOffset;
+			this.step = step;
+			this.destinationIndex = destinationIndex;
+		}
+
+		/**
+		 * The pattern of a {@code Connection_Pattern} enumeration literal.
+		 *
+		 * @param name the name of the literal
+		 * @return the pattern, or {@code null} if this is not a pattern the expansion supports
+		 */
+		static ConnectionPattern parse(String name) {
+			for (ConnectionPattern pattern : values()) {
+				if (pattern.name().equalsIgnoreCase(name)) {
+					return pattern;
+				}
+			}
+			return null;
+		}
+	}
+
+	/** Which declared end of the expanded element a report is about. */
+	private enum End {
+		SOURCE("source"), DESTINATION("destination");
+
+		private final String label;
+
+		End(String label) {
+			this.label = label;
+		}
+
+		@Override
+		public String toString() {
+			return label;
+		}
+	}
+
+	/**
+	 * What a report is about, and where it goes. The texts are the ones the messages had when only
+	 * connections were expanded this way, so a connection is reported exactly as it was.
+	 *
+	 * @param target the instance object a report about the expanded element is attached to
+	 * @param kind what the expanded element is called, {@code connection} or {@code flow specification}
+	 * @param name the name of the expanded element
+	 * @param container the instance object a report about the whole declaration is attached to, used by
+	 *            the short pattern report, which is about a value that describes no element at all
+	 * @param containerName the name of what contains the expanded element, used by the array size
+	 *            mismatch report
+	 */
+	record Subject(Element target, String kind, String name, Element container, String containerName) {
+	}
+
+	private final AnalysisErrorReporterManager errManager;
+	private final Subject subject;
+	private final boolean isOpposite;
+
+	/** The pattern per dimension, or {@code null} to expand with the default pattern. */
+	private final List<PropertyExpression> patterns;
+
+	private final List<Integer> srcSizes;
+	private final List<Integer> dstSizes;
+	private final Pairing pairing;
+
+	/** The indices collected for the dimensions the expansion has entered, outside in. */
+	private final List<Long> srcIndices = new ArrayList<>();
+	private final List<Long> dstIndices = new ArrayList<>();
+
+	private int offset;
+	private int srcOffset;
+	private int dstOffset;
+
+	/**
+	 * @param errManager the error manager to report to
+	 * @param subject what a report is about
+	 * @param isOpposite whether the expanded element goes against the direction of the declaration
+	 * @param patterns the value of {@code Connection_Pattern}, one literal per dimension, or {@code null}
+	 *            to expand with the default pattern
+	 * @param srcSizes the sizes of the array dimensions of the source end, outside in
+	 * @param dstSizes the sizes of the array dimensions of the destination end, outside in
+	 * @param pairing what to hand every paired-up combination of indices to
+	 */
+	ArrayPatternExpansion(AnalysisErrorReporterManager errManager, Subject subject, boolean isOpposite,
+			List<PropertyExpression> patterns, List<Integer> srcSizes, List<Integer> dstSizes, Pairing pairing) {
+		this.errManager = errManager;
+		this.subject = subject;
+		this.isOpposite = isOpposite;
+		this.patterns = patterns;
+		this.srcSizes = srcSizes;
+		this.dstSizes = dstSizes;
+		this.pairing = pairing;
+	}
+
+	/**
+	 * Pair up the elements of the dimension the expansion is at and of every dimension inside it.
+	 *
+	 * @return whether what was expanded has to be dropped; a short pattern is rejected without a
+	 *         replacement, while failures that may still describe one scalar element leave it in place
+	 */
+	boolean expand() {
+		if (patterns != null && offset == 0 && patterns.size() < Math.max(srcSizes.size(), dstSizes.size())) {
+			errManager.error(subject.container(), "Connection pattern has fewer dimensions than its array ends");
+			return true;
+		}
+		if (patterns != null ? offset >= patterns.size()
+				: srcOffset == srcSizes.size() && dstOffset == dstSizes.size()) {
+			pairing.pair(srcIndices, dstIndices);
+			return true;
+		}
+		var patternName = patternName();
+		var pattern = ConnectionPattern.parse(patternName);
+		/*
+		 * An unsupported pattern is neither One_To_All nor All_To_One, so it needs an index at both ends,
+		 * and it is reported below, after the size check the supported patterns go through.
+		 */
+		if (!hasIndexFor(End.SOURCE, pattern) || !hasIndexFor(End.DESTINATION, pattern)) {
+			return false;
+		}
+		var result = true;
+		if (pattern == ConnectionPattern.ALL_TO_ALL) {
+			for (long i = 1; i <= srcSizes.get(srcOffset); i++) {
+				srcIndices.add(i);
+				for (long j = 1; j <= dstSizes.get(dstOffset); j++) {
+					dstIndices.add(j);
+					result &= expandNextDimension(1, 1);
+					dstIndices.removeLast();
+				}
+				srcIndices.removeLast();
+			}
+			return result;
+		}
+		if (pattern == (isOpposite ? ConnectionPattern.ALL_TO_ONE : ConnectionPattern.ONE_TO_ALL)) {
+			// the declared source stays at its one element, so this dimension gives it no index
+			for (long j = 1; j <= dstSizes.get(dstOffset); j++) {
+				dstIndices.add(j);
+				result &= expandNextDimension(0, 1);
+				dstIndices.removeLast();
+			}
+			return result;
+		}
+		if (pattern == (isOpposite ? ConnectionPattern.ONE_TO_ALL : ConnectionPattern.ALL_TO_ONE)) {
+			// the declared destination stays at its one element, so this dimension gives it no index
+			for (long i = 1; i <= srcSizes.get(srcOffset); i++) {
+				srcIndices.add(i);
+				result &= expandNextDimension(1, 0);
+				srcIndices.removeLast();
+			}
+			return result;
+		}
+		// every remaining pattern pairs up two dimensions of the same size
+		int size = srcSizes.get(srcOffset);
+		if (size != dstSizes.get(dstOffset)) {
+			errManager.error(subject.target(),
+					"Array size mismatch (" + patternName + ") on " + subject.kind() + " " + subject.name() + " in "
+							+ subject.containerName() + ": " + size + " at source and " + dstSizes.get(dstOffset)
+							+ " at destination.");
+			return false;
+		}
+		if (pattern == null) {
+			/*
+			 * A pattern the expansion does not know expands into nothing. Report it and keep what was to be
+			 * expanded: returning true would tell the caller that it was expanded, and the caller would drop
+			 * it without a replacement.
+			 */
+			errManager.error(subject.target(),
+					"Unsupported connection pattern '" + patternName + "' on " + subject.kind() + " "
+							+ subject.name());
+			return false;
+		}
+		for (long i = pattern.firstIndex; i <= size - pattern.lastIndexOffset; i += pattern.step) {
+			srcIndices.add(i);
+			dstIndices.add(pattern.destinationIndex.applyAsLong(i, size));
+			result &= expandNextDimension(1, 1);
+			dstIndices.removeLast();
+			srcIndices.removeLast();
+		}
+		return result;
+	}
+
+	/**
+	 * Expand the dimensions inside the one the expansion is at with the indices collected for it, then
+	 * undo the step, so that the caller continues with the cursors and indices it had.
+	 *
+	 * @param srcStep one if this dimension took an index from the source end, zero if it did not
+	 * @param dstStep one if this dimension took an index from the destination end, zero if it did not
+	 * @return whether the expansion succeeded
+	 */
+	private boolean expandNextDimension(int srcStep, int dstStep) {
+		offset++;
+		srcOffset += srcStep;
+		dstOffset += dstStep;
+		var result = expand();
+		dstOffset -= dstStep;
+		srcOffset -= srcStep;
+		offset--;
+		return result;
+	}
+
+	/**
+	 * The name of the pattern of the dimension the expansion is at: the name of the enumeration literal of
+	 * {@code Connection_Pattern}, or the name of the pattern the default expansion uses. The name is what
+	 * the array size mismatch message reports, which is why the default expansion needs one at all.
+	 */
+	private String patternName() {
+		if (patterns != null) {
+			var nv = (NamedValue) patterns.get(offset);
+			return ((EnumerationLiteral) nv.getNamedValue()).getName();
+		}
+		/*
+		 * A default pattern pairs dimensions one-to-one. If only one end has dimensions, every element on
+		 * that end maps to the one scalar end. The spelling of these three names is the spelling they had.
+		 */
+		if (srcSizes.isEmpty()) {
+			return isOpposite ? "All_to_One" : "One_To_All";
+		}
+		if (dstSizes.isEmpty()) {
+			return isOpposite ? "One_To_All" : "All_to_One";
+		}
+		return "One_to_One";
+	}
+
+	/**
+	 * Does the dimension the expansion is at have an index to give to a declared end? Reports the end
+	 * having fewer array dimensions than the patterns need indices for.
+	 * <p>
+	 * {@code End} names the declared end here, and the message follows it. Which of the two size lists to
+	 * look in does not: with {@code isOpposite}, the declared source is the destination of what is being
+	 * expanded, so its dimensions are the ones of the destination.
+	 *
+	 * @param end the declared end
+	 * @param pattern the pattern of the dimension, {@code null} if the model names one that is not
+	 *            supported
+	 * @return whether the pattern has an index for this end
+	 */
+	private boolean hasIndexFor(End end, ConnectionPattern pattern) {
+		// One_To_All takes no index from the declared source, All_To_One none from the declared destination
+		if (pattern == (end == End.SOURCE ? ConnectionPattern.ONE_TO_ALL : ConnectionPattern.ALL_TO_ONE)) {
+			return true;
+		}
+		var atSource = (end == End.SOURCE) != isOpposite;
+		var offsetAtEnd = atSource ? srcOffset : dstOffset;
+		var dimensions = (atSource ? srcSizes : dstSizes).size();
+		if (offsetAtEnd < dimensions) {
+			return true;
+		}
+		errManager.error(subject.target(),
+				"Too few indices for " + subject.kind() + " " + end + " for " + subject.name());
+		return false;
+	}
+}

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/ConnectionArrayExpander.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/ConnectionArrayExpander.java
@@ -27,7 +27,6 @@ import static org.osate.aadl2.modelsupport.util.AadlUtil.getElementCount;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.LongBinaryOperator;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.emf.common.util.EList;
@@ -37,11 +36,9 @@ import org.osate.aadl2.ArrayDimension;
 import org.osate.aadl2.ArraySize;
 import org.osate.aadl2.BasicPropertyAssociation;
 import org.osate.aadl2.Element;
-import org.osate.aadl2.EnumerationLiteral;
 import org.osate.aadl2.Feature;
 import org.osate.aadl2.IntegerLiteral;
 import org.osate.aadl2.ListValue;
-import org.osate.aadl2.NamedValue;
 import org.osate.aadl2.Property;
 import org.osate.aadl2.PropertyAssociation;
 import org.osate.aadl2.PropertyExpression;
@@ -73,6 +70,9 @@ import org.osate.aadl2.util.Aadl2InstanceUtil;
  * connection instances before the expansion runs, see
  * {@link #isStructuralConnectionProperty(Property)}. Both associations are removed from the connection
  * instance they were read from, so they do not survive into the final connection set.
+ * <p>
+ * Which elements a pattern pairs up is {@link ArrayPatternExpansion}; this class decides what a pair of
+ * indices becomes.
  * <p>
  * One expander expands one root once.
  */
@@ -148,7 +148,7 @@ public final class ConnectionArrayExpander {
 				}
 				// only a connection with an array element at one of its ends is expanded
 				if (srcPath.throughArrayElement() || dstPath.throughArrayElement()) {
-					if (new PatternExpansion(conni, false, null, srcPath.sizes(), dstPath.sizes()).expand()) {
+					if (expandPattern(conni, false, null, srcPath.sizes(), dstPath.sizes())) {
 						toRemove.add(conni);
 					}
 				}
@@ -171,8 +171,7 @@ public final class ConnectionArrayExpander {
 						errManager.warning(conni,
 								"Connection pattern specified for connection that does not connect array elements.");
 					} else {
-						if (new PatternExpansion(conni, isOpposite, pattern, srcPath.sizes(), dstPath.sizes())
-								.expand()) {
+						if (expandPattern(conni, isOpposite, pattern, srcPath.sizes(), dstPath.sizes())) {
 							toRemove.add(conni);
 						}
 					}
@@ -273,288 +272,26 @@ public final class ConnectionArrayExpander {
 	}
 
 	/**
-	 * The values of the standard {@code Connection_Pattern} property, which are also the patterns the
-	 * default expansion of an array connection uses. The name of a literal is the name of the constant,
-	 * up to case, which is how {@link #parse(String)} looks a pattern of the model up.
-	 * <p>
-	 * Eleven of the patterns pair up the elements of a source dimension and a destination dimension of
-	 * the same size, and differ only in which source elements take part and which destination element
-	 * each of them is paired with. Those four numbers are the state of such a pattern: the first source
-	 * index, how many elements at the end of the dimension are left out, the step from one source index
-	 * to the next, and the destination index of a source index. The other three patterns have a shape of
-	 * their own and carry none of it.
+	 * Expand a connection instance into the connection instances that its array dimensions, its
+	 * {@code Connection_Pattern} or the default pattern call for.
+	 *
+	 * @param conni the connection instance to expand
+	 * @param isOpposite whether the connection instance goes against the direction of the declaration
+	 * @param patterns the value of {@code Connection_Pattern}, one literal per dimension, or {@code null}
+	 *            to expand with the default pattern
+	 * @param srcSizes the sizes of the array dimensions of the source end, outside in
+	 * @param dstSizes the sizes of the array dimensions of the destination end, outside in
+	 * @return whether the provisional connection instance has to be deleted; a short pattern is rejected
+	 *         without a replacement, while failures that may still describe one scalar connection leave it
+	 *         in place
 	 */
-	private enum ConnectionPattern {
-		/** Every element of the source dimension to every element of the destination dimension. */
-		ALL_TO_ALL,
-
-		/** The one element of the scalar declared source to every element of the destination dimension. */
-		ONE_TO_ALL,
-
-		/** Every element of the source dimension to the one element of the scalar declared destination. */
-		ALL_TO_ONE,
-
-		ONE_TO_ONE(1, 0, 1, (i, size) -> i),
-		NEXT(1, 1, 1, (i, size) -> i + 1),
-		PREVIOUS(2, 0, 1, (i, size) -> i - 1),
-		CYCLIC_NEXT(1, 0, 1, (i, size) -> i == size ? 1 : i + 1),
-		CYCLIC_PREVIOUS(1, 0, 1, (i, size) -> i == 1 ? size : i - 1),
-		NEXT_NEXT(1, 2, 1, (i, size) -> i + 2),
-		PREVIOUS_PREVIOUS(3, 0, 1, (i, size) -> i - 2),
-		CYCLIC_NEXT_NEXT(1, 0, 1, (i, size) -> (i + 1) % size + 1),
-		CYCLIC_PREVIOUS_PREVIOUS(1, 0, 1, (i, size) -> (i + size - 3) % size + 1),
-		EVEN_TO_EVEN(2, 0, 2, (i, size) -> i),
-		ODD_TO_ODD(1, 0, 2, (i, size) -> i);
-
-		/** The first index of the source dimension that takes part. */
-		private final long firstIndex;
-
-		/** How many elements at the end of the source dimension do not take part. */
-		private final int lastIndexOffset;
-
-		/** The distance from one participating source index to the next. */
-		private final long step;
-
-		/** The destination index a source index is paired with, given the size of the dimension. */
-		private final LongBinaryOperator destinationIndex;
-
-		ConnectionPattern() {
-			this(0, 0, 0, null);
-		}
-
-		ConnectionPattern(long firstIndex, int lastIndexOffset, long step, LongBinaryOperator destinationIndex) {
-			this.firstIndex = firstIndex;
-			this.lastIndexOffset = lastIndexOffset;
-			this.step = step;
-			this.destinationIndex = destinationIndex;
-		}
-
-		/**
-		 * The pattern of a {@code Connection_Pattern} enumeration literal.
-		 *
-		 * @param name the name of the literal
-		 * @return the pattern, or {@code null} if this is not a pattern the expansion supports
-		 */
-		static ConnectionPattern parse(String name) {
-			for (ConnectionPattern pattern : values()) {
-				if (pattern.name().equalsIgnoreCase(name)) {
-					return pattern;
-				}
-			}
-			return null;
-		}
-	}
-
-	/**
-	 * One expansion of a connection instance into the connection instances that its array dimensions,
-	 * its {@code Connection_Pattern} or the default pattern call for. The expansion walks the dimensions
-	 * of the two ends outside in, one pattern per dimension, and creates a connection instance for every
-	 * combination of indices the patterns pair up.
-	 * <p>
-	 * The sizes and the patterns do not change; the three cursors and the two index lists are where the
-	 * expansion is. A cursor is advanced by {@link #expandNextDimension(int, int)} only, which also
-	 * restores it, so every level of the recursion sees the cursors and indices it established itself.
-	 * <p>
-	 * Patterns are read in the declarative frame: {@code isOpposite} means that the declared source of
-	 * the connection is the destination of the connection instance, so a pattern that keeps the declared
-	 * source fixed varies the index of the connection instance's destination.
-	 */
-	private final class PatternExpansion {
-		private final ConnectionInstance conni;
-		private final boolean isOpposite;
-
-		/** The pattern per dimension, or {@code null} to expand with the default pattern. */
-		private final List<PropertyExpression> patterns;
-
-		private final List<Integer> srcSizes;
-		private final List<Integer> dstSizes;
-
-		/** The indices collected for the dimensions the expansion has entered, outside in. */
-		private final List<Long> srcIndices = new ArrayList<>();
-		private final List<Long> dstIndices = new ArrayList<>();
-
-		private int offset;
-		private int srcOffset;
-		private int dstOffset;
-
-		/**
-		 * @param conni the connection instance to expand
-		 * @param isOpposite whether the connection instance goes against the direction of the declaration
-		 * @param patterns the value of {@code Connection_Pattern}, one literal per dimension, or
-		 *            {@code null} to expand with the default pattern
-		 * @param srcSizes the sizes of the array dimensions of the source end, outside in
-		 * @param dstSizes the sizes of the array dimensions of the destination end, outside in
-		 */
-		private PatternExpansion(ConnectionInstance conni, boolean isOpposite, List<PropertyExpression> patterns,
-				List<Integer> srcSizes, List<Integer> dstSizes) {
-			this.conni = conni;
-			this.isOpposite = isOpposite;
-			this.patterns = patterns;
-			this.srcSizes = srcSizes;
-			this.dstSizes = dstSizes;
-		}
-
-		/**
-		 * Create the connection instances of the dimension the expansion is at and of every dimension
-		 * inside it.
-		 *
-		 * @return whether the provisional connection instance has to be deleted; a short pattern is rejected
-		 *         without a replacement, while failures that may still describe one scalar connection leave it
-		 *         in place
-		 */
-		private boolean expand() {
-			if (patterns != null && offset == 0
-					&& patterns.size() < Math.max(srcSizes.size(), dstSizes.size())) {
-				errManager.error(conni.getContainingComponentInstance(),
-						"Connection pattern has fewer dimensions than its array ends");
-				return true;
-			}
-			if (patterns != null ? offset >= patterns.size()
-					: srcOffset == srcSizes.size() && dstOffset == dstSizes.size()) {
-				createNewConnection(conni, srcIndices, dstIndices);
-				return true;
-			}
-			String patternName = patternName();
-			ConnectionPattern pattern = ConnectionPattern.parse(patternName);
-			/*
-			 * An unsupported pattern is neither One_To_All nor All_To_One, so it needs an index at both
-			 * ends, and it is reported below, after the size check the supported patterns go through.
-			 */
-			if (!hasIndexFor(End.SOURCE, pattern) || !hasIndexFor(End.DESTINATION, pattern)) {
-				return false;
-			}
-			boolean result = true;
-			if (pattern == ConnectionPattern.ALL_TO_ALL) {
-				for (long i = 1; i <= srcSizes.get(srcOffset); i++) {
-					srcIndices.add(i);
-					for (long j = 1; j <= dstSizes.get(dstOffset); j++) {
-						dstIndices.add(j);
-						result &= expandNextDimension(1, 1);
-						dstIndices.removeLast();
-					}
-					srcIndices.removeLast();
-				}
-				return result;
-			}
-			if (pattern == (isOpposite ? ConnectionPattern.ALL_TO_ONE : ConnectionPattern.ONE_TO_ALL)) {
-				// the declared source stays at its one element, so this dimension gives it no index
-				for (long j = 1; j <= dstSizes.get(dstOffset); j++) {
-					dstIndices.add(j);
-					result &= expandNextDimension(0, 1);
-					dstIndices.removeLast();
-				}
-				return result;
-			}
-			if (pattern == (isOpposite ? ConnectionPattern.ONE_TO_ALL : ConnectionPattern.ALL_TO_ONE)) {
-				// the declared destination stays at its one element, so this dimension gives it no index
-				for (long i = 1; i <= srcSizes.get(srcOffset); i++) {
-					srcIndices.add(i);
-					result &= expandNextDimension(1, 0);
-					srcIndices.removeLast();
-				}
-				return result;
-			}
-			// every remaining pattern pairs up two dimensions of the same size
-			int size = srcSizes.get(srcOffset);
-			if (size != dstSizes.get(dstOffset)) {
-				errManager.error(conni,
-						"Array size mismatch (" + patternName + ") on connection " + conni.getFullName() + " in "
-								+ conni.getContainingComponentInstance().getFullName() + ": " + size
-								+ " at source and " + dstSizes.get(dstOffset) + " at destination.");
-				return false;
-			}
-			if (pattern == null) {
-				/*
-				 * A pattern the expansion does not know expands into nothing. Report it and keep the
-				 * connection: returning true would tell the caller that the connection was expanded, and
-				 * the caller would delete it without a replacement.
-				 */
-				errManager.error(conni,
-						"Unsupported connection pattern '" + patternName + "' on connection " + conni.getFullName());
-				return false;
-			}
-			for (long i = pattern.firstIndex; i <= size - pattern.lastIndexOffset; i += pattern.step) {
-				srcIndices.add(i);
-				dstIndices.add(pattern.destinationIndex.applyAsLong(i, size));
-				result &= expandNextDimension(1, 1);
-				dstIndices.removeLast();
-				srcIndices.removeLast();
-			}
-			return result;
-		}
-
-		/**
-		 * Expand the dimensions inside the one the expansion is at with the indices collected for it, then
-		 * undo the step, so that the caller continues with the cursors and indices it had.
-		 *
-		 * @param srcStep one if this dimension took an index from the source end, zero if it did not
-		 * @param dstStep one if this dimension took an index from the destination end, zero if it did not
-		 * @return whether the connection instance was expanded
-		 */
-		private boolean expandNextDimension(int srcStep, int dstStep) {
-			offset++;
-			srcOffset += srcStep;
-			dstOffset += dstStep;
-			boolean result = expand();
-			dstOffset -= dstStep;
-			srcOffset -= srcStep;
-			offset--;
-			return result;
-		}
-
-		/**
-		 * The name of the pattern of the dimension the expansion is at: the name of the enumeration
-		 * literal of {@code Connection_Pattern}, or the name of the pattern the default expansion uses.
-		 * The name is what the array size mismatch message reports, which is why the default expansion
-		 * needs one at all.
-		 */
-		private String patternName() {
-			if (patterns != null) {
-				NamedValue nv = (NamedValue) patterns.get(offset);
-				return ((EnumerationLiteral) nv.getNamedValue()).getName();
-			}
-			/*
-			 * A default pattern pairs dimensions one-to-one. If only one end has dimensions, every element
-			 * on that end maps to the one scalar end. The spelling of these three names is the spelling
-			 * they had.
-			 */
-			if (srcSizes.isEmpty()) {
-				return isOpposite ? "All_to_One" : "One_To_All";
-			}
-			if (dstSizes.isEmpty()) {
-				return isOpposite ? "One_To_All" : "All_to_One";
-			}
-			return "One_to_One";
-		}
-
-		/**
-		 * Does the dimension the expansion is at have an index to give to a declared end of the
-		 * connection? Reports the end having fewer array dimensions than the patterns need indices for.
-		 * <p>
-		 * {@code End} names the declared end here, and the message follows it. Which of the two size
-		 * lists to look in does not: with {@code isOpposite}, the declared source of the connection is the
-		 * destination of the connection instance, so its dimensions are the ones of the destination.
-		 *
-		 * @param end the declared end of the connection
-		 * @param pattern the pattern of the dimension, {@code null} if the model names one that is not
-		 *            supported
-		 * @return whether the pattern has an index for this end
-		 */
-		private boolean hasIndexFor(End end, ConnectionPattern pattern) {
-			// One_To_All takes no index from the declared source, All_To_One none from the declared destination
-			if (pattern == (end == End.SOURCE ? ConnectionPattern.ONE_TO_ALL : ConnectionPattern.ALL_TO_ONE)) {
-				return true;
-			}
-			boolean atInstanceSource = (end == End.SOURCE) != isOpposite;
-			int offsetAtEnd = atInstanceSource ? srcOffset : dstOffset;
-			int dimensions = (atInstanceSource ? srcSizes : dstSizes).size();
-			if (offsetAtEnd < dimensions) {
-				return true;
-			}
-			errManager.error(conni, "Too few indices for connection " + (end == End.SOURCE ? "source" : "destination")
-					+ " for " + conni.getFullName());
-			return false;
-		}
+	private boolean expandPattern(ConnectionInstance conni, boolean isOpposite, List<PropertyExpression> patterns,
+			List<Integer> srcSizes, List<Integer> dstSizes) {
+		var container = conni.getContainingComponentInstance();
+		var subject = new ArrayPatternExpansion.Subject(conni, "connection", conni.getFullName(), container,
+				container.getFullName());
+		return new ArrayPatternExpansion(errManager, subject, isOpposite, patterns, srcSizes, dstSizes,
+				(srcIndices, dstIndices) -> createNewConnection(conni, srcIndices, dstIndices)).expand();
 	}
 
 	private List<Long> getIndices(RecordValue rv, String field) {

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/ConnectionArrayExpander.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/ConnectionArrayExpander.java
@@ -34,16 +34,11 @@ import org.eclipse.emf.common.util.UniqueEList;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.osate.aadl2.ArrayDimension;
 import org.osate.aadl2.ArraySize;
-import org.osate.aadl2.BasicPropertyAssociation;
 import org.osate.aadl2.Element;
 import org.osate.aadl2.Feature;
-import org.osate.aadl2.IntegerLiteral;
-import org.osate.aadl2.ListValue;
 import org.osate.aadl2.Property;
 import org.osate.aadl2.PropertyAssociation;
 import org.osate.aadl2.PropertyExpression;
-import org.osate.aadl2.PropertySet;
-import org.osate.aadl2.RecordValue;
 import org.osate.aadl2.instance.ComponentInstance;
 import org.osate.aadl2.instance.ConnectionInstance;
 import org.osate.aadl2.instance.ConnectionInstanceEnd;
@@ -77,11 +72,6 @@ import org.osate.aadl2.util.Aadl2InstanceUtil;
  * One expander expands one root once.
  */
 public final class ConnectionArrayExpander {
-	/* The properties that determine how a connection is expanded into connection instances */
-	private static final String COMMUNICATION_PROPERTIES = "Communication_Properties";
-	private static final String CONNECTION_PATTERN = "Connection_Pattern";
-	private static final String CONNECTION_SET = "Connection_Set";
-
 	private final AnalysisErrorReporterManager errManager;
 	private final IProgressMonitor monitor;
 
@@ -95,28 +85,12 @@ public final class ConnectionArrayExpander {
 	}
 
 	/**
-	 * Is this one of the properties that determine how many connection instances a connection expands
-	 * into? Uses the same test as {@link #getPA(ConnectionInstance, String)}, which is what reads the
-	 * cached values.
+	 * Is this one of the properties that determine how many instances a declaration over arrays expands
+	 * into, and that therefore have to be cached before any expansion runs? See
+	 * {@link StructuralProperty}, which is also what reads the cached values back.
 	 */
 	public static boolean isStructuralConnectionProperty(Property property) {
-		return isCommunicationProperty(property, CONNECTION_PATTERN)
-				|| isCommunicationProperty(property, CONNECTION_SET);
-	}
-
-	/**
-	 * Is this the named property of the standard {@code Communication_Properties} property set? The one
-	 * test is shared by {@link #isStructuralConnectionProperty(Property)}, which decides which
-	 * properties are cached on the provisional connection instances, and
-	 * {@link #getPA(ConnectionInstance, String)}, which reads them from there, so the two cannot drift
-	 * apart.
-	 *
-	 * @param property the property definition to test
-	 * @param name the name of the property to look for
-	 */
-	private static boolean isCommunicationProperty(Property property, String name) {
-		return name.equalsIgnoreCase(property.getName()) && property.getOwner() instanceof PropertySet ps
-				&& COMMUNICATION_PROPERTIES.equalsIgnoreCase(ps.getName());
+		return StructuralProperty.isStructural(property);
 	}
 
 	/**
@@ -137,8 +111,8 @@ public final class ConnectionArrayExpander {
 			// track all component instances that contain connection instances
 			replicateConns.add(conni.getComponentInstance());
 
-			PropertyAssociation setPA = getPA(conni, CONNECTION_SET);
-			PropertyAssociation patternPA = getPA(conni, CONNECTION_PATTERN);
+			PropertyAssociation setPA = StructuralProperty.CONNECTION_SET.cachedOn(conni);
+			PropertyAssociation patternPA = StructuralProperty.CONNECTION_PATTERN.cachedOn(conni);
 
 			if (setPA == null && patternPA == null) {
 				InstancePath srcPath = analyzePath(conni.getContainingComponentInstance(), conni.getSource());
@@ -155,12 +129,8 @@ public final class ConnectionArrayExpander {
 			} else if (patternPA != null) {
 				boolean isOpposite = Aadl2InstanceUtil.isOpposite(conni);
 				EcoreUtil.remove(patternPA);
-				List<PropertyExpression> patterns = ((ListValue) patternPA.getOwnedValues().get(0).getOwnedValue())
-						.getOwnedListElements();
 				boolean pathError = false;
-				for (PropertyExpression pe : patterns) {
-					List<PropertyExpression> pattern = ((ListValue) pe).getOwnedListElements();
-
+				for (List<PropertyExpression> pattern : StructuralProperty.alternativesOf(patternPA)) {
 					InstancePath srcPath = analyzePath(conni.getContainingComponentInstance(), conni.getSource());
 					InstancePath dstPath = analyzePath(conni.getContainingComponentInstance(), conni.getDestination());
 					if (srcPath == null || dstPath == null) {
@@ -184,19 +154,12 @@ public final class ConnectionArrayExpander {
 			if (setPA != null) {
 				EcoreUtil.remove(setPA);
 				// TODO-LW: modal conn set allowed?
-				List<Long> srcIndices;
-				List<Long> dstIndices;
-				for (PropertyExpression pe : ((ListValue) setPA.getOwnedValues().get(0).getOwnedValue())
-						.getOwnedListElements()) {
-					RecordValue rv = (RecordValue) pe;
-
-					srcIndices = getIndices(rv, "src");
-					dstIndices = getIndices(rv, "dst");
+				for (StructuralProperty.IndexPair pair : StructuralProperty.pairsOf(setPA)) {
 					if (Aadl2InstanceUtil.isOpposite(conni)) {
 						// flip indices since we are going in the opposite direction
-						createNewConnection(conni, dstIndices, srcIndices);
+						createNewConnection(conni, pair.destination(), pair.source());
 					} else {
-						createNewConnection(conni, srcIndices, dstIndices);
+						createNewConnection(conni, pair.source(), pair.destination());
 					}
 				}
 				toRemove.add(conni);
@@ -292,36 +255,6 @@ public final class ConnectionArrayExpander {
 				container.getFullName());
 		return new ArrayPatternExpansion(errManager, subject, isOpposite, patterns, srcSizes, dstSizes,
 				(srcIndices, dstIndices) -> createNewConnection(conni, srcIndices, dstIndices)).expand();
-	}
-
-	private List<Long> getIndices(RecordValue rv, String field) {
-		List<Long> indices = new ArrayList<>();
-		for (BasicPropertyAssociation fv : rv.getOwnedFieldValues()) {
-			if (fv.getProperty().getName().equalsIgnoreCase(field)) {
-				ListValue lv = (ListValue) fv.getOwnedValue();
-				EList<PropertyExpression> vlist = lv.getOwnedListElements();
-				for (PropertyExpression elem : vlist) {
-					indices.add(((IntegerLiteral) elem).getValue());
-				}
-			}
-		}
-		return indices;
-	}
-
-	/**
-	 * The association of a {@code Communication_Properties} property cached on a provisional connection
-	 * instance, or {@code null} if the connection has none.
-	 *
-	 * @param conni the connection instance to look in
-	 * @param name the name of the property to look for
-	 */
-	private PropertyAssociation getPA(ConnectionInstance conni, String name) {
-		for (PropertyAssociation pa : conni.getOwnedPropertyAssociations()) {
-			if (isCommunicationProperty(pa.getProperty(), name)) {
-				return pa;
-			}
-		}
-		return null;
 	}
 
 	/**

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/EndToEndFlowSession.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/EndToEndFlowSession.java
@@ -25,6 +25,7 @@ package org.osate.aadl2.instantiation.internal;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashSet;
@@ -660,6 +661,93 @@ public final class EndToEndFlowSession {
 	}
 
 	/**
+	 * One way to continue the flow through a leaf: the connection instance that reaches it, and the instance
+	 * of its flow specification the flow goes through, which is null for a subcomponent leaf.
+	 */
+	private record LeafMatch(ConnectionInstance connection, FlowSpecificationInstance flowSpec) {
+	}
+
+	/**
+	 * The one step to take for a leaf that has no flow specification instance to choose between. Holds a
+	 * null so that the single step and the fork over several instances are the same loop.
+	 */
+	private static final List<FlowSpecificationInstance> NO_FLOW_SPEC = Collections.singletonList(null);
+
+	/**
+	 * The instances of a leaf's flow specification on the component the leaf is in. A flow specification over
+	 * feature arrays has one instance per pair of array elements it was expanded into, so the flow forks over
+	 * them; see {@code FlowSpecArrayExpander}.
+	 *
+	 * @param ci the component instance containing the leaf, may be null
+	 * @param leaf the ETE element
+	 * @return the instances in expansion order, empty for a leaf that is not a flow specification and for one
+	 *         whose component has no instance of it
+	 */
+	private static List<FlowSpecificationInstance> flowSpecInstances(ComponentInstance ci, Element leaf) {
+		var fs = specificationOf(leaf);
+		if (ci == null || fs == null) {
+			return List.of();
+		}
+		var instances = new ArrayList<FlowSpecificationInstance>();
+		for (var fsi : ci.getFlowSpecifications()) {
+			if (isSameOrRefined(fs, fsi.getFlowSpecification())) {
+				instances.add(fsi);
+			}
+		}
+		return instances;
+	}
+
+	/** The flow specification a leaf stands for, or null if the leaf is not one. */
+	private static FlowSpecification specificationOf(Element leaf) {
+		return switch (leaf) {
+		case FlowImplementation flowImplementation -> flowImplementation.getSpecification();
+		case FlowSpecification flowSpecification -> flowSpecification;
+		default -> null;
+		};
+	}
+
+	/**
+	 * Are these the same flow specification, or one a refinement of the other? Matches
+	 * {@code ComponentInstance.findFlowSpecInstance}, which is what resolved a leaf before a flow
+	 * specification could stand for more than one instance.
+	 */
+	private static boolean isSameOrRefined(FlowSpecification first, FlowSpecification second) {
+		for (var fs = first; fs != null; fs = fs.getRefined()) {
+			if (fs == second) {
+				return true;
+			}
+		}
+		for (var fs = second; fs != null; fs = fs.getRefined()) {
+			if (fs == first) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Can a connection instance continue the flow into one instance of the next leaf's flow specification?
+	 *
+	 * @param conni the connection instance that would reach the leaf
+	 * @param flowSpec the instance of the leaf's flow specification under consideration
+	 * @param nextFlowImpl the flow implementation the connection must reach, or null when the leaf is the
+	 *            flow specification itself
+	 * @param pinElement whether the array element of the instance has to be pinned, which is needed only
+	 *            when the flow specification stands for more than one instance. A flow implementation may
+	 *            refine a feature-group endpoint to a feature inside it, and its in end is then narrower
+	 *            than the flow specification's, so the extra test is applied only where it decides
+	 *            something.
+	 */
+	private static boolean reaches(ConnectionInstance conni, FlowSpecificationInstance flowSpec,
+			FlowImplementation nextFlowImpl, boolean pinElement) {
+		if (nextFlowImpl == null) {
+			return FlowConnectionMatcher.endsAtFlowSource(conni, flowSpec);
+		}
+		return FlowConnectionMatcher.endsAtFlowInput(conni, nextFlowImpl)
+				&& (!pinElement || FlowConnectionMatcher.endsAtFlowSource(conni, flowSpec));
+	}
+
+	/**
 	 * Continue through a leaf flow element and constrain the incoming connection to the start of the next flow
 	 * implementation when one is known.
 	 *
@@ -673,15 +761,45 @@ public final class EndToEndFlowSession {
 			FlowImplementation nextFlowImpl, FlowIterator iter) {
 		var traversal = getState(etei);
 		var candidate = traversal.candidate;
+		/*
+		 * A flow specification over feature arrays was expanded into one instance per pair of array
+		 * elements, so a leaf may stand for several and the flow forks over them. NO_FLOW_SPEC is the one
+		 * step for a leaf that is not a flow specification at all, which is a subcomponent.
+		 */
+		final var flowSpecs = flowSpecInstances(ci, leaf);
 		// add connection(s), will be empty when starting the ETE
 		if (traversal.connections.isEmpty()) {
-			if (!addLeafElement(ci, etei, leaf)) {
-				abortCandidate(candidate);
-				return;
+			/*
+			 * Nothing has constrained this branch yet, so every instance of the leaf's flow specification
+			 * starts a flow of its own.
+			 */
+			var startIter = (flowSpecs.isEmpty() ? NO_FLOW_SPEC : flowSpecs).iterator();
+			while (startIter.hasNext()) {
+				final var flowSpec = startIter.next();
+				final boolean prepareNext = startIter.hasNext();
+				var branchState = getState(etei);
+				TraversalState stateClone = null;
+				FlowIterator iterClone = null;
+
+				if (prepareNext) {
+					stateClone = forkState(branchState);
+					iterClone = iter.copy();
+				}
+
+				if (addLeafElement(ci, etei, leaf, flowSpec)) {
+					branchState.flowImplementations.add(nextFlowImpl);
+					continueFlow(ci.getContainingComponentInstance(), etei, iter, ci);
+					branchState.flowImplementations.removeLast();
+				} else {
+					abortCandidate(branchState.candidate);
+				}
+
+				if (prepareNext) {
+					activeState = stateClone;
+					etei = stateClone.candidate.instance;
+					iter = iterClone;
+				}
 			}
-			traversal.flowImplementations.add(nextFlowImpl);
-			continueFlow(ci.getContainingComponentInstance(), etei, iter, ci);
-			traversal.flowImplementations.removeLast();
 		} else {
 			var connis = FlowConnectionMatcher.collectConnectionInstances(ci, etei,
 					traversal.connections);
@@ -710,19 +828,24 @@ public final class EndToEndFlowSession {
 				 * Issue 1984: the endpoint predicates are a filter, not an error reporter. Determine the applicable
 				 * connections first and report an error only when none of the candidates can continue this flow.
 				 */
-				final var connectionsToUse = new ArrayList<ConnectionInstance>();
+				final var matches = new ArrayList<LeafMatch>();
 				for (var ciToCheck : connis) {
-					if ((flowFilter == null || FlowConnectionMatcher.startsAtFlowOutput(flowFilter, ciToCheck))
-							&& (nextFlowImpl == null
-									? (leaf instanceof FlowSpecification flowSpecification
-											? FlowConnectionMatcher.endsAtFlowSource(ci, ciToCheck, flowSpecification)
-											: true)
-									: FlowConnectionMatcher.endsAtFlowInput(ciToCheck, nextFlowImpl))) {
-						connectionsToUse.add(ciToCheck);
+					if (flowFilter != null && !FlowConnectionMatcher.startsAtFlowOutput(flowFilter, ciToCheck)) {
+						continue;
+					}
+					if (nextFlowImpl == null && !(leaf instanceof FlowSpecification)) {
+						// a subcomponent leaf becomes the component instance itself, so nothing narrows the choice
+						matches.add(new LeafMatch(ciToCheck, null));
+						continue;
+					}
+					for (var flowSpec : flowSpecs) {
+						if (reaches(ciToCheck, flowSpec, nextFlowImpl, flowSpecs.size() > 1)) {
+							matches.add(new LeafMatch(ciToCheck, flowSpec));
+						}
 					}
 				}
 
-				if (connectionsToUse.isEmpty()) {
+				if (matches.isEmpty()) {
 					/*
 					 * Connections may bypass the start of the selected flow implementation: the declarative flow and the
 					 * actual component connections then describe different paths.
@@ -743,11 +866,11 @@ public final class EndToEndFlowSession {
 					traversal.connections.clear();
 					failCandidate(candidate);
 				} else {
-					// continue the flow along each eligible connection instance
-					var connIter = connectionsToUse.iterator();
-					while (connIter.hasNext()) {
-						final var conni = connIter.next();
-						final boolean prepareNext = connIter.hasNext();
+					// continue the flow along each eligible connection instance and flow specification instance
+					var matchIter = matches.iterator();
+					while (matchIter.hasNext()) {
+						final var match = matchIter.next();
+						final boolean prepareNext = matchIter.hasNext();
 						var branchState = getState(etei);
 						TraversalState stateClone = null;
 						FlowIterator iterClone = null;
@@ -758,8 +881,8 @@ public final class EndToEndFlowSession {
 						}
 
 						branchState.flowImplementations.add(nextFlowImpl);
-						etei.getFlowElements().add(conni);
-						if (addLeafElement(ci, etei, leaf)) {
+						etei.getFlowElements().add(match.connection());
+						if (addLeafElement(ci, etei, leaf, match.flowSpec())) {
 							// prepare next connection filter
 							branchState.connections.clear();
 							if (iter.hasNext()) {
@@ -802,7 +925,7 @@ public final class EndToEndFlowSession {
 		var candidate = traversal.candidate;
 		// add connection(s), will be empty when starting the ETE
 		if (traversal.connections.isEmpty()) {
-			addLeafElement(ci, etei, a);
+			addLeafElement(ci, etei, a, null);
 			continueFlow(ci.getContainingComponentInstance(), etei, iter, ci);
 		} else {
 			var connis = FlowConnectionMatcher.collectConnectionInstances(ci, etei,
@@ -851,7 +974,7 @@ public final class EndToEndFlowSession {
 					var continuation = branchState.continuations.pop();
 
 					etei.getFlowElements().add(match.connection());
-					addLeafElement(match.target(), etei, match.leaf());
+					addLeafElement(match.target(), etei, match.leaf(), null);
 
 					// prepare next connection filter
 					var lastConn = branchState.connections.getLast();
@@ -1028,20 +1151,19 @@ public final class EndToEndFlowSession {
 	 * @param ci the component instance containing the leaf
 	 * @param etei the candidate receiving the leaf
 	 * @param leaf a flow specification, flow implementation, or subcomponent
+	 * @param flowSpec the instance of the leaf's flow specification the flow goes through, chosen by the
+	 *            caller among the instances the feature arrays of the flow specification were expanded into;
+	 *            null for a subcomponent leaf and when the component has no instance of the specification
 	 * @return whether the leaf was added successfully
 	 */
-	private boolean addLeafElement(ComponentInstance ci, EndToEndFlowInstance etei, Element leaf) {
+	private boolean addLeafElement(ComponentInstance ci, EndToEndFlowInstance etei, Element leaf,
+			FlowSpecificationInstance flowSpec) {
 		var candidate = getCandidate(etei);
-		FlowSpecification fs = switch (leaf) {
-		case FlowImplementation flowImplementation -> flowImplementation.getSpecification();
-		case FlowSpecification flowSpecification -> flowSpecification;
-		default -> null;
-		};
+		var fs = specificationOf(leaf);
 		if (fs != null) {
 			// append a flow specification instance
-			var fsi = ci.findFlowSpecInstance(fs);
-			if (fsi != null) {
-				etei.getFlowElements().add(fsi);
+			if (flowSpec != null) {
+				etei.getFlowElements().add(flowSpec);
 			} else {
 				reportOwnerError(candidate, "Incomplete end-to-end flow instance " + etei.getName()
 						+ ": Could not find flow spec " + fs.getName() + " of component " + ci.getName());

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/FlowConnectionMatcher.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/FlowConnectionMatcher.java
@@ -31,7 +31,6 @@ import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.osate.aadl2.Connection;
 import org.osate.aadl2.FlowImplementation;
-import org.osate.aadl2.FlowSpecification;
 import org.osate.aadl2.instance.ComponentInstance;
 import org.osate.aadl2.instance.ConnectionInstance;
 import org.osate.aadl2.instance.ConnectionInstanceEnd;
@@ -84,28 +83,28 @@ public final class FlowConnectionMatcher {
 	}
 
 	/**
-	 * Check whether a connection instance ends at a flow specification's source feature. A connection to the source
-	 * feature itself or to a feature nested within it is accepted by walking up the feature-instance containment chain.
+	 * Check whether a connection instance ends at the source feature of one instance of a flow specification. A
+	 * connection to the source feature itself or to a feature nested within it is accepted by walking up the
+	 * feature-instance containment chain.
+	 * <p>
+	 * The instance is given rather than looked up from the flow specification, because a flow specification over
+	 * feature arrays has one instance per pair of array elements and each of them has a source feature instance of its
+	 * own. Asking about one of them is what decides which array element a flow goes through.
 	 *
-	 * @param flowComponent the component that owns the flow specification instance
 	 * @param conni the connection instance
-	 * @param fspec the flow specification that must follow the connection
-	 * @return whether the connection destination reaches the flow source
+	 * @param fsi the flow specification instance that must follow the connection
+	 * @return whether the connection destination reaches that instance's flow source
 	 */
-	public static boolean endsAtFlowSource(ComponentInstance flowComponent, ConnectionInstance conni,
-			FlowSpecification fspec) {
+	public static boolean endsAtFlowSource(ConnectionInstance conni, FlowSpecificationInstance fsi) {
 		ConnectionInstanceEnd cie = conni.getDestination();
-		if (cie instanceof FeatureInstance conniFi) {
-			FlowSpecificationInstance fsi = flowComponent.findFlowSpecInstance(fspec);
-			if (fsi != null) {
-				FeatureInstance fsSrcFi = fsi.getSource();
-				EObject e = conniFi;
-				while (e instanceof FeatureInstance fi) {
-					if (fi == fsSrcFi) {
-						return true;
-					}
-					e = fi.eContainer();
+		if (fsi != null && cie instanceof FeatureInstance conniFi) {
+			FeatureInstance fsSrcFi = fsi.getSource();
+			EObject e = conniFi;
+			while (e instanceof FeatureInstance fi) {
+				if (fi == fsSrcFi) {
+					return true;
 				}
+				e = fi.eContainer();
 			}
 		}
 		return false;

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/FlowSpecArrayExpander.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/FlowSpecArrayExpander.java
@@ -1,0 +1,276 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.aadl2.instantiation.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.osate.aadl2.PropertyExpression;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.aadl2.instance.FeatureInstance;
+import org.osate.aadl2.instance.FlowSpecificationInstance;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+
+/**
+ * Expands the provisional flow specification instances of one instance model root into the final set. A
+ * flow specification whose in or out end is a feature array stands for one flow specification instance
+ * per pair of elements that {@code Connection_Pattern}, {@code Connection_Set} or the default pattern
+ * pairs up, so a flow that goes through such a component goes through one element of it.
+ * <p>
+ * Both properties apply to a flow specification (AS5506D section 10.1) with the meaning they have on a
+ * connection: they say which source array element has a flow to which destination array element. The
+ * arithmetic is therefore the same, and is {@link ArrayPatternExpansion}; this class decides what a pair
+ * of indices becomes. When the property is not set, {@code One_To_One} applies, which is why a model that
+ * declares nothing still gets one flow specification instance per element.
+ * <p>
+ * Only an end that is a feature array itself is expanded. An end reached through a feature group that is
+ * an array keeps the first element of that group, as it always did.
+ * <p>
+ * {@code Connection_Pattern} and {@code Connection_Set} have to be cached on the provisional flow
+ * specification instances before the expansion runs, the same window the connection expansion needs, see
+ * {@link StructuralProperty}. Both associations are removed from the instance they were read from, so
+ * they do not survive into the final set.
+ * <p>
+ * The expansion replaces the provisional instances that {@code InstantiateModel.instantiateFlowSpecs}
+ * produced, so it has to run before the end to end flows are built over them. A flow specification that
+ * cannot be paired up is reported and left alone, so it is still there to be referred to.
+ * <p>
+ * One expander expands one root once.
+ */
+public final class FlowSpecArrayExpander {
+	private final AnalysisErrorReporterManager errManager;
+	private final IProgressMonitor monitor;
+
+	/**
+	 * @param monitor the progress monitor
+	 * @param errManager the error manager to report to
+	 */
+	public FlowSpecArrayExpander(IProgressMonitor monitor, AnalysisErrorReporterManager errManager) {
+		this.monitor = monitor;
+		this.errManager = errManager;
+	}
+
+	/**
+	 * Expand the provisional flow specification instances below a root into the final set.
+	 *
+	 * @param root the instance model root to expand the flow specification instances of
+	 * @throws InterruptedException if instantiation is canceled
+	 */
+	public void processFlowSpecifications(ComponentInstance root) throws InterruptedException {
+		checkCanceled();
+		for (var provisional : List.copyOf(root.getFlowSpecifications())) {
+			expand(root, provisional);
+			checkCanceled();
+		}
+		for (var child : root.getComponentInstances()) {
+			processFlowSpecifications(child);
+		}
+	}
+
+	/**
+	 * Replace one provisional flow specification instance with the instances its paired-up array elements
+	 * call for. Does nothing when neither end is an array element and no property says otherwise, and
+	 * leaves the provisional instance in place when the pairing could not be produced.
+	 *
+	 * @param ci the component instance that owns the flow specification instance
+	 * @param provisional the flow specification instance to expand
+	 */
+	private void expand(ComponentInstance ci, FlowSpecificationInstance provisional) {
+		var setPA = StructuralProperty.CONNECTION_SET.cachedOn(provisional);
+		var patternPA = StructuralProperty.CONNECTION_PATTERN.cachedOn(provisional);
+		var srcSizes = arraySizes(provisional.getSource());
+		var dstSizes = arraySizes(provisional.getDestination());
+		var overArrays = !srcSizes.isEmpty() || !dstSizes.isEmpty();
+
+		if (setPA == null && patternPA == null && !overArrays) {
+			return;
+		}
+
+		var variants = new ArrayList<FlowSpecificationInstance>();
+		if (setPA == null && patternPA == null) {
+			expandPattern(ci, provisional, null, srcSizes, dstSizes, variants);
+		} else if (patternPA != null) {
+			EcoreUtil.remove(patternPA);
+			for (var pattern : StructuralProperty.alternativesOf(patternPA)) {
+				if (overArrays) {
+					expandPattern(ci, provisional, pattern, srcSizes, dstSizes, variants);
+				} else {
+					errManager.warning(provisional,
+							"Connection pattern specified for flow specification that does not connect array elements.");
+				}
+			}
+		}
+		// no else as we want both the pattern and the connection set evaluated
+		if (setPA != null) {
+			EcoreUtil.remove(setPA);
+			for (var pair : StructuralProperty.pairsOf(setPA)) {
+				createVariant(provisional, pair.source(), pair.destination(), variants);
+			}
+		}
+
+		if (variants.isEmpty()) {
+			/*
+			 * Either nothing was paired up, or every pairing was rejected and reported. Keep the provisional
+			 * instance: dropping it would leave the flow specification without an instance for a flow to
+			 * refer to, which is also what the connection expansion does with a connection it rejected.
+			 */
+			return;
+		}
+		name(provisional, variants);
+		replace(ci, provisional, variants);
+	}
+
+	/**
+	 * Pair up the array elements of the two ends and create one flow specification instance per pair.
+	 *
+	 * @param ci the component instance that owns the flow specification instance
+	 * @param provisional the flow specification instance being expanded
+	 * @param pattern one literal per array dimension, or {@code null} to use the default pattern
+	 * @param srcSizes the sizes of the array dimensions of the source end, empty if it is not an array
+	 * @param dstSizes the sizes of the array dimensions of the destination end, empty if it is not an
+	 *            array
+	 * @param variants collects the instances created for the pairs
+	 */
+	private void expandPattern(ComponentInstance ci, FlowSpecificationInstance provisional,
+			List<PropertyExpression> pattern, List<Integer> srcSizes, List<Integer> dstSizes,
+			List<FlowSpecificationInstance> variants) {
+		var subject = new ArrayPatternExpansion.Subject(provisional, "flow specification", provisional.getName(), ci,
+				ci.getInstanceObjectPath());
+		new ArrayPatternExpansion(errManager, subject, false, pattern, srcSizes, dstSizes,
+				(srcIndices, dstIndices) -> createVariant(provisional, srcIndices, dstIndices, variants)).expand();
+	}
+
+	/**
+	 * Create the flow specification instance for one pair of paired-up element indices. The two ends are
+	 * set explicitly rather than copied, because both have an eOpposite on {@code FeatureInstance} and
+	 * {@code EcoreUtil.copy} does not carry a reference that has one.
+	 *
+	 * @param provisional the flow specification instance being expanded
+	 * @param srcIndices the index of the source element, empty if the source end is not an array
+	 * @param dstIndices the index of the destination element, empty if the destination end is not an array
+	 * @param variants collects the created instance
+	 */
+	private void createVariant(FlowSpecificationInstance provisional, List<Long> srcIndices, List<Long> dstIndices,
+			List<FlowSpecificationInstance> variants) {
+		var variant = EcoreUtil.copy(provisional);
+		variant.setSource(elementAt(provisional.getSource(), srcIndices));
+		variant.setDestination(elementAt(provisional.getDestination(), dstIndices));
+		variants.add(variant);
+	}
+
+	/**
+	 * The sizes of the array dimensions of a flow specification end. A feature array has at most one
+	 * dimension, so this is one size or none at all. The size is the number of feature instances the
+	 * feature was instantiated into, which is what the array bound evaluated to.
+	 *
+	 * @param end the source or destination of a flow specification instance, {@code null} for the end a
+	 *            flow source or a flow sink does not have
+	 * @return the size of the dimension of the end, or an empty list if the end is not an array element
+	 */
+	private List<Integer> arraySizes(FeatureInstance end) {
+		if (end == null || end.getIndex() == 0) {
+			return List.of();
+		}
+		var elements = siblings(end).stream().filter(sibling -> sibling.getFeature() == end.getFeature()).count();
+		return List.of((int) elements);
+	}
+
+	/**
+	 * The feature instance of one element of a flow specification end.
+	 *
+	 * @param end the end the provisional instance was created with, which is the first element of the
+	 *            array when the end is one
+	 * @param indices the index of the element, empty if the end is not an array
+	 * @return the feature instance of that element, or {@code end} itself if the end is not an array
+	 */
+	private FeatureInstance elementAt(FeatureInstance end, List<Long> indices) {
+		if (end == null || indices.isEmpty()) {
+			return end;
+		}
+		var index = indices.getFirst();
+		return siblings(end).stream()
+				.filter(sibling -> sibling.getFeature() == end.getFeature() && sibling.getIndex() == index)
+				.findFirst()
+				.orElse(end);
+	}
+
+	/**
+	 * The feature instances the elements of a feature array are among: those of the component instance for
+	 * a feature of a component type, and those of the enclosing feature group instance for a feature of a
+	 * feature group type.
+	 */
+	private List<FeatureInstance> siblings(FeatureInstance end) {
+		EObject owner = end.eContainer();
+		if (owner instanceof FeatureInstance featureGroup) {
+			return featureGroup.getFeatureInstances();
+		}
+		return ((ComponentInstance) owner).getFeatureInstances();
+	}
+
+	/**
+	 * Name the instances of a flow specification. One instance keeps the name of the declaration, so a
+	 * flow specification that pairs up nothing reads as it always did; several are numbered from one in
+	 * pairing order, the way the several instances of one end to end flow declaration are.
+	 *
+	 * @param provisional the flow specification instance being expanded
+	 * @param variants the instances created for its pairs
+	 */
+	private void name(FlowSpecificationInstance provisional, List<FlowSpecificationInstance> variants) {
+		if (variants.size() == 1) {
+			return;
+		}
+		var number = 1;
+		for (var variant : variants) {
+			variant.setName(provisional.getName() + "_" + number++);
+		}
+	}
+
+	/**
+	 * Put the instances of a flow specification where its provisional instance was, so that the flow
+	 * specifications of a component instance stay in declaration order, and detach the provisional one.
+	 * Its two ends are cleared first, because a feature instance keeps the flow specification instances
+	 * that start or end at it.
+	 *
+	 * @param ci the component instance that owns the flow specification instances
+	 * @param provisional the flow specification instance being replaced
+	 * @param variants the instances that replace it
+	 */
+	private void replace(ComponentInstance ci, FlowSpecificationInstance provisional,
+			List<FlowSpecificationInstance> variants) {
+		var flowSpecifications = ci.getFlowSpecifications();
+		flowSpecifications.addAll(flowSpecifications.indexOf(provisional), variants);
+		provisional.setSource(null);
+		provisional.setDestination(null);
+		EcoreUtil.remove(provisional);
+	}
+
+	private void checkCanceled() throws InterruptedException {
+		if (monitor.isCanceled()) {
+			throw new InterruptedException();
+		}
+	}
+}

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/StructuralProperty.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/StructuralProperty.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.aadl2.instantiation.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.osate.aadl2.BasicPropertyAssociation;
+import org.osate.aadl2.IntegerLiteral;
+import org.osate.aadl2.ListValue;
+import org.osate.aadl2.Property;
+import org.osate.aadl2.PropertyAssociation;
+import org.osate.aadl2.PropertyExpression;
+import org.osate.aadl2.PropertySet;
+import org.osate.aadl2.RecordValue;
+import org.osate.aadl2.instance.InstanceObject;
+
+/**
+ * A property of the standard {@code Communication_Properties} property set whose value decides how many
+ * instances a declaration over arrays stands for. Both apply to a connection and to a flow specification,
+ * and both have to be cached on the provisional instances before either expansion runs, which is why
+ * {@code InstantiateModel} splits them out of the properties it caches at the end.
+ * <p>
+ * The one place that knows the names is here, so that what
+ * {@link #isStructural(Property) is cached early} and what
+ * {@link #cachedOn(InstanceObject) is read back} cannot drift apart.
+ */
+enum StructuralProperty {
+	/** Which elements of the two arrays are paired up. */
+	CONNECTION_PATTERN("Connection_Pattern"),
+
+	/** Which pairs of element indices are paired up, listed one by one. */
+	CONNECTION_SET("Connection_Set");
+
+	private static final String COMMUNICATION_PROPERTIES = "Communication_Properties";
+
+	private final String propertyName;
+
+	StructuralProperty(String propertyName) {
+		this.propertyName = propertyName;
+	}
+
+	/**
+	 * Is this one of the properties that decide how many instances a declaration expands into?
+	 *
+	 * @param property the property definition to test
+	 */
+	static boolean isStructural(Property property) {
+		for (var structural : values()) {
+			if (structural.matches(property)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * The association of this property cached on an instance object.
+	 *
+	 * @param io the instance object the value was cached on
+	 * @return the association, or {@code null} if the object carries no value for this property
+	 */
+	PropertyAssociation cachedOn(InstanceObject io) {
+		for (var pa : io.getOwnedPropertyAssociations()) {
+			if (matches(pa.getProperty())) {
+				return pa;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * The alternatives of a {@code Connection_Pattern} value. The property is a list of dimension pattern
+	 * values, and a dimension pattern value is a list with one literal per array dimension, so the
+	 * alternatives are the outer list and the elements paired up are the union over them.
+	 *
+	 * @param patternPA the cached {@code Connection_Pattern} association
+	 */
+	static List<List<PropertyExpression>> alternativesOf(PropertyAssociation patternPA) {
+		var alternatives = new ArrayList<List<PropertyExpression>>();
+		for (var alternative : valueOf(patternPA)) {
+			alternatives.add(((ListValue) alternative).getOwnedListElements());
+		}
+		return alternatives;
+	}
+
+	/**
+	 * One pair of a {@code Connection_Set} value: the index of a source element and the index of a
+	 * destination element, one integer per array dimension of that end.
+	 */
+	record IndexPair(List<Long> source, List<Long> destination) {
+	}
+
+	/**
+	 * The element index pairs of a {@code Connection_Set} value.
+	 *
+	 * @param setPA the cached {@code Connection_Set} association
+	 */
+	static List<IndexPair> pairsOf(PropertyAssociation setPA) {
+		var pairs = new ArrayList<IndexPair>();
+		for (var pair : valueOf(setPA)) {
+			var record = (RecordValue) pair;
+			pairs.add(new IndexPair(indices(record, "src"), indices(record, "dst")));
+		}
+		return pairs;
+	}
+
+	/** The elements of the list value of an association. Both properties are lists. */
+	private static List<PropertyExpression> valueOf(PropertyAssociation pa) {
+		return ((ListValue) pa.getOwnedValues().get(0).getOwnedValue()).getOwnedListElements();
+	}
+
+	/** The integers of one field of a {@code Connection_Pair} record value. */
+	private static List<Long> indices(RecordValue record, String field) {
+		var indices = new ArrayList<Long>();
+		for (BasicPropertyAssociation fieldValue : record.getOwnedFieldValues()) {
+			if (fieldValue.getProperty().getName().equalsIgnoreCase(field)) {
+				for (var index : ((ListValue) fieldValue.getOwnedValue()).getOwnedListElements()) {
+					indices.add(((IntegerLiteral) index).getValue());
+				}
+			}
+		}
+		return indices;
+	}
+
+	/**
+	 * Is this the property definition of this constant? Compared by name and by the name of the owning
+	 * property set, because the standard property sets are resolved per model rather than shared.
+	 */
+	private boolean matches(Property property) {
+		return propertyName.equalsIgnoreCase(property.getName()) && property.getOwner() instanceof PropertySet ps
+				&& COMMUNICATION_PROPERTIES.equalsIgnoreCase(ps.getName());
+	}
+}

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/package-info.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/package-info.java
@@ -23,17 +23,23 @@
  */
 /**
  * The internals of instance model creation: the across-first enumeration of connection instances,
- * the expansion of connection arrays, the enumeration of system operation modes, and the discovery
- * of end-to-end flow instances.
+ * the expansion of arrays, the enumeration of system operation modes, and the discovery of
+ * end-to-end flow instances.
  *
  * <p>
  * {@link org.osate.aadl2.instantiation.internal.ConnectionArrayExpander} expands the connection
- * instances of one instance model root into the final connection set, and
+ * instances of one instance model root into the final connection set,
+ * {@link org.osate.aadl2.instantiation.internal.FlowSpecArrayExpander} does the same for its flow
+ * specification instances, and
  * {@link org.osate.aadl2.instantiation.internal.SystemOperationModeBuilder} enumerates the system
- * operation modes of a system instance. Both are phases of {@code InstantiateModel}, which is the
- * entry point that carries the compatibility promise for them. The rest of the package is the
- * connection instance traversal described below, and the end-to-end flow discovery described after
- * it.
+ * operation modes of a system instance. All three are phases of {@code InstantiateModel}, which is
+ * the entry point that carries the compatibility promise for them. The two expanders read the same
+ * two properties, identified by
+ * {@link org.osate.aadl2.instantiation.internal.StructuralProperty}, and pair up array elements the
+ * same way, which is
+ * {@link org.osate.aadl2.instantiation.internal.ArrayPatternExpansion}. The rest of the package is
+ * the connection instance traversal described below, and the end-to-end flow discovery described
+ * after it.
  * </p>
  *
  * <p>

--- a/core/org.osate.core.tests/models/issue2787/.gitignore
+++ b/core/org.osate.core.tests/models/issue2787/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue2787/.project
+++ b/core/org.osate.core.tests/models/issue2787/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue2787</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue2787/Issue2787.aadl
+++ b/core/org.osate.core.tests/models/issue2787/Issue2787.aadl
@@ -1,0 +1,84 @@
+-- Regression fixture for issue #2787: a flow specification whose ends are feature arrays stands for
+-- one flow per pair of elements that Connection_Pattern or Connection_Set pairs up, and the pairing
+-- has to reach the end to end flow instances built over it.
+--
+-- A feature array is allowed only in an abstract, thread, device, memory, system, or processor
+-- classifier, so the array ends here sit on devices and on abstract components rather than on the
+-- processes that issue #1833 used.
+package Issue2787
+public
+	data Sample
+	end Sample;
+
+	device Sensor
+	features
+		outp: out data port Sample[2];
+	flows
+		fsrc: flow source outp;
+	end Sensor;
+
+	device Actuator
+	features
+		inp: in data port Sample[2];
+	flows
+		fsnk: flow sink inp;
+	end Actuator;
+
+	-- A leaf that carries the flow through, so the flow path is the whole component
+	abstract Worker
+	features
+		inp: in data port Sample[2];
+		outp: out data port Sample[2];
+	flows
+		wpath: flow path inp -> outp;
+	end Worker;
+
+	-- The same flow path, but realized by a flow implementation that runs through Worker
+	abstract Relay
+	features
+		inp: in data port Sample[2];
+		outp: out data port Sample[2];
+	flows
+		fpath: flow path inp -> outp;
+	end Relay;
+
+	abstract implementation Relay.i
+	subcomponents
+		worker: abstract Worker;
+	connections
+		down: port inp -> worker.inp;
+		up: port worker.outp -> outp;
+	flows
+		fpath: flow path inp -> down -> worker.wpath -> up -> outp;
+	end Relay.i;
+
+	system Top
+	end Top;
+
+	-- The model of issue #1833: a flow source and a flow sink on feature arrays, connected element by
+	-- element. The connection stands for two connection instances, so the flow has to stand for two flow
+	-- instances as well.
+	system implementation Top.i
+	subcomponents
+		sensor: device Sensor;
+		actuator: device Actuator;
+	connections
+		c: port sensor.outp -> actuator.inp;
+	flows
+		etef: end to end flow sensor.fsrc -> c -> actuator.fsnk;
+	end Top.i;
+
+	-- The same flow through a component whose flow specification is realized by a flow implementation.
+	-- The element a flow specification instance is for pins the element its implementation runs through.
+	system implementation Top.viaImplementation
+	subcomponents
+		sensor: device Sensor;
+		relay: abstract Relay.i;
+		actuator: device Actuator;
+	connections
+		toRelay: port sensor.outp -> relay.inp;
+		fromRelay: port relay.outp -> actuator.inp;
+	flows
+		etef: end to end flow sensor.fsrc -> toRelay -> relay.fpath -> fromRelay -> actuator.fsnk;
+	end Top.viaImplementation;
+end Issue2787;

--- a/core/org.osate.core.tests/models/issue2787/Issue2787.aadl
+++ b/core/org.osate.core.tests/models/issue2787/Issue2787.aadl
@@ -81,4 +81,35 @@ public
 	flows
 		etef: end to end flow sensor.fsrc -> toRelay -> relay.fpath -> fromRelay -> actuator.fsnk;
 	end Top.viaImplementation;
+
+	-- A nested end to end flow replicated by the flow specification instances of a feature array. Every
+	-- subcomponent here is a single component, so the multiplicity comes from the arrays on their features
+	-- alone. The flow that contains the nested one has to be replicated with it, and each replica has to
+	-- pick the nested replica of its own array element. The nested flow ends its container here.
+	system implementation Top.nested
+	subcomponents
+		sensor: device Sensor;
+		worker: abstract Worker;
+		actuator: device Actuator;
+	connections
+		toWorker: port sensor.outp -> worker.inp;
+		fromWorker: port worker.outp -> actuator.inp;
+	flows
+		inner: end to end flow worker.wpath -> fromWorker -> actuator.fsnk;
+		outer: end to end flow sensor.fsrc -> toWorker -> inner;
+	end Top.nested;
+
+	-- The same, with the nested flow starting its container instead of ending it
+	system implementation Top.nestedAtStart
+	subcomponents
+		sensor: device Sensor;
+		worker: abstract Worker;
+		actuator: device Actuator;
+	connections
+		toWorker: port sensor.outp -> worker.inp;
+		fromWorker: port worker.outp -> actuator.inp;
+	flows
+		inner: end to end flow sensor.fsrc -> toWorker -> worker.wpath;
+		outer: end to end flow inner -> fromWorker -> actuator.fsnk;
+	end Top.nestedAtStart;
 end Issue2787;

--- a/core/org.osate.core.tests/models/issue2787/Issue2787Failures.aadl
+++ b/core/org.osate.core.tests/models/issue2787/Issue2787Failures.aadl
@@ -1,0 +1,48 @@
+-- The pairings a flow specification over feature arrays cannot produce. The reports mirror the ones the
+-- connection expansion makes for the same situations, because the pairing is the same arithmetic.
+package Issue2787Failures
+public
+	data Sample
+	end Sample;
+
+	-- One_To_One applies by default and the two arrays have different sizes, so there is no pairing.
+	abstract Mismatch
+	features
+		inp: in data port Sample[4];
+		outp: out data port Sample[3];
+	flows
+		wrongSizes: flow path inp -> outp;
+	end Mismatch;
+
+	-- A pattern on a flow specification whose ends are not arrays has nothing to pair up.
+	abstract Plain
+	features
+		inp: in data port Sample;
+		outp: out data port Sample;
+	flows
+		notAnArray: flow path inp -> outp {
+			Communication_Properties::Connection_Pattern => ((One_To_One));
+		};
+	end Plain;
+
+	-- Only one end is an array, and the pattern needs an index at both ends.
+	abstract Underspecified
+	features
+		inp: in data port Sample[2];
+		outp: out data port Sample;
+	flows
+		tooFewIndices: flow path inp -> outp {
+			Communication_Properties::Connection_Pattern => ((One_To_One));
+		};
+	end Underspecified;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+	subcomponents
+		mismatch: abstract Mismatch;
+		plain: abstract Plain;
+		underspecified: abstract Underspecified;
+	end Top.i;
+end Issue2787Failures;

--- a/core/org.osate.core.tests/models/issue2787/Issue2787Patterns.aadl
+++ b/core/org.osate.core.tests/models/issue2787/Issue2787Patterns.aadl
@@ -1,0 +1,77 @@
+-- The patterns a flow specification over feature arrays can be paired up by. There are no connections
+-- and no end to end flows here: what is under test is the set of flow specification instances the
+-- pairing produces, and their source and destination array elements.
+package Issue2787Patterns
+public
+	data Sample
+	end Sample;
+
+	-- Multiple flow specifications involving the same features are allowed, so one component can carry
+	-- one flow specification per pairing.
+	abstract Shifter
+	features
+		inp: in data port Sample[3];
+		outp: out data port Sample[3];
+	flows
+		-- No property: One_To_One applies
+		straight: flow path inp -> outp;
+		-- Next drops the last source element, because it has no successor
+		shifted: flow path inp -> outp {
+			Communication_Properties::Connection_Pattern => ((Next));
+		};
+		-- Two alternatives in one property value: the pairings are the union of both
+		bidirectional: flow path inp -> outp {
+			Communication_Properties::Connection_Pattern => ((Next), (Previous));
+		};
+		-- Explicit index pairs instead of a pattern
+		selected: flow path inp -> outp {
+			Communication_Properties::Connection_Set => ([src => (1); dst => (3);], [src => (3); dst => (1);]);
+		};
+		-- A pattern and a set together: the pairings are the union of both
+		combined: flow path inp -> outp {
+			Communication_Properties::Connection_Pattern => ((Even_To_Even));
+			Communication_Properties::Connection_Set => ([src => (1); dst => (1);]);
+		};
+	end Shifter;
+
+	-- One array end and one scalar end. All_To_One applies, so every element of the array end has its own
+	-- flow to the single element of the scalar end.
+	abstract Merger
+	features
+		inp: in data port Sample[2];
+		outp: out data port Sample;
+	flows
+		merge: flow path inp -> outp;
+	end Merger;
+
+	-- The mirror of Merger: One_To_All applies.
+	abstract Splitter
+	features
+		inp: in data port Sample;
+		outp: out data port Sample[2];
+	flows
+		split: flow path inp -> outp;
+	end Splitter;
+
+	-- A flow source and a flow sink have one array end each, so the pairing degenerates to one flow per
+	-- element of that end. The flow names avoid 'source' and 'sink', which are reserved words.
+	abstract Boundary
+	features
+		inp: in data port Sample[2];
+		outp: out data port Sample[3];
+	flows
+		emit: flow source outp;
+		absorb: flow sink inp;
+	end Boundary;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+	subcomponents
+		shifter: abstract Shifter;
+		merger: abstract Merger;
+		splitter: abstract Splitter;
+		boundary: abstract Boundary;
+	end Top.i;
+end Issue2787Patterns;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2787Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2787Test.java
@@ -170,8 +170,9 @@ public class Issue2787Test extends XtextTest {
 		assertEquals(List.of(
 				"Error: Array size mismatch (One_to_One) on flow specification wrongSizes"
 						+ " in Top_i_Instance.mismatch: 4 at source and 3 at destination.",
-				"Warning: Connection pattern specified for flow specification that does not connect array elements.",
-				"Error: Too few indices for flow specification destination for tooFewIndices"), diagnostics(instance));
+				"Error: Too few indices for flow specification destination for tooFewIndices",
+				"Warning: Connection pattern specified for flow specification that does not connect array elements."),
+				diagnostics(instance));
 	}
 
 	/**
@@ -229,6 +230,10 @@ public class Issue2787Test extends XtextTest {
 		return objects.stream().map(InstanceObject::getName).sorted().toList();
 	}
 
+	/**
+	 * The reports of an instantiation, sorted. Which component instance is expanded first is not what is
+	 * under test, so the order the reports were made in is not pinned here.
+	 */
 	private List<String> diagnostics(SystemInstance instance) {
 		return ((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource())).getErrors()
 				.stream()

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2787Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2787Test.java
@@ -123,6 +123,32 @@ public class Issue2787Test extends XtextTest {
 	}
 
 	/**
+	 * A nested end to end flow whose replication comes from the flow specification instances of a feature
+	 * array, not from an array of subcomponents: every subcomponent in the model is a single component. The
+	 * flow that contains the nested one is replicated with it, and each replica refers to the nested replica
+	 * of its own array element. Asserted for the nested flow ending its container and starting it, the two
+	 * handshakes {@code processEndToEndFlow} has.
+	 */
+	@Test
+	public void aNestedFlowIsReplicatedPerArrayElement() throws Exception {
+		var ending = instantiate("Issue2787.aadl", "Top.nested");
+
+		assertEquals(List.of("inner_1 : wpath_1 -> worker.outp[1] --> actuator.inp[1] -> fsnk_1",
+				"inner_2 : wpath_2 -> worker.outp[2] --> actuator.inp[2] -> fsnk_2",
+				"outer_1 : fsrc_1 -> sensor.outp[1] --> worker.inp[1] -> inner_1",
+				"outer_2 : fsrc_2 -> sensor.outp[2] --> worker.inp[2] -> inner_2"), flows(ending));
+		assertEquals(List.of(), diagnostics(ending));
+
+		var starting = instantiate("Issue2787.aadl", "Top.nestedAtStart");
+
+		assertEquals(List.of("inner_1 : fsrc_1 -> sensor.outp[1] --> worker.inp[1] -> wpath_1",
+				"inner_2 : fsrc_2 -> sensor.outp[2] --> worker.inp[2] -> wpath_2",
+				"outer_1 : inner_1 -> worker.outp[1] --> actuator.inp[1] -> fsnk_1",
+				"outer_2 : inner_2 -> worker.outp[2] --> actuator.inp[2] -> fsnk_2"), flows(starting));
+		assertEquals(List.of(), diagnostics(starting));
+	}
+
+	/**
 	 * Every pairing a flow specification over feature arrays can be given. The pairings, their order, and
 	 * the reports are the ones the same property values produce on a connection, because the pairing is the
 	 * same arithmetic.

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2787Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2787Test.java
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.aadl2.instance.FeatureInstance;
+import org.osate.aadl2.instance.InstanceObject;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * A flow specification whose ends are feature arrays used to become a single flow specification instance
+ * between the first element of each end, because the endpoint lookup returned the first feature instance
+ * of the array. {@code Connection_Pattern} and {@code Connection_Set} apply to a flow specification, and
+ * were never read there, so there was no way to say which source element flows to which destination
+ * element either.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue2787Test extends XtextTest {
+	private static final String MODEL_DIR = "org.osate.core.tests/models/issue2787/";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	private AnalysisErrorReporterManager errorManager;
+
+	/**
+	 * The model of issue #1833. Both flow specification ends are feature arrays of the same size, so the
+	 * default {@code One_To_One} pairing gives each element its own flow specification instance.
+	 */
+	@Test
+	public void flowSpecificationsAreExpandedPerElement() throws Exception {
+		var instance = instantiate("Issue2787.aadl", "Top.i");
+
+		assertEquals(List.of("Top_i_Instance.actuator.fsnk_1 : inp[1] -> <none>",
+				"Top_i_Instance.actuator.fsnk_2 : inp[2] -> <none>",
+				"Top_i_Instance.sensor.fsrc_1 : <none> -> outp[1]",
+				"Top_i_Instance.sensor.fsrc_2 : <none> -> outp[2]"), flowSpecifications(instance));
+		assertEquals(List.of(), diagnostics(instance));
+	}
+
+	/**
+	 * The connection between the two feature arrays is expanded per element, and so is the end to end flow
+	 * over it: one flow instance per element, each built from the flow specification instances of that
+	 * element.
+	 */
+	@Test
+	public void endToEndFlowIsBuiltPerElement() throws Exception {
+		var instance = instantiate("Issue2787.aadl", "Top.i");
+
+		assertEquals(List.of("sensor.outp[1] --> actuator.inp[1]", "sensor.outp[2] --> actuator.inp[2]"),
+				names(instance.getAllConnectionInstances()));
+		assertEquals(List.of("etef_1 : fsrc_1 -> sensor.outp[1] --> actuator.inp[1] -> fsnk_1",
+				"etef_2 : fsrc_2 -> sensor.outp[2] --> actuator.inp[2] -> fsnk_2"), flows(instance));
+		assertEquals(List.of(), diagnostics(instance));
+	}
+
+	/**
+	 * The flow specification of the relay is realized by a flow implementation. The element a flow
+	 * specification instance is for pins the element the implementation runs through, so the flow instances
+	 * stay on one element from the sensor to the actuator.
+	 */
+	@Test
+	public void flowImplementationStaysOnTheArrayElement() throws Exception {
+		var instance = instantiate("Issue2787.aadl", "Top.viaImplementation");
+
+		assertEquals(List.of("relay.worker.outp[1] --> actuator.inp[1]", "relay.worker.outp[2] --> actuator.inp[2]",
+				"sensor.outp[1] --> relay.worker.inp[1]", "sensor.outp[2] --> relay.worker.inp[2]"),
+				names(instance.getAllConnectionInstances()));
+		assertEquals(List.of(
+				"etef_1 : fsrc_1 -> sensor.outp[1] --> relay.worker.inp[1] -> wpath_1"
+						+ " -> relay.worker.outp[1] --> actuator.inp[1] -> fsnk_1",
+				"etef_2 : fsrc_2 -> sensor.outp[2] --> relay.worker.inp[2] -> wpath_2"
+						+ " -> relay.worker.outp[2] --> actuator.inp[2] -> fsnk_2"),
+				flows(instance));
+		assertEquals(List.of(), diagnostics(instance));
+	}
+
+	/**
+	 * Every pairing a flow specification over feature arrays can be given. The pairings, their order, and
+	 * the reports are the ones the same property values produce on a connection, because the pairing is the
+	 * same arithmetic.
+	 */
+	@Test
+	public void patternsPairUpTheElements() throws Exception {
+		var instance = instantiate("Issue2787Patterns.aadl", "Top.i");
+
+		assertEquals(List.of("Top_i_Instance.boundary.absorb_1 : inp[1] -> <none>",
+				"Top_i_Instance.boundary.absorb_2 : inp[2] -> <none>",
+				"Top_i_Instance.boundary.emit_1 : <none> -> outp[1]",
+				"Top_i_Instance.boundary.emit_2 : <none> -> outp[2]",
+				"Top_i_Instance.boundary.emit_3 : <none> -> outp[3]",
+				"Top_i_Instance.merger.merge_1 : inp[1] -> outp", "Top_i_Instance.merger.merge_2 : inp[2] -> outp",
+				"Top_i_Instance.shifter.bidirectional_1 : inp[1] -> outp[2]",
+				"Top_i_Instance.shifter.bidirectional_2 : inp[2] -> outp[3]",
+				"Top_i_Instance.shifter.bidirectional_3 : inp[2] -> outp[1]",
+				"Top_i_Instance.shifter.bidirectional_4 : inp[3] -> outp[2]",
+				"Top_i_Instance.shifter.combined_1 : inp[2] -> outp[2]",
+				"Top_i_Instance.shifter.combined_2 : inp[1] -> outp[1]",
+				"Top_i_Instance.shifter.selected_1 : inp[1] -> outp[3]",
+				"Top_i_Instance.shifter.selected_2 : inp[3] -> outp[1]",
+				"Top_i_Instance.shifter.shifted_1 : inp[1] -> outp[2]",
+				"Top_i_Instance.shifter.shifted_2 : inp[2] -> outp[3]",
+				"Top_i_Instance.shifter.straight_1 : inp[1] -> outp[1]",
+				"Top_i_Instance.shifter.straight_2 : inp[2] -> outp[2]",
+				"Top_i_Instance.shifter.straight_3 : inp[3] -> outp[3]",
+				"Top_i_Instance.splitter.split_1 : inp -> outp[1]",
+				"Top_i_Instance.splitter.split_2 : inp -> outp[2]"), flowSpecifications(instance));
+		assertEquals(List.of(), diagnostics(instance));
+	}
+
+	/**
+	 * A pairing that cannot be produced leaves the flow specification instance in place, so the flow
+	 * specification is still there to be referred to, and is reported the way the connection expansion
+	 * reports the same situation.
+	 */
+	@Test
+	public void unpairableFlowSpecificationsAreReported() throws Exception {
+		var instance = instantiate("Issue2787Failures.aadl", "Top.i");
+
+		assertEquals(List.of("Top_i_Instance.mismatch.wrongSizes : inp[1] -> outp[1]",
+				"Top_i_Instance.plain.notAnArray : inp -> outp",
+				"Top_i_Instance.underspecified.tooFewIndices : inp[1] -> outp"), flowSpecifications(instance));
+		assertEquals(List.of(
+				"Error: Array size mismatch (One_to_One) on flow specification wrongSizes"
+						+ " in Top_i_Instance.mismatch: 4 at source and 3 at destination.",
+				"Warning: Connection pattern specified for flow specification that does not connect array elements.",
+				"Error: Too few indices for flow specification destination for tooFewIndices"), diagnostics(instance));
+	}
+
+	/**
+	 * The flow specification instances of a model, as {@code path : source -> destination}, sorted. The
+	 * name of the instance carries the pairing, and its two ends carry the array elements it pairs up.
+	 */
+	private List<String> flowSpecifications(SystemInstance instance) {
+		return collect(instance, ComponentInstance::getFlowSpecifications, new ArrayList<>()).stream()
+				.map(fsi -> fsi.getInstanceObjectPath() + " : " + end(fsi.getSource()) + " -> "
+						+ end(fsi.getDestination()))
+				.sorted()
+				.toList();
+	}
+
+	private static String end(FeatureInstance fi) {
+		return fi == null ? "<none>" : fi.getFullName();
+	}
+
+	/**
+	 * The end to end flow instances of a model, as {@code name : element -> element -> ...}, sorted.
+	 */
+	private List<String> flows(SystemInstance instance) {
+		return collect(instance, ComponentInstance::getEndToEndFlows, new ArrayList<>()).stream()
+				.map(flow -> flow.getName() + " : " + String.join(" -> ",
+						flow.getFlowElements().stream().map(InstanceObject::getName).toList()))
+				.sorted()
+				.toList();
+	}
+
+	private <T extends InstanceObject> List<T> collect(ComponentInstance ci,
+			Function<ComponentInstance, List<T>> of, List<T> result) {
+		result.addAll(of.apply(ci));
+		ci.getComponentInstances().forEach(child -> collect(child, of, result));
+		return result;
+	}
+
+	private SystemInstance instantiate(String model, String implementationName) throws Exception {
+		var pkg = testHelper.parseFile(MODEL_DIR + model);
+		validationHelper.assertNoIssues(pkg);
+		var implementation = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals(implementationName))
+				.findFirst()
+				.orElseThrow();
+		errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+
+		var instance = InstantiateModel.instantiate(implementation, errorManager);
+
+		assertNotNull(instance);
+		return instance;
+	}
+
+	private List<String> names(List<? extends InstanceObject> objects) {
+		return objects.stream().map(InstanceObject::getName).sorted().toList();
+	}
+
+	private List<String> diagnostics(SystemInstance instance) {
+		return ((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource())).getErrors()
+				.stream()
+				.map(message -> message.kind + ": " + message.message)
+				.sorted()
+				.toList();
+	}
+}


### PR DESCRIPTION
Fixes #2787.

## Cause

`InstantiateModel.instantiateFlowSpecs` creates one `FlowSpecificationInstance` per flow specification and resolves its ends with `findFeatureInstance`, which returns the **first** `FeatureInstance` of a feature array. A flow specification whose in or out end is a feature array therefore became a single instance between element 1 of each end.

`Connection_Pattern` and `Connection_Set` are declared `applies to (connection, flow specification)` in `Communication_Properties`, and were never read there, so there was also no way to say which source element flows to which destination element.

`FlowConnectionMatcher.endsAtFlowSource` then looked the flow specification instance up with `findFlowSpecInstance`, which returns the first one, so even once several instances exist a connection instance reaching any other element matched nothing.

## Correction

`FlowSpecArrayExpander` (new, `instantiation.internal`) replaces each provisional flow specification instance with one instance per pair of elements the properties pair up:

- Both ends arrays of the same size, no property: `One_To_One`, as the property description states for an unset value.
- One end an array, the other scalar: `All_To_One` or `One_To_All`, so every element of the array end has its own flow.
- Any of the 14 `Supported_Connection_Patterns` literals, several alternatives in one value, `Connection_Set`, or a pattern and a set together, whose pairings are the union.
- Size mismatch, an unsupported literal, too few indices, or a pattern on a flow specification with no array end are reported the way the connection expansion reports the same situations, and the provisional instance is kept, so the flow specification is still there for a flow to refer to.

The pairing arithmetic is now `ArrayPatternExpansion`, lifted out of `ConnectionArrayExpander` because a flow specification reads the same two properties with the same meaning; `StructuralProperty` is the one place that identifies those two properties and decodes their values. The connection expander keeps every one of its four messages verbatim.

One instance keeps the name of the declaration; several are named `fs_1`, `fs_2`, … in pairing order, the way the several instances of one end to end flow declaration already are. No metamodel, grammar, property set, or API signature change.

The expansion runs in the window where the two properties are already cached on provisional instances and before the end to end flows are built over them, and it runs for **every** instance model root: it needs only the component's own feature instances, so it does not depend on the system operation modes a referenced classifier root has none of.

End to end flow traversal forks over the instances — at the start of a flow each starts a flow of its own, after a connection the branches are the compatible pairs of connection instance and flow specification instance — and `endsAtFlowSource` takes the instance under consideration instead of looking one up. Nothing else needed an element test: `carriesConnectionPath` already requires the next connection instance to start exactly at the previous element's destination feature instance, so a branch that entered one element stays on it, inside a flow implementation too.

## Regression

`core/org.osate.core.tests/models/issue2787/`, asserted by `Issue2787Test`:

- `Issue2787.aadl` — Aaron Greenhouse's first example in #1833 (a flow source and a flow sink on feature arrays, connected element by element), and the same flow through a component whose flow specification is realized by a flow implementation. Asserts the flow specification instances with their paired elements, and the end to end flow instances: `etef_1` through element 1 and `etef_2` through element 2, with the implementation staying on the element its flow specification instance is for.
- `Issue2787Patterns.aadl` — one flow specification per pairing: the default, `Next`, two alternatives in one value, `Connection_Set`, a pattern and a set together, one array end against one scalar end in both directions, and a flow source and a flow sink whose single end is an array. Asserts every resulting instance with its source and destination array element.
- `Issue2787Failures.aadl` — size mismatch, a pattern with no array end, and a pattern needing an index the scalar end cannot give. Asserts the reports and that the flow specification instance survives.

All five cases fail before the fix with a single instance on element 1, a single flow instance, and no report.

The array ends sit on devices and abstract components rather than on the processes of the original issue, because a feature array is allowed only in an abstract, thread, device, memory, system, or processor classifier.

## Validation

Focused, from the repository root:

    mvn -o -s releng/osate.releng/settings.xml -Plocal -T6 \
      -pl :org.osate.aadl2.instantiation,:org.osate.core.feature,:org.osate.core.tests \
      -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false \
      -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
      -Dtest=Issue2787Test -DfailIfNoTests=false clean install

`Issue2787Test` 5/5. The whole of `org.osate.core.tests` is 800/800, including the 96 tests over connection arrays, patterns and connection sets, which pass unchanged after the extraction.

Clean root reactor:

    mvn -s releng/osate.releng/settings.xml -Plocal -T6 \
      -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false \
      -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
      -DfailIfNoTests=false clean install

BUILD SUCCESS, 1395 tests, 0 failures, 0 errors.

## Dependencies

None. Based on `master` at 61e405b81a. #3005, which #2787 was marked blocked by, is merged.

## Residual risk

Instantiation output changes for any model that has a flow specification over feature arrays: n flow specification instances named `fs_1`…`fs_n` instead of one named `fs` on element 1, and correspondingly more end to end flow instances, so flow analyses such as latency will report more flows. That is the point of the issue, but it is a visible change for existing models.

One existing characterization recorded the old behavior and is updated here: `Serializer1Test.testFlowSpecification`, where a flow sink on a feature array now serializes as `f4_1` and `f4_2`. Its two other array cases are unchanged, and the test now says why — an array declared inside a feature group type is not allowed and is instantiated as a single feature, and a feature reached *through* an array feature group is not itself an array feature.

A flow end reached through an array feature group keeps the first element of that group, as before. That is deliberate scope for this change and worth its own issue if it matters.

`Connection_Pattern` and `Connection_Set` on a flow specification are reported only during instantiation, as they are for connections; nothing was added to the editor's validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)