### PR TITLE
Keep appended list elements in every modal value 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CachePropertyAssociationsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CachePropertyAssociationsSwitch.java
@@ -36,6 +36,7 @@ import org.osate.aadl2.ListValue;
 import org.osate.aadl2.ModalPropertyValue;
 import org.osate.aadl2.Property;
 import org.osate.aadl2.PropertyAssociation;
+import org.osate.aadl2.PropertyExpression;
 import org.osate.aadl2.ReferenceValue;
 import org.osate.aadl2.instance.ComponentInstance;
 import org.osate.aadl2.instance.ConnectionInstance;
@@ -294,25 +295,29 @@ public class CachePropertyAssociationsSwitch extends AadlProcessingSwitchWithPro
 
 	private List<Issue> fillPropertyValue(InstanceObject io, PropertyAssociation pa, List<EvaluatedProperty> values) {
 		final var issues = new ArrayList<Issue>();
-		final var valueIter = values.iterator();
-		final var proxies = valueIter.next().getProxies();
+		final var proxies = values.getFirst().getProxies();
+		/*
+		 * The values that the first one appends to, flattened into the elements that go in front of every
+		 * modal value of the appending association, least specific first.
+		 */
+		final var appendedTo = new ArrayList<PropertyExpression>();
+
+		for (var value : values.subList(1, values.size())) {
+			var prx = value.getProxies().getFirst();
+
+			if (prx.isModal()) {
+				throw new InvalidModelException(pa, "Trying to append to a modal list value");
+			}
+			appendedTo.addAll(0, ((ListValue) prx.getValue()).getOwnedListElements());
+		}
 
 		for (var proxy : proxies) {
 			var newVal = Aadl2Factory.eINSTANCE.createModalPropertyValue();
 
 			newVal.setOwnedValue(EcoreUtil.copy(proxy.getValue()));
-			// process list appends
-			while (valueIter.hasNext()) {
-				var prx = valueIter.next().getProxies().getFirst();
-
-				if (prx.isModal()) {
-					throw new InvalidModelException(pa, "Trying to append to a modal list value");
-				}
-
-				var appended = (ListValue) EcoreUtil.copy(prx.getValue());
-
+			if (!appendedTo.isEmpty()) {
 				((ListValue) newVal.getOwnedValue()).getOwnedListElements().addAll(0,
-						appended.getOwnedListElements());
+						EcoreUtil.copyAll(appendedTo));
 			}
 
 			boolean valueIsUsed;

--- a/core/org.osate.core.tests/models/issue3103/.gitignore
+++ b/core/org.osate.core.tests/models/issue3103/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3103/.project
+++ b/core/org.osate.core.tests/models/issue3103/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3103</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3103/Issue3103.aadl
+++ b/core/org.osate.core.tests/models/issue3103/Issue3103.aadl
@@ -1,0 +1,60 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- A modal appending association on a thread implementation, over a non-modal value declared on the
+-- thread type. Every modal value of the appending association must end up with the two elements from
+-- the type in front of its own element.
+package Issue3103
+public
+	with Issue3103Props;
+
+	thread T
+		properties
+			Issue3103Props::Nums => (1, 2);
+	end T;
+
+	thread implementation T.i
+		modes
+			m1: initial mode;
+			m2: mode;
+		properties
+			Issue3103Props::Nums +=> (10) in modes (m1), (20) in modes (m2);
+	end T.i;
+
+	process Pr
+	end Pr;
+
+	process implementation Pr.i
+		subcomponents
+			s: thread T.i;
+	end Pr.i;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			p: process Pr.i;
+	end Top.i;
+end Issue3103;

--- a/core/org.osate.core.tests/models/issue3103/Issue3103Props.aadl
+++ b/core/org.osate.core.tests/models/issue3103/Issue3103Props.aadl
@@ -1,0 +1,30 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- A list valued property that a model can append to with '+=>'. None of the predeclared list valued
+-- properties is declared in a property set that a test project may extend, so the property the test
+-- appends to lives here.
+property set Issue3103Props is
+	Nums: list of aadlinteger applies to (all);
+end Issue3103Props;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3103Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3103Test.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.IntegerLiteral;
+import org.osate.aadl2.ListValue;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * A modal appending association must keep the appended-to elements in every one of its modal values.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3103Test extends XtextTest {
+	private static final String PATH = "org.osate.core.tests/models/issue3103/";
+	private static final String MODEL = PATH + "Issue3103.aadl";
+	private static final String PROPERTIES = PATH + "Issue3103Props.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	/**
+	 * The thread type declares {@code Nums => (1, 2)} and the thread implementation appends a different
+	 * single element in each of its two modes. Property lookup hands the appending association's modal
+	 * values and the value it appends to to {@code CachePropertyAssociationsSwitch.fillPropertyValue},
+	 * which must prepend the two inherited elements to each modal value, not only to the first.
+	 */
+	@Test
+	public void everyModalValueOfAnAppendingAssociationKeepsTheAppendedToElements() throws Exception {
+		var pkg = testHelper.parseFile(MODEL, PROPERTIES);
+		validationHelper.assertNoIssues(pkg);
+		var implementation = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+		var errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+
+		var instance = InstantiateModel.instantiate(implementation, errorManager);
+
+		assertEquals(Map.of("m1", List.of(1L, 2L, 10L), "m2", List.of(1L, 2L, 20L)),
+				numsPerThreadMode(instance));
+		var reporter = (QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource());
+		assertEquals(List.of(), reporter.getErrors());
+	}
+
+	/**
+	 * The {@code Nums} value cached on the thread instance {@code p.s}, keyed by the name of the thread
+	 * mode that the system operation mode holding it activates. Each system operation mode of this model
+	 * activates exactly one mode of the thread.
+	 */
+	private static Map<String, List<Long>> numsPerThreadMode(SystemInstance instance) {
+		var thread = component(component(instance, "p"), "s");
+		var associations = thread.getOwnedPropertyAssociations()
+				.stream()
+				.filter(association -> association.getProperty().getName().equals("Nums"))
+				.toList();
+		assertEquals(1, associations.size());
+		var values = new LinkedHashMap<String, List<Long>>();
+
+		for (var som : instance.getSystemOperationModes()) {
+			var value = (ListValue) associations.getFirst().valueInMode(som);
+
+			assertEquals(1, som.getCurrentModes().size());
+			values.put(som.getCurrentModes().getFirst().getMode().getName(), value.getOwnedListElements()
+					.stream()
+					.map(element -> (long) ((IntegerLiteral) element).getValue())
+					.toList());
+		}
+		return values;
+	}
+
+	private static ComponentInstance component(ComponentInstance container, String name) {
+		return container.getComponentInstances()
+				.stream()
+				.filter(component -> component.getName().equals(name))
+				.findFirst()
+				.orElseThrow();
+	}
+}


### PR DESCRIPTION
Fixes #3103

## Cause and correction

`CachePropertyAssociationsSwitch.fillPropertyValue()` created the iterator over the evaluated
values outside the loop over the modal values of the most specific one, and the append loop drained
it. The first modal value received the elements of every less specific value; all later modal
values kept only their own elements. A modal appending association therefore lost the inherited part
of the list in all modes but the first.

The elements of the values that are appended to are now collected once, before the loop over the
modal values, in the order the old append loop produced them (least specific first). Each modal
value gets a fresh copy of those elements in front of its own. The check that rejects appending to a
modal value moved with the collecting loop and inspects the same proxies as before.

## Regression model and assertion

`core/org.osate.core.tests/models/issue3103/` declares a list valued property `Nums`, a thread type
with `Nums => (1, 2)`, and a thread implementation with two modes and
`Nums +=> (10) in modes (m1), (20) in modes (m2)`. The model has no AADL errors and instantiation
reports none.

`Issue3103Test` instantiates `Top.i` and reads the cached `Nums` association of the thread instance
`p.s` in each system operation mode, asserting `(1, 2, 10)` for `m1` and `(1, 2, 20)` for `m2`.
Before the fix the value for `m2` was `(20)`.

## Validation

- `mvn -o -s releng/osate.releng/settings.xml -Plocal -pl :org.osate.core.tests -Dtest=Issue3103Test -DfailIfNoTests=false clean verify` on the regression commit alone: 1 test, 1 failure, `expected:<{m2=[1, 2, 20], m1=[1, 2, 10]}> but was:<{m1=[1, 2, 10], m2=[20]}>`.
- Same command with the fix: 1 test, 0 failures.
- Clean root reactor with tests: `mvn -s releng/osate.releng/settings.xml -Plocal -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -DfailIfNoTests=false clean install` — BUILD SUCCESS, no failures or errors in any test bundle; `org.osate.core.tests` ran 827 tests.

## Dependencies

None. The branch is based on `master` at d8f4dd3139 and contains the regression commit followed by
the production fix.

## Residual risk

Low. The change is confined to `fillPropertyValue()`. Non-appending associations are unaffected:
`values` then has one entry, the collected element list is empty, and the value is copied as before.
For a non-modal appending association the single modal value gets the same concatenation in the same
order as before. No existing test model in the repository uses `+=>`, so the appending path itself
is only covered by the new regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)