### PR TITLE
Compare property definitions without rebuilding qualified names 🤖

### DIFF
--- a/core/org.osate.aadl2/src/org/osate/aadl2/impl/PropertyImpl.java
+++ b/core/org.osate.aadl2/src/org/osate/aadl2/impl/PropertyImpl.java
@@ -592,7 +592,26 @@ public class PropertyImpl extends BasicPropertyImpl implements Property {
 	}
 
 	public boolean equals(Object p) {
+		if (this == p) {
+			/*
+			 * A resolved model holds one Property object per definition, so this is the case that the
+			 * property lookup hits whenever the answer is yes.
+			 */
+			return true;
+		}
 		if (p instanceof Property) {
+			/*
+			 * A qualified name ends with the element's own name, so two properties whose names already
+			 * differ ignoring case cannot have qualified names that are equal ignoring case. Rejecting on
+			 * the name alone therefore gives the same answer as comparing the qualified names, and it does
+			 * it with a field read instead of a walk up the namespace chain that builds a fresh string.
+			 * The property lookup compares one property against every property association of an element,
+			 * so all but one of those comparisons ends here.
+			 */
+			String name = getName();
+			if (name != null && !name.equalsIgnoreCase(((Property) p).getName())) {
+				return false;
+			}
 			String p1Name = getQualifiedName();
 			String p2Name = ((Property) p).getQualifiedName();
 			if (p1Name != null) {

--- a/core/org.osate.aadl2/src/org/osate/aadl2/impl/PropertyImpl.java
+++ b/core/org.osate.aadl2/src/org/osate/aadl2/impl/PropertyImpl.java
@@ -625,7 +625,27 @@ public class PropertyImpl extends BasicPropertyImpl implements Property {
 		if (eIsProxy()) {
 			return eProxyURI().toString().hashCode();
 		}
-		return getQualifiedName() != null ? getQualifiedName().hashCode() : super.hashCode();
+		String qualifiedName = getQualifiedName();
+		if (qualifiedName == null) {
+			return super.hashCode();
+		}
+		/*
+		 * equals compares qualified names ignoring case, so the hash has to ignore case as well.
+		 * Hashing the qualified name as written would let a hash based collection keep two entries
+		 * that are equal, because they would land in different buckets.
+		 *
+		 * Two characters count as the same ignoring case exactly when folding each through
+		 * toUpperCase and then toLowerCase gives the same character; that is what
+		 * String.equalsIgnoreCase compares. Hashing the folded characters therefore agrees with
+		 * equals. Folding here rather than calling toLowerCase keeps this independent of the default
+		 * locale and allocates no second string. For a qualified name that is already lower case
+		 * this is String.hashCode.
+		 */
+		int hash = 0;
+		for (int i = 0; i < qualifiedName.length(); i++) {
+			hash = 31 * hash + Character.toLowerCase(Character.toUpperCase(qualifiedName.charAt(i)));
+		}
+		return hash;
 	}
 
 	/*

--- a/core/org.osate.core.tests/models/issue3095/.gitignore
+++ b/core/org.osate.core.tests/models/issue3095/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3095/.project
+++ b/core/org.osate.core.tests/models/issue3095/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3095</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3095/Issue3095.aadl
+++ b/core/org.osate.core.tests/models/issue3095/Issue3095.aadl
@@ -1,0 +1,40 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- Associations that name each of the three property definitions, so that a test reads the resolved
+-- Property objects out of a parsed model rather than constructing them.
+package Issue3095
+public
+	with Issue3095A, Issue3095B;
+
+	system Top
+		properties
+			Issue3095A::Count => 1;
+			Issue3095B::Count => 2;
+			Issue3095A::Other => 3;
+	end Top;
+
+	system implementation Top.i
+	end Top.i;
+end Issue3095;

--- a/core/org.osate.core.tests/models/issue3095/Issue3095A.aadl
+++ b/core/org.osate.core.tests/models/issue3095/Issue3095A.aadl
@@ -1,0 +1,30 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- Two property sets that each declare a property named Count, so that a test can compare two
+-- distinct property definitions whose simple names are equal but whose qualified names are not.
+property set Issue3095A is
+	Count: aadlinteger applies to (all);
+	Other: aadlinteger applies to (all);
+end Issue3095A;

--- a/core/org.osate.core.tests/models/issue3095/Issue3095B.aadl
+++ b/core/org.osate.core.tests/models/issue3095/Issue3095B.aadl
@@ -1,0 +1,28 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- The second property set declaring Count. See Issue3095A.
+property set Issue3095B is
+	Count: aadlinteger applies to (all);
+end Issue3095B;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3095Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3095Test.java
@@ -29,6 +29,11 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.testing.validation.ValidationTestHelper;
@@ -53,8 +58,9 @@ import com.itemis.xtext.testing.XtextTest;
  * instantiation (issue #3095). The comparison is by qualified name and ignores case, so two
  * definitions that come from different property sets are distinct even when their simple names are
  * equal, and a definition read from one model equals a definition of the same qualified name that
- * was built elsewhere. These tests pin those answers, so that an optimization of the comparison is
- * held to producing exactly them.
+ * was built elsewhere. {@code hashCode} agrees with that, so a hash based collection keyed by a
+ * property definition holds one entry per definition. These tests pin those answers, so that an
+ * optimization of the comparison is held to producing exactly them.
  * </p>
  */
 @RunWith(XtextRunner.class)
@@ -73,15 +79,16 @@ public class Issue3095Test extends XtextTest {
 
 	@Test
 	public void aPropertyDefinitionEqualsItself() throws Exception {
-		Property countA = property("Issue3095A::Count");
+		Property countA = definitions().get("Issue3095A::Count");
 
 		assertTrue(countA.equals(countA));
 	}
 
 	@Test
 	public void definitionsOfTheSameNameInDifferentPropertySetsAreNotEqual() throws Exception {
-		Property countA = property("Issue3095A::Count");
-		Property countB = property("Issue3095B::Count");
+		var definitions = definitions();
+		Property countA = definitions.get("Issue3095A::Count");
+		Property countB = definitions.get("Issue3095B::Count");
 
 		assertEquals("Count", countA.getName());
 		assertEquals("Count", countB.getName());
@@ -91,8 +98,9 @@ public class Issue3095Test extends XtextTest {
 
 	@Test
 	public void definitionsOfDifferentNamesInOnePropertySetAreNotEqual() throws Exception {
-		Property countA = property("Issue3095A::Count");
-		Property otherA = property("Issue3095A::Other");
+		var definitions = definitions();
+		Property countA = definitions.get("Issue3095A::Count");
+		Property otherA = definitions.get("Issue3095A::Other");
 
 		assertFalse(countA.equals(otherA));
 		assertFalse(otherA.equals(countA));
@@ -104,7 +112,7 @@ public class Issue3095Test extends XtextTest {
 	 */
 	@Test
 	public void aSeparatelyBuiltDefinitionOfTheSameQualifiedNameIsEqualIgnoringCase() throws Exception {
-		Property countA = property("Issue3095A::Count");
+		Property countA = definitions().get("Issue3095A::Count");
 		Property sameName = definition("Issue3095A", "Count");
 		Property sameNameOtherCase = definition("issue3095a", "COUNT");
 
@@ -119,22 +127,52 @@ public class Issue3095Test extends XtextTest {
 	}
 
 	/**
-	 * {@code hashCode} hashes the qualified name as written while {@code equals} ignores case, so two
-	 * definitions that are equal can hash differently. That is how it already behaves; it is recorded
-	 * here so that a change to the comparison is not mistaken for a change to this.
+	 * Equal definitions hash alike, including when they differ only in case, so that a hash based
+	 * collection keyed by a property definition holds one entry per definition.
 	 */
 	@Test
-	public void hashCodeIsCaseSensitiveWhereEqualsIsNot() throws Exception {
-		Property countA = property("Issue3095A::Count");
+	public void equalDefinitionsHashAlikeIgnoringCase() throws Exception {
+		Property countA = definitions().get("Issue3095A::Count");
 		Property sameNameOtherCase = definition("issue3095a", "COUNT");
 
 		assertTrue(countA.equals(sameNameOtherCase));
-		assertNotEquals(countA.hashCode(), sameNameOtherCase.hashCode());
+		assertEquals(countA.hashCode(), sameNameOtherCase.hashCode());
+	}
+
+	/**
+	 * The consequence of the two agreeing: a definition that is already in a hash set is recognized as
+	 * present even when it is spelled with different case.
+	 */
+	@Test
+	public void aHashSetHoldsOneEntryPerDefinitionIgnoringCase() throws Exception {
+		var definitions = definitions();
+		Property countA = definitions.get("Issue3095A::Count");
+		Property countB = definitions.get("Issue3095B::Count");
+
+		Set<Property> set = new HashSet<>();
+		set.add(countA);
+		set.add(definition("issue3095a", "COUNT"));
+		set.add(definition("ISSUE3095A", "count"));
+		assertEquals(1, set.size());
+		assertTrue(set.contains(countA));
+
+		set.add(countB);
+		assertEquals(2, set.size());
+	}
+
+	/** Definitions that are not equal are still allowed to hash alike, but these do not. */
+	@Test
+	public void definitionsOfDifferentQualifiedNamesHashDifferently() throws Exception {
+		var definitions = definitions();
+		Property countA = definitions.get("Issue3095A::Count");
+
+		assertNotEquals(countA.hashCode(), definitions.get("Issue3095B::Count").hashCode());
+		assertNotEquals(countA.hashCode(), definitions.get("Issue3095A::Other").hashCode());
 	}
 
 	@Test
 	public void aSeparatelyBuiltDefinitionOfAnotherQualifiedNameIsNotEqual() throws Exception {
-		Property countA = property("Issue3095A::Count");
+		Property countA = definitions().get("Issue3095A::Count");
 
 		assertFalse(countA.equals(definition("Issue3095A", "Counter")));
 		assertFalse(countA.equals(definition("Issue3095C", "Count")));
@@ -151,16 +189,25 @@ public class Issue3095Test extends XtextTest {
 		assertNull(unnamed.getQualifiedName());
 		assertTrue(unnamed.equals(unnamed));
 		assertFalse(unnamed.equals(alsoUnnamed));
-		assertFalse(unnamed.equals(property("Issue3095A::Count")));
+		assertFalse(unnamed.equals(definitions().get("Issue3095A::Count")));
 	}
 
 	@Test
 	public void aDefinitionIsNotEqualToSomethingThatIsNotAProperty() throws Exception {
-		assertFalse(property("Issue3095A::Count").equals("Issue3095A::Count"));
+		assertFalse(definitions().get("Issue3095A::Count").equals("Issue3095A::Count"));
 	}
 
-	/** A property definition of {@code qualifiedName}, read from the fixture's associations. */
-	private Property property(String qualifiedName) throws Exception {
+	/**
+	 * The property definitions the fixture associates, keyed by qualified name, all read from one
+	 * parse.
+	 *
+	 * <p>
+	 * One parse per call matters: {@code TestHelper.parseFile} loads into a resource set it cleans
+	 * between calls, so a definition read from an earlier parse is detached by the time a later parse
+	 * returns, and comparing across parses compares against a stale object.
+	 * </p>
+	 */
+	private Map<String, Property> definitions() throws Exception {
 		AadlPackage pkg = testHelper.parseFile(MODEL, SET_A, SET_B);
 		validationHelper.assertNoIssues(pkg);
 		ComponentType top = (ComponentType) pkg.getOwnedPublicSection()
@@ -169,12 +216,14 @@ public class Issue3095Test extends XtextTest {
 				.filter(classifier -> classifier.getName().equals("Top"))
 				.findFirst()
 				.orElseThrow(() -> new IllegalStateException("No component type Top"));
-		return top.getOwnedPropertyAssociations()
-				.stream()
-				.map(association -> association.getProperty())
-				.filter(definition -> qualifiedName.equals(definition.getQualifiedName()))
-				.findFirst()
-				.orElseThrow(() -> new IllegalStateException("No association naming " + qualifiedName));
+		var byQualifiedName = new LinkedHashMap<String, Property>();
+		for (var association : top.getOwnedPropertyAssociations()) {
+			Property definition = association.getProperty();
+			byQualifiedName.put(definition.getQualifiedName(), definition);
+		}
+		assertEquals(Set.of("Issue3095A::Count", "Issue3095B::Count", "Issue3095A::Other"),
+				byQualifiedName.keySet());
+		return byQualifiedName;
 	}
 
 	/** A property definition built in memory, in a property set of its own. */

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3095Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3095Test.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.Aadl2Factory;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentType;
+import org.osate.aadl2.Property;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * Characterizes when {@code PropertyImpl} considers two property definitions equal.
+ *
+ * <p>
+ * Property lookup compares one property definition against the property definition of every
+ * property association it walks past, which makes this the most frequently executed comparison in
+ * instantiation (issue #3095). The comparison is by qualified name and ignores case, so two
+ * definitions that come from different property sets are distinct even when their simple names are
+ * equal, and a definition read from one model equals a definition of the same qualified name that
+ * was built elsewhere. These tests pin those answers, so that an optimization of the comparison is
+ * held to producing exactly them.
+ * </p>
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3095Test extends XtextTest {
+	private static final String PROJECT = "org.osate.core.tests/models/issue3095/";
+	private static final String MODEL = PROJECT + "Issue3095.aadl";
+	private static final String SET_A = PROJECT + "Issue3095A.aadl";
+	private static final String SET_B = PROJECT + "Issue3095B.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void aPropertyDefinitionEqualsItself() throws Exception {
+		Property countA = property("Issue3095A::Count");
+
+		assertTrue(countA.equals(countA));
+	}
+
+	@Test
+	public void definitionsOfTheSameNameInDifferentPropertySetsAreNotEqual() throws Exception {
+		Property countA = property("Issue3095A::Count");
+		Property countB = property("Issue3095B::Count");
+
+		assertEquals("Count", countA.getName());
+		assertEquals("Count", countB.getName());
+		assertFalse(countA.equals(countB));
+		assertFalse(countB.equals(countA));
+	}
+
+	@Test
+	public void definitionsOfDifferentNamesInOnePropertySetAreNotEqual() throws Exception {
+		Property countA = property("Issue3095A::Count");
+		Property otherA = property("Issue3095A::Other");
+
+		assertFalse(countA.equals(otherA));
+		assertFalse(otherA.equals(countA));
+	}
+
+	/**
+	 * The comparison is by qualified name, not by identity, so a separately built definition of the
+	 * same qualified name is equal, and so is one that differs only in case.
+	 */
+	@Test
+	public void aSeparatelyBuiltDefinitionOfTheSameQualifiedNameIsEqualIgnoringCase() throws Exception {
+		Property countA = property("Issue3095A::Count");
+		Property sameName = definition("Issue3095A", "Count");
+		Property sameNameOtherCase = definition("issue3095a", "COUNT");
+
+		assertEquals("Issue3095A::Count", sameName.getQualifiedName());
+		assertTrue(countA.equals(sameName));
+		assertTrue(sameName.equals(countA));
+		assertEquals(countA.hashCode(), sameName.hashCode());
+
+		assertEquals("issue3095a::COUNT", sameNameOtherCase.getQualifiedName());
+		assertTrue(countA.equals(sameNameOtherCase));
+		assertTrue(sameNameOtherCase.equals(countA));
+	}
+
+	/**
+	 * {@code hashCode} hashes the qualified name as written while {@code equals} ignores case, so two
+	 * definitions that are equal can hash differently. That is how it already behaves; it is recorded
+	 * here so that a change to the comparison is not mistaken for a change to this.
+	 */
+	@Test
+	public void hashCodeIsCaseSensitiveWhereEqualsIsNot() throws Exception {
+		Property countA = property("Issue3095A::Count");
+		Property sameNameOtherCase = definition("issue3095a", "COUNT");
+
+		assertTrue(countA.equals(sameNameOtherCase));
+		assertNotEquals(countA.hashCode(), sameNameOtherCase.hashCode());
+	}
+
+	@Test
+	public void aSeparatelyBuiltDefinitionOfAnotherQualifiedNameIsNotEqual() throws Exception {
+		Property countA = property("Issue3095A::Count");
+
+		assertFalse(countA.equals(definition("Issue3095A", "Counter")));
+		assertFalse(countA.equals(definition("Issue3095C", "Count")));
+	}
+
+	/**
+	 * A definition with no name has no qualified name, and the comparison falls back to identity.
+	 */
+	@Test
+	public void anUnnamedDefinitionIsEqualOnlyToItself() throws Exception {
+		Property unnamed = Aadl2Factory.eINSTANCE.createProperty();
+		Property alsoUnnamed = Aadl2Factory.eINSTANCE.createProperty();
+
+		assertNull(unnamed.getQualifiedName());
+		assertTrue(unnamed.equals(unnamed));
+		assertFalse(unnamed.equals(alsoUnnamed));
+		assertFalse(unnamed.equals(property("Issue3095A::Count")));
+	}
+
+	@Test
+	public void aDefinitionIsNotEqualToSomethingThatIsNotAProperty() throws Exception {
+		assertFalse(property("Issue3095A::Count").equals("Issue3095A::Count"));
+	}
+
+	/** A property definition of {@code qualifiedName}, read from the fixture's associations. */
+	private Property property(String qualifiedName) throws Exception {
+		AadlPackage pkg = testHelper.parseFile(MODEL, SET_A, SET_B);
+		validationHelper.assertNoIssues(pkg);
+		ComponentType top = (ComponentType) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals("Top"))
+				.findFirst()
+				.orElseThrow(() -> new IllegalStateException("No component type Top"));
+		return top.getOwnedPropertyAssociations()
+				.stream()
+				.map(association -> association.getProperty())
+				.filter(definition -> qualifiedName.equals(definition.getQualifiedName()))
+				.findFirst()
+				.orElseThrow(() -> new IllegalStateException("No association naming " + qualifiedName));
+	}
+
+	/** A property definition built in memory, in a property set of its own. */
+	private static Property definition(String propertySetName, String propertyName) {
+		var propertySet = Aadl2Factory.eINSTANCE.createPropertySet();
+		propertySet.setName(propertySetName);
+		Property definition = Aadl2Factory.eINSTANCE.createProperty();
+		definition.setName(propertyName);
+		propertySet.getOwnedProperties().add(definition);
+		return definition;
+	}
+}


### PR DESCRIPTION
Part of #3095. This is the first of two PRs for that issue; #3095 is closed by the follow-up, not by this one.

## Cause and correction

Property lookup compares one property definition against the definition of every property association of every element it walks past — `PropertyAcc.addLocal` and `addLocalContained` both do `pa.getProperty().equals(property)`. `PropertyImpl.equals` built **both** qualified names from scratch for each comparison, and `NamedElementOperations.qualifiedName` walks up the namespace chain concatenating a fresh string on every call. All but one comparison per element is a mismatch, so two strings were built and discarded, millions of times per instantiation. The same comparison dominates `InstantiateModel.addUsedPropertyDefinitions`, where each `UniqueEList.add` runs `contains` over the accumulated filter.

Profiling attributed 77.1% of `cachePropertyAssociations` and 80.2% of `addUsedPropertyDefinitions` to this one comparison, with the leaf frames being the namespace walk itself (`eContainer` 32%, `hasName` 15%, `getOwner` 13%).

**Correction 1 — reject on the simple name first.** This is exact rather than approximate: a qualified name ends with the element's own name, so two definitions whose names already differ ignoring case cannot have qualified names that are equal ignoring case. Rejecting on the name therefore answers exactly what the qualified-name comparison would, from a field read. Identity short-circuits as well, which is the case a resolved model hits whenever the answer is yes.

**Correction 2 — a defect found alongside, not a performance change.** `equals` compares qualified names with `equalsIgnoreCase` while `hashCode` hashed the qualified name **as written**, so two definitions that are equal landed in different buckets. A `HashSet<Property>` kept one entry per spelling rather than one per definition, and a `HashMap<Property, ...>` could miss a key that was present. `hashCode` now hashes case-folded characters: two characters count as the same ignoring case exactly when folding each through `toUpperCase` then `toLowerCase` gives the same character, which is what `String.equalsIgnoreCase` compares, so the folded hash agrees with `equals` by construction and does not depend on the default locale. The qualified name is also built once per call instead of twice.

## Regression model and assertions

`core/org.osate.core.tests/models/issue3095/` declares a property named `Count` in each of two property sets (`Issue3095A`, `Issue3095B`) and associates both, plus `Issue3095A::Other`, on one component type. The test reads resolved `Property` objects out of the parsed model rather than constructing them.

`Issue3095Test` (10 tests) pins:

- definitions of equal simple name from **different** property sets are not equal — the case the new name pre-check must pass through to the qualified-name comparison rather than accept;
- definitions of different simple names in one property set are not equal;
- a separately built definition of the same qualified name **is** equal, including when it differs only in case — so the pre-check must be case-insensitive;
- an unnamed definition has no qualified name and is equal only to itself;
- equal definitions hash alike ignoring case, and a `HashSet` holds one entry per definition;
- definitions of different qualified names hash differently, so agreeing with `equals` is not achieved by making the hash useless.

Every definition a test compares comes from **one** parse. `TestHelper` loads into a resource set it cleans between calls, so a definition read from an earlier parse is detached by the time a later parse returns; an earlier draft of this test compared against a stale object and reported a false pass.

The two hash tests fail before the fix commit — the set holds three entries whose elements are all `equals` to one another — and pass after it.

## Validation

Clean root reactor, run outside the sandbox at each of the two fix commits:

```
mvn -s releng/osate.releng/settings.xml -Plocal \
  -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false \
  -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
  -DfailIfNoTests=false clean install
```

| | modules | tests | result |
|---|---|---|---|
| at the `equals` fix | 137 | 2,830 | BUILD SUCCESS, 0 failures |
| at the `hashCode` fix | 137 | 2,834 | BUILD SUCCESS, 0 failures |

`org.osate.core.tests` alone: 822 tests, 0 failures (814 pre-existing plus the 8 added here; the count is 10 in the final commit after the hash tests were split out).

Focused: `-Dtest=Issue3095Test -DfailIfNoTests=false` → 10 tests, 0 failures.

### Performance

Measured headlessly on a generated model — 11,808 component instances, 75,948 feature instances, 2,754 connection instances, 64 used property definitions, subcomponent and feature arrays, `Connection_Pattern` and `Connection_Set` expansions:

| phase | before | after |
|---|---|---|
| used property definitions | 877 ms | 260 ms |
| — accumulator `add` | 697 ms | 53 ms |
| cache remaining properties | 5,033 ms | 2,811 ms |
| — `Property.evaluate` | 3,347 ms | 985 ms |
| **total instantiation** | **8,091 ms** | **3,749 ms (−54%)** |

The benchmark is deliberately not committed: it is a generated fixture plus a driver that only prints numbers, and it needs a 6 GB heap because the instance model serializes to about 500 MB. Full method and attribution are in https://github.com/osate/osate2/issues/3095#issuecomment-5427196339.

## Dependencies

None. Based on `master` at `58006b9744`.

The follow-up PR for #3095 item 4 is based on this branch and should be merged after it. Because this repository merges with "Create a merge commit", GitHub retargets that PR to `master` automatically when this one merges.

## Residual risk

**`hashCode` changes hash-collection iteration order.** Anything keyed by `Property` in a `HashMap`/`HashSet` and then iterated can emit in a different order. A sweep of the reactor found the collections keyed by `Property` are `LinkedHashMap` in EMV2's `EMV2AnnexInstantiator` (insertion-ordered, unaffected) and one `HashMap<Property, List<Mode>>` in `PropertiesValidator.buildPropertySetForModeMap`, which is iterated to emit "Value not set for mode" warnings — so the order of those warnings could shift. No test in the reactor asserts that order, and the full build is green. That same map was also one of the collections the old `hashCode` made unreliable.

**The instance model is byte identical.** SHA-256 of the serialized instance resource is unchanged from the pre-change baseline across repeated runs, at both fix commits, with and without an up-front `EcoreUtil.resolveAll`. This was the acceptance criterion #3095 set.

**`equals` semantics are unchanged by construction**, and the argument is spelled out in the code comment rather than left to the reader: the pre-check can only reject pairs the qualified-name comparison would also reject.

**Not exercised by the benchmark:** modes and system operation modes (a replicated modal classifier explodes the SOM count) and annex instantiation. Neither phase was significant in what was measured, but neither was measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
