### PR TITLE
Resolve flow segments to every element of a subcomponent array 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/doc/e2e_instantiation.md
+++ b/core/org.osate.aadl2.instantiation/doc/e2e_instantiation.md
@@ -123,7 +123,7 @@ end to end flow
   consumer.fsnk
 ```
 
-Five sources of multiplicity:
+Six sources of multiplicity:
 
 1. **Multiple flow implementations** for one flow specification — in the test model
    `BasicAndBranching.aadl`, `Choice.two_paths` declares `fpath` twice, once through `upper` and
@@ -136,6 +136,9 @@ Five sources of multiplicity:
    out end is a feature array was expanded by `FlowSpecArrayExpander` into one instance per pair of
    array elements that `Connection_Pattern`, `Connection_Set` or the default `One_To_One` pairs up
    (issue #2787).
+6. **Multiple component instances** for one subcomponent named by a segment — a subcomponent array has
+   one component instance per element, and each of them continues a flow of its own (issue #1833).
+   A nested ETE replicated this way replicates the flow that contains it, through source 4.
 
 Each multiplicity point **forks** the traversal. Surviving branches are named `<flow>_1`,
 `<flow>_2`, … at commit time.
@@ -331,17 +334,27 @@ processETESegment(ci, etei, segment, iter, errorElement)
   │                            else:
   │                                traversal.connections += fe   (pending filter)
   │
-  ├─ FlowSpecification ──────► sci = ci.findSubcomponentInstance(segment.getContext())
-  │                            sci != null → processSubcomponentFlow(sci, …)
-  │                            sci == null → owner error, "Could not find component
-  │                                          instance for subcomponent …"
+  ├─ FlowSpecification ──────► scis = subcomponentInstances(ci, segment.getContext(), …)
+  │                            FORK PER ELEMENT → processSubcomponentFlow(element, …)
+  │                            scis empty → owner error, "Could not find component
+  │                                         instance for subcomponent …"
   │
-  ├─ Subcomponent ───────────► processFlowStep(sci, …)  (implicit flow: whole component)
+  ├─ Subcomponent ───────────► scis = subcomponentInstances(ci, fe, …)
+  │                            FORK PER ELEMENT → processFlowStep(element, …)
+  │                            (implicit flow: the whole component)
   │
   ├─ DataAccess / SubprogramAccess ─► processAccess(…)
   │
   └─ EndToEndFlow ───────────► processEndToEndFlow(…)   (nested flow)
 ```
+
+A declaration names a subcomponent, not one of its elements, so `subcomponentInstances` returns all
+of them and `forkOverElements` continues a flow per element (issue #1833). It **narrows** them first:
+with pending connections, only the elements some matching connection instance ends in survive.
+Forking into an element no connection reaches would create a branch that can only die, and
+§6.4 would report that death as a missing semantic connection — so issue 1984's filter-first rule
+has to be applied one fork earlier. When nothing reaches any element, one element is kept, so the
+report is made once, the way it was when a declaration resolved to the first element only.
 
 ### 6.2 Descent and ascent
 
@@ -903,4 +916,5 @@ attributions in this document can be checked without relying on the source comme
 | [#2987](https://github.com/osate/osate2/issues/2987) | Cyclic nested end-to-end flows create cyclic instance graphs | §6.7, §10 — `activeDeclarations` cycle check |
 | [#2988](https://github.com/osate/osate2/issues/2988) | End-to-end flow connection matching ignores declarative connection context | §6.4 — `isSameOrRefinedConnection` |
 | [#2787](https://github.com/osate/osate2/issues/2787) | Flow specifications need to be able to reference features in a feature array | §2, §3, §6.4, §6.5 — one flow specification instance per pair of array elements, and the fork over them |
+| [#1833](https://github.com/osate/osate2/issues/1833) | Array ports and connections do not appear in flow instances | §3, §6.1 — a segment that names a subcomponent array resolves to every element, narrowed to the ones a connection reaches |
 | [#3055](https://github.com/osate/osate2/issues/3055) | Refactor `CreateEndToEndFlowsSwitch` into focused collaborators | §1, §4.1 — where each type lives and what it owns |

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/EndToEndFlowSession.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/EndToEndFlowSession.java
@@ -506,6 +506,127 @@ public final class EndToEndFlowSession {
 		host.processETESegment(ci, etei, firstSegment, iter, ete);
 	}
 
+	/** One traversal step, taken once per element of a subcomponent array by {@link #forkOverElements}. */
+	private interface ElementStep {
+		/**
+		 * @param element the element of the subcomponent array this branch goes through
+		 * @param etei the flow instance of this branch
+		 * @param iter this branch's position in the declaration
+		 */
+		void take(ComponentInstance element, EndToEndFlowInstance etei, FlowIterator iter);
+	}
+
+	/**
+	 * Take a step once per element of a subcomponent array, forking the candidate so that each element
+	 * continues a flow of its own. A declaration names a subcomponent, not one of its elements, so all of
+	 * them are possible continuations; the connection filter of the next hop is what narrows them down
+	 * again, because a connection instance has to start exactly at the element the branch is in.
+	 *
+	 * @param elements the elements of the subcomponent array, in instantiation order
+	 * @param etei the flow instance to fork
+	 * @param iter the position in the declaration, copied per fork so every branch resumes where its
+	 *            siblings did
+	 * @param step the step to take for each element
+	 */
+	private void forkOverElements(List<ComponentInstance> elements, EndToEndFlowInstance etei, FlowIterator iter,
+			ElementStep step) {
+		var elementIter = elements.iterator();
+		while (elementIter.hasNext()) {
+			final var element = elementIter.next();
+			final boolean prepareNext = elementIter.hasNext();
+			TraversalState stateClone = null;
+			FlowIterator iterClone = null;
+
+			if (prepareNext) {
+				stateClone = forkState(getState(etei));
+				iterClone = iter.copy();
+			}
+
+			step.take(element, etei, iter);
+
+			if (prepareNext) {
+				activeState = stateClone;
+				etei = stateClone.candidate.instance;
+				iter = iterClone;
+			}
+		}
+	}
+
+	/**
+	 * The component instances of a subcomponent in a component instance that a flow can continue into: one
+	 * for a plain subcomponent, and for a subcomponent array the elements some pending connection instance
+	 * reaches. Matches {@code ComponentInstance.findSubcomponentInstance}, which returned the first of
+	 * them, in accepting a refined subcomponent.
+	 * <p>
+	 * The elements are narrowed here rather than in the step that resolves them, because forking into an
+	 * element no connection reaches would create a branch that can only die, and the step would report that
+	 * death as a missing semantic connection. Issue 1984's rule that the endpoint predicates are a filter
+	 * and not an error reporter is the same rule; it just has to be applied one fork earlier now that a
+	 * declaration can stand for several elements.
+	 *
+	 * @param ci the component instance containing the subcomponent, may be null
+	 * @param sc the subcomponent
+	 * @param etei the flow instance whose current endpoint constrains the elements
+	 * @param pending the declarative connections awaiting resolution, empty at the start of a flow
+	 * @return the component instances in instantiation order, empty if there are none
+	 */
+	private static List<ComponentInstance> subcomponentInstances(ComponentInstance ci, Subcomponent sc,
+			EndToEndFlowInstance etei, List<Connection> pending) {
+		if (ci == null || sc == null) {
+			return List.of();
+		}
+		var instances = new ArrayList<ComponentInstance>();
+		for (var child : ci.getComponentInstances()) {
+			if (isSameOrRefined(sc, child.getSubcomponent())) {
+				instances.add(child);
+			}
+		}
+		if (instances.size() < 2 || pending.isEmpty()) {
+			// at the start of a flow nothing constrains the choice, so every element starts a flow of its own
+			return instances;
+		}
+		/*
+		 * The elements are siblings, so they all see the same enclosing connection instances; which of them a
+		 * connection instance ends in is what tells the elements apart.
+		 */
+		var connis = FlowConnectionMatcher.collectConnectionInstances(instances.getFirst(), etei, pending);
+		var reachable = instances.stream()
+				.filter(element -> connis.stream().anyMatch(conni -> endsIn(conni.getDestination(), element)))
+				.toList();
+		/*
+		 * Nothing reaches any element. Keep one, so that the step reports the missing connection once, the way
+		 * it did when a declaration resolved to the first element only.
+		 */
+		return reachable.isEmpty() ? List.of(instances.getFirst()) : reachable;
+	}
+
+	/** Is a connection instance end inside a component instance, or the component instance itself? */
+	private static boolean endsIn(ConnectionInstanceEnd end, ComponentInstance element) {
+		var ci = end instanceof ComponentInstance component ? component : end.getContainingComponentInstance();
+		while (ci != null) {
+			if (ci == element) {
+				return true;
+			}
+			ci = ci.getContainingComponentInstance();
+		}
+		return false;
+	}
+
+	/** Are these the same subcomponent, or one a refinement of the other? */
+	private static boolean isSameOrRefined(Subcomponent first, Subcomponent second) {
+		for (var sc = first; sc != null; sc = sc.getRefined()) {
+			if (sc == second) {
+				return true;
+			}
+		}
+		for (var sc = second; sc != null; sc = sc.getRefined()) {
+			if (sc == first) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	/**
 	 * Consume one declarative flow segment. Connection declarations are accumulated until a concrete flow element
 	 * resolves them; other segment kinds delegate to their specialized traversal methods and may fork the candidate.
@@ -538,18 +659,27 @@ public final class EndToEndFlowSession {
 		}
 		case FlowSpecification flowSpecification -> {
 			var sc = (Subcomponent) parts.context();
-			var sci = ci.findSubcomponentInstance(sc);
-			if (sci != null) {
-				host.processSubcomponentFlow(sci, etei, flowSpecification, iter);
-			} else {
+			var scis = subcomponentInstances(ci, sc, etei, traversal.connections);
+			if (scis.isEmpty()) {
 				reportOwnerError(candidate,
 						"Incomplete End-to-end flow instance " + etei.getName()
 								+ ": Could not find component instance for subcomponent " + sc.getName()
 								+ " in flow implementation " + errorElement.getName());
+			} else {
+				forkOverElements(scis, etei, iter, (element, branch, position) -> host
+						.processSubcomponentFlow(element, branch, flowSpecification, position));
 			}
 		}
-		case Subcomponent subcomponent ->
-			host.processFlowStep(ci.findSubcomponentInstance(subcomponent), etei, subcomponent, iter);
+		case Subcomponent subcomponent -> {
+			var scis = subcomponentInstances(ci, subcomponent, etei, traversal.connections);
+			if (scis.isEmpty()) {
+				// no element to step into; the step itself reports what a null component instance means
+				host.processFlowStep(null, etei, subcomponent, iter);
+			} else {
+				forkOverElements(scis, etei, iter,
+						(element, branch, position) -> host.processFlowStep(element, branch, subcomponent, position));
+			}
+		}
 		/*
 		 * Only data and subprogram accesses are traversed. Another access kind, a bus access for instance, is not a
 		 * proxy for a component the flow passes through, and neither is any remaining flow element kind.

--- a/core/org.osate.core.tests/models/issue1833/.gitignore
+++ b/core/org.osate.core.tests/models/issue1833/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue1833/.project
+++ b/core/org.osate.core.tests/models/issue1833/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue1833</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue1833/Issue1833.aadl
+++ b/core/org.osate.core.tests/models/issue1833/Issue1833.aadl
@@ -1,0 +1,126 @@
+-- Regression fixture for issue #1833: the second example of the issue, where the multiplicity comes
+-- from arrays of subcomponents rather than from feature arrays. The connection between the two arrays
+-- is expanded into one connection instance per element, so the end to end flow over it has to be
+-- instantiated once per element as well.
+--
+-- Processes rather than threads, so the arrays can sit directly in the system, and no feature arrays
+-- anywhere: what is under test here is resolving a flow segment to every element of a subcomponent
+-- array.
+package Issue1833
+public
+	data Sample
+	end Sample;
+
+	process Emitter
+	features
+		outp: out data port Sample;
+	flows
+		fsrc: flow source outp;
+	end Emitter;
+
+	process Receiver
+	features
+		inp: in data port Sample;
+	flows
+		fsnk: flow sink inp;
+	end Receiver;
+
+	-- A data port takes only one incoming connection, so the fan-in case below needs a queuing port
+	process QueuingReceiver
+	features
+		inp: in event data port Sample;
+	flows
+		fsnk: flow sink inp;
+	end QueuingReceiver;
+
+	system Top
+	end Top;
+
+	-- One_To_One is the default, so the connection pairs the elements up by index and the flow has one
+	-- instance per index.
+	system implementation Top.i
+	subcomponents
+		emitters: process Emitter[2];
+		receivers: process Receiver[2];
+	connections
+		c: port emitters.outp -> receivers.inp;
+	flows
+		etef: end to end flow emitters.fsrc -> c -> receivers.fsnk;
+	end Top.i;
+
+	-- The pattern of the issue's example, written out. Same result as Top.i.
+	system implementation Top.patterned
+	subcomponents
+		emitters: process Emitter[2];
+		receivers: process Receiver[2];
+	connections
+		c: port emitters.outp -> receivers.inp {
+			Communication_Properties::Connection_Pattern => ((One_To_One));
+		};
+	flows
+		etef: end to end flow emitters.fsrc -> c -> receivers.fsnk;
+	end Top.patterned;
+
+	-- A pattern that crosses the indices. Each element still has a flow, but it ends in the other
+	-- element of the receiver array, which is only reachable if the segments are resolved to every
+	-- element rather than to the first one.
+	system implementation Top.crossed
+	subcomponents
+		emitters: process Emitter[2];
+		receivers: process Receiver[2];
+	connections
+		c: port emitters.outp -> receivers.inp {
+			Communication_Properties::Connection_Pattern => ((Cyclic_Next));
+		};
+	flows
+		etef: end to end flow emitters.fsrc -> c -> receivers.fsnk;
+	end Top.crossed;
+
+	-- All_To_All: every element of the emitter array reaches every element of the receiver array, so
+	-- there is a flow per pair. A data port takes only one incoming connection, so the receivers queue.
+	system implementation Top.broadcast
+	subcomponents
+		emitters: process Emitter[2];
+		receivers: process QueuingReceiver[2];
+	connections
+		c: port emitters.outp -> receivers.inp {
+			Communication_Properties::Connection_Pattern => ((All_To_All));
+		};
+	flows
+		etef: end to end flow emitters.fsrc -> c -> receivers.fsnk;
+	end Top.broadcast;
+
+	-- Only one end is an array. All_To_One applies, so both emitters reach the one receiver.
+	system implementation Top.fanIn
+	subcomponents
+		emitters: process Emitter[2];
+		receiver: process QueuingReceiver;
+	connections
+		c: port emitters.outp -> receiver.inp;
+	flows
+		etef: end to end flow emitters.fsrc -> c -> receiver.fsnk;
+	end Top.fanIn;
+
+	process Relay
+	features
+		inp: in data port Sample;
+		outp: out data port Sample;
+	flows
+		fpath: flow path inp -> outp;
+	end Relay;
+
+	-- A nested end to end flow that is itself replicated per array element. The flow that contains it has
+	-- to be replicated with it, and each replica has to pick the nested replica of its own element.
+	system implementation Top.nested
+	subcomponents
+		emitters: process Emitter[2];
+		relays: process Relay[2];
+		receivers: process Receiver[2];
+	connections
+		toRelay: port emitters.outp -> relays.inp;
+		fromRelay: port relays.outp -> receivers.inp;
+	flows
+		inner: end to end flow relays.fpath -> fromRelay -> receivers.fsnk;
+		outer: end to end flow emitters.fsrc -> toRelay -> inner;
+	end Top.nested;
+end Issue1833;

--- a/core/org.osate.core.tests/models/issue1833/Issue1833.aadl
+++ b/core/org.osate.core.tests/models/issue1833/Issue1833.aadl
@@ -109,8 +109,31 @@ public
 		fpath: flow path inp -> outp;
 	end Relay;
 
-	-- A nested end to end flow that is itself replicated per array element. The flow that contains it has
-	-- to be replicated with it, and each replica has to pick the nested replica of its own element.
+	-- A box whose flow specification is realized by a flow implementation, so a flow that starts at
+	-- boxes.fpath descends into it and carries a leading declarative connection with it
+	system Box
+	features
+		inp: in data port Sample;
+		outp: out data port Sample;
+	flows
+		fpath: flow path inp -> outp;
+	end Box;
+
+	system implementation Box.i
+	subcomponents
+		relay: process Relay;
+	connections
+		down: port inp -> relay.inp;
+		up: port relay.outp -> outp;
+	flows
+		fpath: flow path inp -> down -> relay.fpath -> up -> outp;
+	end Box.i;
+
+	-- The four positions a replicated nested end to end flow can be in. In each of them the flow that
+	-- contains it has to be replicated with it, and each replica of the container has to pick the nested
+	-- replica of its own element.
+
+	-- (a) the nested flow ends the container, so the container reaches it along a connection
 	system implementation Top.nested
 	subcomponents
 		emitters: process Emitter[2];
@@ -123,4 +146,50 @@ public
 		inner: end to end flow relays.fpath -> fromRelay -> receivers.fsnk;
 		outer: end to end flow emitters.fsrc -> toRelay -> inner;
 	end Top.nested;
+
+	-- (b) the nested flow starts the container, so nothing constrains which replica a replica of the
+	-- container takes, and the container continues after it
+	system implementation Top.nestedAtStart
+	subcomponents
+		emitters: process Emitter[2];
+		relays: process Relay[2];
+		receivers: process Receiver[2];
+	connections
+		toRelay: port emitters.outp -> relays.inp;
+		fromRelay: port relays.outp -> receivers.inp;
+	flows
+		inner: end to end flow emitters.fsrc -> toRelay -> relays.fpath;
+		outer: end to end flow inner -> fromRelay -> receivers.fsnk;
+	end Top.nestedAtStart;
+
+	-- (c) the nested flow sits in the middle, so the container both reaches it and continues after it
+	system implementation Top.nestedInMiddle
+	subcomponents
+		emitters: process Emitter[2];
+		firstRelays: process Relay[2];
+		secondRelays: process Relay[2];
+		receivers: process Receiver[2];
+	connections
+		toFirst: port emitters.outp -> firstRelays.inp;
+		betweenRelays: port firstRelays.outp -> secondRelays.inp;
+		toReceiver: port secondRelays.outp -> receivers.inp;
+	flows
+		inner: end to end flow firstRelays.fpath -> betweenRelays -> secondRelays.fpath;
+		outer: end to end flow emitters.fsrc -> toFirst -> inner -> toReceiver -> receivers.fsnk;
+	end Top.nestedInMiddle;
+
+	-- (d) the nested flow starts inside a flow implementation, so it carries a leading declarative
+	-- connection that the container's connection instance has to contain
+	system implementation Top.nestedThroughImplementation
+	subcomponents
+		emitters: process Emitter[2];
+		boxes: system Box.i[2];
+		receivers: process Receiver[2];
+	connections
+		toBox: port emitters.outp -> boxes.inp;
+		fromBox: port boxes.outp -> receivers.inp;
+	flows
+		inner: end to end flow boxes.fpath -> fromBox -> receivers.fsnk;
+		outer: end to end flow emitters.fsrc -> toBox -> inner;
+	end Top.nestedThroughImplementation;
 end Issue1833;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue1833Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue1833Test.java
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.aadl2.instance.EndToEndFlowInstance;
+import org.osate.aadl2.instance.InstanceObject;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * A flow segment that names a subcomponent array was resolved with findSubcomponentInstance, which
+ * returns the first element of the array, so an end to end flow over such an array became a single flow
+ * instance through element 1 no matter how many connection instances the array connection stood for.
+ * <p>
+ * This is Aaron Greenhouse's second example in the issue. The first one, where the multiplicity comes
+ * from feature arrays rather than subcomponent arrays, is issue #2787.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue1833Test extends XtextTest {
+	private static final String MODEL_DIR = "org.osate.core.tests/models/issue1833/";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	private AnalysisErrorReporterManager errorManager;
+
+	/**
+	 * The model of the issue. The connection between the two arrays is expanded per element, so the flow
+	 * over it has one instance per element, each through the array element of its own index.
+	 */
+	@Test
+	public void endToEndFlowIsBuiltPerArrayElement() throws Exception {
+		var instance = instantiate("Issue1833.aadl", "Top.i");
+
+		assertEquals(List.of("emitters[1].outp --> receivers[1].inp", "emitters[2].outp --> receivers[2].inp"),
+				names(instance.getAllConnectionInstances()));
+		assertEquals(List.of(
+				"etef_1 : emitters[1].fsrc -> emitters[1].outp --> receivers[1].inp -> receivers[1].fsnk",
+				"etef_2 : emitters[2].fsrc -> emitters[2].outp --> receivers[2].inp -> receivers[2].fsnk"),
+				flows(instance));
+		assertEquals(List.of(), diagnostics(instance));
+	}
+
+	/**
+	 * Writing out the One_To_One pattern the issue's example used changes nothing, since it is the default.
+	 */
+	@Test
+	public void anExplicitOneToOnePatternIsTheSame() throws Exception {
+		var instance = instantiate("Issue1833.aadl", "Top.patterned");
+
+		assertEquals(List.of(
+				"etef_1 : emitters[1].fsrc -> emitters[1].outp --> receivers[1].inp -> receivers[1].fsnk",
+				"etef_2 : emitters[2].fsrc -> emitters[2].outp --> receivers[2].inp -> receivers[2].fsnk"),
+				flows(instance));
+		assertEquals(List.of(), diagnostics(instance));
+	}
+
+	/**
+	 * A pattern that crosses the indices. Each flow still exists, but it ends in the other element of the
+	 * receiver array, which is reachable only if the segment resolves to every element.
+	 */
+	@Test
+	public void aCrossingPatternKeepsBothFlows() throws Exception {
+		var instance = instantiate("Issue1833.aadl", "Top.crossed");
+
+		assertEquals(List.of("emitters[1].outp --> receivers[2].inp", "emitters[2].outp --> receivers[1].inp"),
+				names(instance.getAllConnectionInstances()));
+		assertEquals(List.of(
+				"etef_1 : emitters[1].fsrc -> emitters[1].outp --> receivers[2].inp -> receivers[2].fsnk",
+				"etef_2 : emitters[2].fsrc -> emitters[2].outp --> receivers[1].inp -> receivers[1].fsnk"),
+				flows(instance));
+		assertEquals(List.of(), diagnostics(instance));
+	}
+
+	/**
+	 * All_To_All connects every emitter to every receiver, so there is a flow per pair. Which flow gets
+	 * which number depends on the order the branches were forked in, so the numbers and the paths are
+	 * asserted separately.
+	 */
+	@Test
+	public void everyPairOfElementsGetsAFlow() throws Exception {
+		var instance = instantiate("Issue1833.aadl", "Top.broadcast");
+
+		assertEquals(List.of("etef_1", "etef_2", "etef_3", "etef_4"), names(flowInstances(instance)));
+		assertEquals(List.of("emitters[1].fsrc -> emitters[1].outp --> receivers[1].inp -> receivers[1].fsnk",
+				"emitters[1].fsrc -> emitters[1].outp --> receivers[2].inp -> receivers[2].fsnk",
+				"emitters[2].fsrc -> emitters[2].outp --> receivers[1].inp -> receivers[1].fsnk",
+				"emitters[2].fsrc -> emitters[2].outp --> receivers[2].inp -> receivers[2].fsnk"),
+				flowPaths(instance));
+		assertEquals(List.of(), diagnostics(instance));
+	}
+
+	/**
+	 * Only the source is an array, so All_To_One applies and both emitters have a flow into the one
+	 * receiver.
+	 */
+	@Test
+	public void bothElementsFlowIntoOneReceiver() throws Exception {
+		var instance = instantiate("Issue1833.aadl", "Top.fanIn");
+
+		assertEquals(List.of("etef_1 : emitters[1].fsrc -> emitters[1].outp --> receiver.inp -> receiver.fsnk",
+				"etef_2 : emitters[2].fsrc -> emitters[2].outp --> receiver.inp -> receiver.fsnk"), flows(instance));
+		assertEquals(List.of(), diagnostics(instance));
+	}
+
+	/**
+	 * A nested end to end flow that is replicated per array element replicates the flow that contains it,
+	 * and each replica of the container refers to the nested replica of its own element.
+	 */
+	@Test
+	public void aReplicatedNestedFlowReplicatesItsContainer() throws Exception {
+		var instance = instantiate("Issue1833.aadl", "Top.nested");
+
+		assertEquals(List.of(
+				"inner_1 : relays[1].fpath -> relays[1].outp --> receivers[1].inp -> receivers[1].fsnk",
+				"inner_2 : relays[2].fpath -> relays[2].outp --> receivers[2].inp -> receivers[2].fsnk",
+				"outer_1 : emitters[1].fsrc -> emitters[1].outp --> relays[1].inp -> inner_1",
+				"outer_2 : emitters[2].fsrc -> emitters[2].outp --> relays[2].inp -> inner_2"), flows(instance));
+		assertEquals(List.of(), diagnostics(instance));
+	}
+
+	/**
+	 * The end to end flow instances of a model, as {@code name : element -> element -> ...}, sorted. An
+	 * element is named by its path relative to the system instance, so which array element a flow goes
+	 * through is part of what is asserted.
+	 */
+	private List<String> flows(SystemInstance instance) {
+		return flowInstances(instance).stream().map(flow -> flow.getName() + " : " + path(instance, flow)).sorted()
+				.toList();
+	}
+
+	/** The paths of the end to end flow instances of a model, without their names, sorted. */
+	private List<String> flowPaths(SystemInstance instance) {
+		return flowInstances(instance).stream().map(flow -> path(instance, flow)).sorted().toList();
+	}
+
+	private String path(SystemInstance instance, EndToEndFlowInstance flow) {
+		return String.join(" -> ",
+				flow.getFlowElements().stream().map(element -> relative(instance, element)).toList());
+	}
+
+	/**
+	 * The path of an instance object relative to the system instance. A nested flow instance is named
+	 * rather than expanded, so the containment of one flow in another stays visible.
+	 */
+	private String relative(SystemInstance instance, InstanceObject element) {
+		if (element instanceof EndToEndFlowInstance nested) {
+			return nested.getName();
+		}
+		var prefix = instance.getInstanceObjectPath() + ".";
+		var elementPath = element.getInstanceObjectPath();
+		return elementPath.startsWith(prefix) ? elementPath.substring(prefix.length()) : elementPath;
+	}
+
+	private List<EndToEndFlowInstance> flowInstances(ComponentInstance ci) {
+		return collectFlows(ci, new ArrayList<>());
+	}
+
+	private List<EndToEndFlowInstance> collectFlows(ComponentInstance ci, List<EndToEndFlowInstance> result) {
+		result.addAll(ci.getEndToEndFlows());
+		ci.getComponentInstances().forEach(child -> collectFlows(child, result));
+		return result;
+	}
+
+	private SystemInstance instantiate(String model, String implementationName) throws Exception {
+		var pkg = testHelper.parseFile(MODEL_DIR + model);
+		validationHelper.assertNoIssues(pkg);
+		var implementation = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals(implementationName))
+				.findFirst()
+				.orElseThrow();
+		errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+
+		var instance = InstantiateModel.instantiate(implementation, errorManager);
+
+		assertNotNull(instance);
+		return instance;
+	}
+
+	private List<String> names(List<? extends InstanceObject> objects) {
+		return objects.stream().map(InstanceObject::getName).sorted().toList();
+	}
+
+	private List<String> diagnostics(SystemInstance instance) {
+		return ((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource())).getErrors()
+				.stream()
+				.map(message -> message.kind + ": " + message.message)
+				.sorted()
+				.toList();
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue1833Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue1833Test.java
@@ -151,7 +151,8 @@ public class Issue1833Test extends XtextTest {
 
 	/**
 	 * A nested end to end flow that is replicated per array element replicates the flow that contains it,
-	 * and each replica of the container refers to the nested replica of its own element.
+	 * and each replica of the container refers to the nested replica of its own element. Here the nested
+	 * flow ends the container, so the container reaches it along a connection.
 	 */
 	@Test
 	public void aReplicatedNestedFlowReplicatesItsContainer() throws Exception {
@@ -162,6 +163,60 @@ public class Issue1833Test extends XtextTest {
 				"inner_2 : relays[2].fpath -> relays[2].outp --> receivers[2].inp -> receivers[2].fsnk",
 				"outer_1 : emitters[1].fsrc -> emitters[1].outp --> relays[1].inp -> inner_1",
 				"outer_2 : emitters[2].fsrc -> emitters[2].outp --> relays[2].inp -> inner_2"), flows(instance));
+		assertEquals(List.of(), diagnostics(instance));
+	}
+
+	/**
+	 * The nested flow starts the container. Nothing constrains which replica a replica of the container
+	 * takes, so the fork is over the nested replicas themselves, and the container continues after the one
+	 * it took.
+	 */
+	@Test
+	public void aReplicatedNestedFlowCanStartItsContainer() throws Exception {
+		var instance = instantiate("Issue1833.aadl", "Top.nestedAtStart");
+
+		assertEquals(List.of("inner_1 : emitters[1].fsrc -> emitters[1].outp --> relays[1].inp -> relays[1].fpath",
+				"inner_2 : emitters[2].fsrc -> emitters[2].outp --> relays[2].inp -> relays[2].fpath",
+				"outer_1 : inner_1 -> relays[1].outp --> receivers[1].inp -> receivers[1].fsnk",
+				"outer_2 : inner_2 -> relays[2].outp --> receivers[2].inp -> receivers[2].fsnk"), flows(instance));
+		assertEquals(List.of(), diagnostics(instance));
+	}
+
+	/**
+	 * The nested flow sits in the middle of the container, which therefore both reaches it along a
+	 * connection and continues after it along another.
+	 */
+	@Test
+	public void aReplicatedNestedFlowCanSitInTheMiddle() throws Exception {
+		var instance = instantiate("Issue1833.aadl", "Top.nestedInMiddle");
+
+		assertEquals(List.of(
+				"inner_1 : firstRelays[1].fpath -> firstRelays[1].outp --> secondRelays[1].inp"
+						+ " -> secondRelays[1].fpath",
+				"inner_2 : firstRelays[2].fpath -> firstRelays[2].outp --> secondRelays[2].inp"
+						+ " -> secondRelays[2].fpath",
+				"outer_1 : emitters[1].fsrc -> emitters[1].outp --> firstRelays[1].inp -> inner_1"
+						+ " -> secondRelays[1].outp --> receivers[1].inp -> receivers[1].fsnk",
+				"outer_2 : emitters[2].fsrc -> emitters[2].outp --> firstRelays[2].inp -> inner_2"
+						+ " -> secondRelays[2].outp --> receivers[2].inp -> receivers[2].fsnk"), flows(instance));
+		assertEquals(List.of(), diagnostics(instance));
+	}
+
+	/**
+	 * The nested flow starts at a flow specification that is realized by a flow implementation, so it
+	 * carries a leading declarative connection. The connection instance by which a replica of the container
+	 * reaches a nested replica has to contain that connection, which is what keeps the two on the same
+	 * element.
+	 */
+	@Test
+	public void aReplicatedNestedFlowCanStartInsideAnImplementation() throws Exception {
+		var instance = instantiate("Issue1833.aadl", "Top.nestedThroughImplementation");
+
+		assertEquals(List.of(
+				"inner_1 : boxes[1].relay.fpath -> boxes[1].relay.outp --> receivers[1].inp -> receivers[1].fsnk",
+				"inner_2 : boxes[2].relay.fpath -> boxes[2].relay.outp --> receivers[2].inp -> receivers[2].fsnk",
+				"outer_1 : emitters[1].fsrc -> emitters[1].outp --> boxes[1].relay.inp -> inner_1",
+				"outer_2 : emitters[2].fsrc -> emitters[2].outp --> boxes[2].relay.inp -> inner_2"), flows(instance));
 		assertEquals(List.of(), diagnostics(instance));
 	}
 

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3032Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3032Test.java
@@ -74,7 +74,8 @@ public class Issue3032Test extends XtextTest {
 
 	/**
 	 * A subcomponent array expands the connection into one connection instance per element. The end to
-	 * end flow has to be built over those connection instances.
+	 * end flow has to be built over those connection instances, one flow instance per element since issue
+	 * #1833.
 	 */
 	@Test
 	public void endToEndFlowUsesExpandedArrayConnection() throws Exception {
@@ -82,8 +83,8 @@ public class Issue3032Test extends XtextTest {
 
 		assertEquals(List.of("producers[1].outp --> consumers[1].inp", "producers[2].outp --> consumers[2].inp"),
 				names(instance.getAllConnectionInstances()));
-		assertEquals(List.of(List.of("fsrc", "producers[1].outp --> consumers[1].inp", "fsnk")),
-				flowElementNames(instance));
+		assertEquals(List.of(List.of("fsrc", "producers[1].outp --> consumers[1].inp", "fsnk"),
+				List.of("fsrc", "producers[2].outp --> consumers[2].inp", "fsnk")), flowElementNames(instance));
 		assertNoDanglingFlowConnections(instance);
 		assertEquals(List.of(), diagnostics(instance));
 	}
@@ -98,26 +99,29 @@ public class Issue3032Test extends XtextTest {
 
 		assertEquals(List.of("producers[1].outp --> consumers[1].inp", "producers[2].outp --> consumers[2].inp"),
 				names(instance.getAllConnectionInstances()));
-		assertEquals(List.of(List.of("fsrc", "producers[1].outp --> consumers[1].inp", "fsnk")),
-				flowElementNames(instance));
+		assertEquals(List.of(List.of("fsrc", "producers[1].outp --> consumers[1].inp", "fsnk"),
+				List.of("fsrc", "producers[2].outp --> consumers[2].inp", "fsnk")), flowElementNames(instance));
 		assertNoDanglingFlowConnections(instance);
 		assertEquals(List.of(), diagnostics(instance));
 	}
 
 	/**
-	 * A {@code Connection_Set} that crosses the element indices leaves no connection instance that
-	 * continues the declared flow. Instantiation has to report that instead of producing a flow instance
-	 * whose connection segment is missing.
+	 * A {@code Connection_Set} that crosses the element indices connects each producer to the other
+	 * consumer, so the declared flow has an instance per element that ends in the other element. This test
+	 * used to record that no flow was built and that the missing connection was reported, which was the
+	 * defect of issue #1833: the flow segments resolved to the first element of each array only, and no
+	 * connection instance goes from the first producer to the first consumer here.
 	 */
 	@Test
-	public void unconnectableEndToEndFlowIsReported() throws Exception {
+	public void aCrossedConnectionSetConnectsTheOtherElement() throws Exception {
 		SystemInstance instance = instantiate("Issue3032Set.aadl", "Top.crossed");
 
 		assertEquals(List.of("producers[1].outp --> consumers[2].inp", "producers[2].outp --> consumers[1].inp"),
 				names(instance.getAllConnectionInstances()));
-		assertEquals(List.of(), flowElementNames(instance));
-		assertEquals(List.of("Error: Cannot create end to end flow 'etef' because there are no semantic connections"
-				+ " that connect to the start of the flow 'fsnk' at feature 'inp'"), diagnostics(instance));
+		assertEquals(List.of(List.of("fsrc", "producers[1].outp --> consumers[2].inp", "fsnk"),
+				List.of("fsrc", "producers[2].outp --> consumers[1].inp", "fsnk")), flowElementNames(instance));
+		assertNoDanglingFlowConnections(instance);
+		assertEquals(List.of(), diagnostics(instance));
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1833.

**Supersedes #3094.** That PR was opened against `2787_flow_spec_feature_array_expansion` so its diff would show this change alone. #3093 merged into `master` first, and #3094 then merged into its base branch rather than into `master`, because GitHub retargets an open PR only when its base branch is *deleted* and that branch still existed. The result is that these four commits sit on `origin/2787_flow_spec_feature_array_expansion` and never reached `master`. This PR is the same four commits rebased onto current `master`; nothing in them changed.

## Cause

`EndToEndFlowSession.processETESegment` resolves a segment that names a subcomponent with `ComponentInstance.findSubcomponentInstance`, which returns the **first** component instance of that subcomponent. For an array of subcomponents that is element 1, so an end to end flow over such an array became a single flow instance through element 1, however many connection instances the array connection stood for.

With a pattern that crosses the indices it became no flow instance at all: no connection instance goes from element 1 to element 1, so the traversal reported "there are no semantic connections that connect to the start of the flow" and failed the candidate.

## Correction

Both segment kinds that name a subcomponent resolve to all of its component instances, and `forkOverElements` continues a flow per element. A declaration names a subcomponent, not one of its elements.

The elements are **narrowed before** the fork, to those some pending connection instance ends in. Forking into an element no connection reaches would create a branch that can only die, and `processFlowStep` would report that death as a missing semantic connection — so issue 1984's rule that the endpoint predicates are a filter and not an error reporter has to be applied one fork earlier now that a declaration can stand for several elements. When nothing reaches any element, one element is kept, so the report is still made exactly once, as it was when a declaration resolved to the first element only. Narrowing before the fork is also what keeps the flow numbering in element order.

A nested end to end flow replicated this way replicates the flow that contains it **without further change**: `processEndToEndFlow` already forks over the nested expansion's candidates, and `FlowConnectionMatcher.isCompatibleNestedConnection` compares feature instances rather than declarative features, so each replica of the container pairs with the nested replica of its own element.

## Regression

`core/org.osate.core.tests/models/issue1833/Issue1833.aadl`, asserted by `Issue1833Test` (9 cases). Aaron Greenhouse's second example in the issue, plus:

- `Top.patterned` — `One_To_One` written out, same result, since it is the default.
- `Top.crossed` — `Cyclic_Next`; each flow ends in the *other* element, reachable only if the segment resolves to every element.
- `Top.broadcast` — `All_To_All`, a flow per pair. Numbers and paths asserted separately, since which flow gets which number depends on the fork order.
- `Top.fanIn` — one array end against one scalar end, `All_To_One`.
- `Top.nested`, `Top.nestedAtStart`, `Top.nestedInMiddle`, `Top.nestedThroughImplementation` — the four positions a replicated nested flow can be in, each taking a different path through `processEndToEndFlow`. In all four the container is replicated per element and each replica refers to the nested replica of its own element.

Every element is asserted by its path relative to the system instance, so which array element a flow goes through is part of what is checked. All nine fail without the production change: the `One_To_One`, `All_To_All`, fan-in and nested cases produce one flow instance through element 1, and the crossing pattern produces none at all.

## Validation

From the repository root, on `master` at 3c7dededb7:

    mvn -o -s releng/osate.releng/settings.xml -Plocal -T6 \
      -pl :org.osate.aadl2.instantiation,:org.osate.core.feature,:org.osate.core.tests \
      -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false \
      -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
      -DfailIfNoTests=false clean install

`org.osate.core.tests` 811/811, `Issue1833Test` 9/9. Re-run against current `master` specifically to check the new connection-boundary reporting of #3047 against these fixtures; it adds no diagnostic to any of them.

The identical tree was also validated by a clean root reactor before the rebase: BUILD SUCCESS, 1405 tests, 0 failures, 0 errors.

## Residual risk

Instantiation output changes for any model with an end to end flow over an array of subcomponents: one flow instance per element instead of one through element 1, so flow analyses will report more flows. That is the point of the issue.

`Issue3032Test` recorded the old behavior for three of its models and is updated here. Two now have a flow instance per element. The third, `unconnectableEndToEndFlowIsReported`, asserted that a crossed `Connection_Set` produces no flow and reports the missing connection — which *was* this defect — so it is renamed to `aCrossedConnectionSetConnectsTheOtherElement` and now asserts the two flows. What #3032 is about, that a flow is built over the final connection instances and refers to none that was deleted, is still asserted for all three. Because that update travels with this PR, `master` will not be green on `Issue3032Test` until this merges.

A flow over a large subcomponent array forks once per element at its first segment before any connection can narrow the choice, so an array of n elements starts n branches there. Each is pruned at the next hop, and this is the same shape the connection expansion already has, but it is worth knowing for very wide arrays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)