### PR TITLE
Decide the abstract case once per property acceptance test 🤖

### DIFF
--- a/core/org.osate.aadl2/src/org/osate/aadl2/impl/NamedElementImpl.java
+++ b/core/org.osate.aadl2/src/org/osate/aadl2/impl/NamedElementImpl.java
@@ -483,14 +483,27 @@ public abstract class NamedElementImpl extends ElementImpl implements NamedEleme
 	};
 
 	public boolean acceptsProperty(Property property) {
-
-		for (PropertyOwner appliesTo : property.getAppliesTos()) {
-			if (Aadl2Package.eINSTANCE.getAbstract().isSuperTypeOf(eClass())) {
-				return true;
-			}
+		EList<PropertyOwner> appliesTos = property.getAppliesTos();
+		if (appliesTos.isEmpty()) {
+			return false;
+		}
+		/*
+		 * Whether this element is an Abstract does not depend on which entry of the applies to list is
+		 * being looked at, so answer it once. Deciding it inside the loop asked the same question of the
+		 * metaclass once per entry, and this is the most frequently executed test in instantiation
+		 * (issue #3095). The empty check above keeps the answer the same as when it was decided inside
+		 * the loop, which an empty list never entered.
+		 */
+		EClass metaclass = eClass();
+		if (Aadl2Package.eINSTANCE.getAbstract().isSuperTypeOf(metaclass)) {
+			return true;
+		}
+		for (PropertyOwner appliesTo : appliesTos) {
 			if (appliesTo instanceof MetaclassReference) {
-				MetaclassReference metaRef = (MetaclassReference) appliesTo;
-				if (metaRef.getMetaclass() != null && metaRef.getMetaclass().isSuperTypeOf(eClass())) {
+				// One call: getMetaclass resolves the metaclass names on first use and answers from a
+				// field after that, but it was asked twice per entry.
+				EClass appliesToMetaclass = ((MetaclassReference) appliesTo).getMetaclass();
+				if (appliesToMetaclass != null && appliesToMetaclass.isSuperTypeOf(metaclass)) {
 					return true;
 				}
 			}

--- a/core/org.osate.core.tests/models/issue3095/Issue3095AppliesTo.aadl
+++ b/core/org.osate.core.tests/models/issue3095/Issue3095AppliesTo.aadl
@@ -1,0 +1,30 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- An applies to (all) property and one restricted to a single category, so that a test can check
+-- which named elements accept which.
+property set Issue3095AppliesTo is
+	Anything: aadlinteger applies to (all);
+	ThreadOnly: aadlinteger applies to (thread);
+end Issue3095AppliesTo;

--- a/core/org.osate.core.tests/models/issue3095/Issue3095Categories.aadl
+++ b/core/org.osate.core.tests/models/issue3095/Issue3095Categories.aadl
@@ -1,0 +1,45 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- One classifier per category the acceptance test needs: a thread that the restricted property
+-- applies to, a process that it does not, and an abstract classifier, which accepts any property that
+-- applies to something. Each association is placed where it is legal, so that the test reads the
+-- resolved property definitions from a model with no issues.
+package Issue3095Categories
+public
+	with Issue3095AppliesTo;
+
+	thread Worker
+		properties
+			Issue3095AppliesTo::ThreadOnly => 1;
+	end Worker;
+
+	process Holder
+		properties
+			Issue3095AppliesTo::Anything => 2;
+	end Holder;
+
+	abstract AnythingGoes
+	end AnythingGoes;
+end Issue3095Categories;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3095AcceptsPropertyTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3095AcceptsPropertyTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.Aadl2Factory;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.Classifier;
+import org.osate.aadl2.Property;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * Characterizes which named elements accept which property definitions.
+ *
+ * <p>
+ * {@code NamedElementImpl.acceptsProperty} decides this by walking the property's applies to list, and
+ * the property caching phase of instantiation asks it for every pair of instance object and used
+ * property definition, which makes it the most frequently executed test in a run (issue #3095). Three
+ * answers matter and are easy to get wrong when the walk is rearranged: a property restricted to a
+ * category is accepted only by that category, an abstract classifier accepts a property that applies
+ * to anything at all, and a property that applies to nothing is accepted by no element, not even an
+ * abstract one.
+ * </p>
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3095AcceptsPropertyTest extends XtextTest {
+	private static final String PROJECT = "org.osate.core.tests/models/issue3095/";
+	private static final String MODEL = PROJECT + "Issue3095Categories.aadl";
+	private static final String PROPERTY_SET = PROJECT + "Issue3095AppliesTo.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void aPropertyThatAppliesToAllIsAcceptedByEveryCategory() throws Exception {
+		var model = parse();
+		Property anything = property(model, "Holder", "Issue3095AppliesTo::Anything");
+
+		assertTrue(classifier(model, "Worker").acceptsProperty(anything));
+		assertTrue(classifier(model, "Holder").acceptsProperty(anything));
+		assertTrue(classifier(model, "AnythingGoes").acceptsProperty(anything));
+	}
+
+	@Test
+	public void aPropertyRestrictedToOneCategoryIsAcceptedOnlyByThatCategory() throws Exception {
+		var model = parse();
+		Property threadOnly = property(model, "Worker", "Issue3095AppliesTo::ThreadOnly");
+
+		assertTrue(classifier(model, "Worker").acceptsProperty(threadOnly));
+		assertFalse(classifier(model, "Holder").acceptsProperty(threadOnly));
+	}
+
+	/**
+	 * An abstract classifier accepts a property whatever category it is restricted to, because an
+	 * abstract component stands in for a component of any category.
+	 */
+	@Test
+	public void anAbstractClassifierAcceptsAPropertyRestrictedToAnotherCategory() throws Exception {
+		var model = parse();
+		Property threadOnly = property(model, "Worker", "Issue3095AppliesTo::ThreadOnly");
+
+		assertTrue(classifier(model, "AnythingGoes").acceptsProperty(threadOnly));
+	}
+
+	/**
+	 * A definition that applies to nothing is accepted by no element. The abstract case is the one worth
+	 * pinning: being abstract does not make an element accept a property that applies to nothing.
+	 */
+	@Test
+	public void aPropertyThatAppliesToNothingIsAcceptedByNoElement() throws Exception {
+		var model = parse();
+		Property appliesToNothing = Aadl2Factory.eINSTANCE.createProperty();
+		appliesToNothing.setName("AppliesToNothing");
+
+		assertTrue(appliesToNothing.getAppliesTos().isEmpty());
+		assertFalse(classifier(model, "Worker").acceptsProperty(appliesToNothing));
+		assertFalse(classifier(model, "Holder").acceptsProperty(appliesToNothing));
+		assertFalse(classifier(model, "AnythingGoes").acceptsProperty(appliesToNothing));
+	}
+
+	/** The fixture's classifiers by name, all from one parse. */
+	private Map<String, Classifier> parse() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(MODEL, PROPERTY_SET);
+		validationHelper.assertNoIssues(pkg);
+		var byName = new LinkedHashMap<String, Classifier>();
+		for (Classifier classifier : pkg.getOwnedPublicSection().getOwnedClassifiers()) {
+			byName.put(classifier.getName(), classifier);
+		}
+		return byName;
+	}
+
+	private static Classifier classifier(Map<String, Classifier> model, String name) {
+		Classifier classifier = model.get(name);
+		if (classifier == null) {
+			throw new IllegalStateException("No classifier " + name + " in " + model.keySet());
+		}
+		return classifier;
+	}
+
+	/** The definition of {@code qualifiedName}, read from the named classifier's associations. */
+	private static Property property(Map<String, Classifier> model, String classifierName, String qualifiedName) {
+		return classifier(model, classifierName).getOwnedPropertyAssociations()
+				.stream()
+				.map(association -> association.getProperty())
+				.filter(definition -> qualifiedName.equals(definition.getQualifiedName()))
+				.findFirst()
+				.orElseThrow(() -> new IllegalStateException(
+						"No association naming " + qualifiedName + " on " + classifierName));
+	}
+}


### PR DESCRIPTION
Fixes #3095.

This is the second and last of two PRs for that issue. #3099 carries the change that produced nearly all of the improvement; this one carries #3095 item 4, and the issue is closed here because the remaining proposals were measured and deliberately dropped — see "Scope of the issue" below.

## Cause and correction

`NamedElementImpl.acceptsProperty` decided whether the element is an `Abstract` **inside** the loop over the property's applies-to list, although the answer does not depend on which entry is being examined:

```java
for (PropertyOwner appliesTo : property.getAppliesTos()) {
    if (Aadl2Package.eINSTANCE.getAbstract().isSuperTypeOf(eClass())) {
        return true;
    }
    ...
```

A property that applies to twenty metaclasses therefore asked the metaclass the same question twenty times. `CachePropertyAssociationsSwitch.cachePropertyAssociations` runs this test once per pair of instance object and used property definition, which on the benchmark is 5,616,455 calls.

The check now happens once, before the loop. **An empty applies-to list still answers no**, because the loop body was never entered for one and so the abstract shortcut was never reached; the early `return false` preserves exactly that. The metaclass of an applies-to entry is also fetched once per entry rather than twice — `MetaclassReference.getMetaclass()` resolves the metaclass names on first use and answers from a field afterwards, so that part is for clarity, and it measured at zero.

## Regression model and assertions

`core/org.osate.core.tests/models/issue3095/` gains `Issue3095AppliesTo.aadl` (a property `Anything` that applies to `all` and a property `ThreadOnly` restricted to `thread`) and `Issue3095Categories.aadl` (a thread, a process, and an abstract classifier, with each association placed where it is legal so the fixture has no issues).

`Issue3095AcceptsPropertyTest` (4 tests) pins the four answers the rearrangement must preserve:

- a property that applies to `all` is accepted by every category;
- a property restricted to `thread` is accepted by the thread and **not** by the process;
- an abstract classifier accepts a property restricted to another category — the shortcut being moved;
- a property that applies to **nothing** is accepted by no element, **including the abstract one**.

The last is the subtle case and the reason the empty-list early return exists: being abstract must not make an element accept a property that applies to nothing.

This is a characterization test of a behavior-preserving change, so it passes both before and after the production commit. That was verified in both directions rather than assumed.

## Validation

Clean root reactor, run outside the sandbox on this branch:

```
mvn -s releng/osate.releng/settings.xml -Plocal \
  -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false \
  -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
  -DfailIfNoTests=false clean install
```

→ 137 modules, **2,842 tests, 0 failures**, BUILD SUCCESS.

Focused: `-Dtest=Issue3095AcceptsPropertyTest -DfailIfNoTests=false` → 4 tests, 0 failures, run both with and without the production commit applied.

### Performance

On the same generated benchmark as #3099, measured against that PR as the baseline:

| | before | after |
|---|---|---|
| `acceptsProperty` | 610 ms | 455 ms, over 5,616,455 calls |
| total instantiation | 3,749 ms | 3,750–3,880 ms |

**No total improvement is claimed.** The 155 ms saving is about 4% of the run, which is inside the run-to-run spread of the total, so it is visible only on the instrumented sub-timer. This is stated in the commit message too. If that is not worth the churn, this PR is the one to reject — #3099 stands on its own.

## Dependencies

**Based on `3095_speed_up_model_instantiation` (#3099), not on `master`.** Merge #3099 first. Because this repository merges with "Create a merge commit", GitHub will retarget this PR's base to `master` automatically at that point; the base should read `master` and the diff should show only these two commits before this one is merged.

The stacking is deliberate rather than incidental: the headroom above is only meaningful measured on top of #3099, and the memo table discussed below would have depended on that PR's `hashCode` fix being correct.

## Scope of the issue

#3095 proposed five changes and asked that measurement come first. It did, and the numbers revise its ranking enough that four of the five are not worth making. The reasoning is recorded at https://github.com/osate/osate2/issues/3095#issuecomment-5427515653; in short: item 1 is ~224 ms, item 2 is ~53 ms and already largely realized by #3099, item 3 is ≤62 ms for the widest blast radius in the set, and item 5 is bounded by a phase that is 5% of the run.

The memo table that is the other half of item 4 — worth ~455 ms, collapsing 5,616,455 calls to about 1,240 distinct answers — was declined on correctness grounds, not payoff:

- A memo on `PropertyImpl` keyed by `EClass` has the right lifetime but needs invalidation when `appliesTos` changes, and the only hook guaranteed to fire is overriding `didChange()` on the list the **generated** `getAppliesTos()` returns, which means marking that accessor `@generated NOT` and carrying it through EMF regeneration.
- It can be poisoned: `MetaclassReference.getMetaclass()` resolves lazily, so a caller asking `acceptsProperty` before the metaclass names are populated would cache an answer of *no* that nothing later invalidates. Instantiation never does this, but `acceptsProperty` is public API that validators call while a model is being edited.
- A cache owned by the instantiation would be edit-safe but wrong: the answer is not a pure function of `(EClass, Property)` for `ComponentInstance`, `FeatureGroup` or `ConnectionInstance`, only for the plain-feature majority. Separating out the metaclass-only part would mean new public API, which #3095 rules out.

## Residual risk

**Low, and the risk is concentrated in one case.** The change is a loop-invariant hoist plus an empty-list guard in a single method. The guard is the only place the answer could have changed, and it is what `aPropertyThatAppliesToNothingIsAcceptedByNoElement` covers.

`acceptsProperty` has overrides in `FeatureGroupImpl`, `SubcomponentImpl`, `ClassifierImpl`, `ComponentInstanceImpl`, `ConnectionInstanceImpl`, `ConnectionReferenceImpl` and `SystemOperationModeImpl`. Those that delegate via `super.acceptsProperty` reach the changed code and are covered by the full reactor run; `ComponentInstanceImpl` and `SystemOperationModeImpl` do not call it at all and are untouched.

The instance model is byte identical: SHA-256 of the serialized instance resource is unchanged from the pre-change baseline across repeated runs, with and without an up-front `EcoreUtil.resolveAll`.

**Not exercised by the benchmark:** modes and system operation modes, and annex instantiation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
