### PR TITLE
Make the reference value passes agree by removing a dead type test 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CacheContainedPropertyAssociationsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CacheContainedPropertyAssociationsSwitch.java
@@ -309,6 +309,11 @@ public class CacheContainedPropertyAssociationsSwitch extends AadlProcessingSwit
 	 * Replace the reference values of a copied property association with references to the instance
 	 * objects they denote in the context of {@code context}, reporting an error on {@code io} for a
 	 * reference that cannot be evaluated at all.
+	 * <p>
+	 * A value that has already been instantiated is an
+	 * {@link org.osate.aadl2.instance.InstanceReferenceValue}, which is not a {@link ReferenceValue}, so
+	 * the test below leaves it alone. Here that cannot happen anyway, because the values are copies of a
+	 * declarative association.
 	 *
 	 * @return the problems found, which the caller reports only if it keeps the association
 	 */
@@ -337,7 +342,8 @@ public class CacheContainedPropertyAssociationsSwitch extends AadlProcessingSwit
 
 	/**
 	 * Replace the reference values of a copied property association with references to the instance
-	 * objects they denote in the context of a feature instance.
+	 * objects they denote in the context of a feature instance. As above, an already instantiated value is
+	 * not a {@link ReferenceValue} and is therefore left alone.
 	 *
 	 * @return the problems found
 	 */

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CachePropertyAssociationsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CachePropertyAssociationsSwitch.java
@@ -391,12 +391,16 @@ public class CachePropertyAssociationsSwitch extends AadlProcessingSwitchWithPro
 	 * Replace the reference values of a cached value with references to the instance objects they denote
 	 * in the context of {@code io}. Returns the problems found, which the caller reports only if it keeps
 	 * the value.
+	 * <p>
+	 * A value that has already been instantiated is an {@link InstanceReferenceValue}, which is not a
+	 * {@link ReferenceValue}, so the test below leaves it alone. The same holds for the other passes that
+	 * instantiate reference values, here and in {@link CacheContainedPropertyAssociationsSwitch}.
 	 */
 	private static List<Issue> instantiateReferenceValues(final ModalPropertyValue value, final InstanceObject io) {
 		final var issues = new ArrayList<Issue>();
 
 		for (var elem : properContentsOf(value)) {
-			if (elem instanceof ReferenceValue rv && !(rv instanceof InstanceReferenceValue)) {
+			if (elem instanceof ReferenceValue rv) {
 				try {
 					var irv = rv.instantiate(io);
 					if (irv != null) {
@@ -416,13 +420,14 @@ public class CachePropertyAssociationsSwitch extends AadlProcessingSwitchWithPro
 	/**
 	 * Retry the reference values of a property association cached on a semantic connection that the
 	 * connection reference could not resolve, this time in the context of the connection's component
-	 * instance. A value that is already instantiated is left alone, and so is one that this context
-	 * cannot resolve either.
+	 * instance. The values that {@link #instantiateReferenceValues} has already replaced are
+	 * {@link InstanceReferenceValue}s, which are not {@link ReferenceValue}s, so the test below leaves
+	 * them alone; a value that this context cannot resolve either is left alone as well.
 	 */
 	private static void instantiateConnectionReferenceValues(final PropertyAssociationInstance pa,
 			final ComponentInstance context) {
 		for (var elem : properContentsOf(pa)) {
-			if (elem instanceof ReferenceValue rv && !(rv instanceof InstanceReferenceValue)) {
+			if (elem instanceof ReferenceValue rv) {
 				var irv = rv.instantiate(context);
 				if (irv != null) {
 					EcoreUtil.replace(rv, irv);

--- a/core/org.osate.core.tests/models/issue3104/Issue3104.aadl
+++ b/core/org.osate.core.tests/models/issue3104/Issue3104.aadl
@@ -9,8 +9,8 @@ public
 
 	--  The properties on connection c hold every shape of reference value that the connection
 	--  property cache instantiates: a list, a modal list, a single reference that resolves two
-	--  levels down, a reference to a connection, and a reference to a call sequence, which is
-	--  not instantiated and so stays unresolved.
+	--  levels down, a reference to a connection, a reference to a call sequence, which is not
+	--  instantiated and so stays unresolved, and a list that mixes the last two.
 	system implementation Top.i
 		subcomponents
 			src: process Sender.i;
@@ -23,6 +23,7 @@ public
 				Issue3104Props::Bound_Subprogram => reference (src.worker.helper);
 				Issue3104Props::Bound_Connection => reference (src.inner);
 				Issue3104Props::Bound_Call_Sequence => reference (src.worker.startup);
+				Issue3104Props::Bound_Mixed => (reference (src.inner), reference (src.worker.startup));
 			};
 		modes
 			running: initial mode;

--- a/core/org.osate.core.tests/models/issue3104/Issue3104Props.aadl
+++ b/core/org.osate.core.tests/models/issue3104/Issue3104Props.aadl
@@ -16,4 +16,8 @@ property set Issue3104Props is
 	-- A reference to a call sequence, which no context resolves because call sequences are not
 	-- instantiated.
 	Bound_Call_Sequence: reference (subprogram call sequence) applies to (connection);
+
+	-- A list in which one element resolves and one does not. This is the shape whose elements the
+	-- retry pass used to visit twice, and instantiate twice where the first visit resolved nothing.
+	Bound_Mixed: list of reference (connection, subprogram call sequence) applies to (connection);
 end Issue3104Props;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3104Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3104Test.java
@@ -24,7 +24,6 @@
 package org.osate.core.tests.issues;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
@@ -71,9 +70,9 @@ import com.itemis.xtext.testing.XtextTest;
  * pass over the association in the context of the connection's enclosing component instance, and
  * that pass used to visit the values of a list twice (issue #3104). These tests pin what the pass
  * produces for every shape of reference value a connection property can hold - a list, a modal
- * list, a reference that resolves two levels down, a reference to a connection, and a reference
- * that no context resolves - so that folding the two visits into one is held to producing exactly
- * them.
+ * list, a reference that resolves two levels down, a reference to a connection, a reference that no
+ * context resolves, and a list that mixes the last two - so that folding the two visits into one is
+ * held to producing exactly them.
  * </p>
  */
 @RunWith(XtextRunner.class)
@@ -152,13 +151,30 @@ public class Issue3104Test extends XtextTest {
 		var values = valuesOf("Issue3104Props::Bound_Call_Sequence");
 
 		assertEquals(1, values.size());
-		PropertyExpression value = values.get(0).getOwnedValue();
-		assertTrue(value instanceof ReferenceValue);
-		assertFalse(value instanceof InstanceReferenceValue);
-		assertEquals(List.of("src", "worker", "startup"), ((ReferenceValue) value).getContainmentPathElements()
-				.stream()
-				.map(element -> element.getNamedElement().getName())
-				.collect(Collectors.toList()));
+		assertEquals(List.of("src", "worker", "startup"), declarativePathOf(values.get(0).getOwnedValue()));
+	}
+
+	/**
+	 * A list whose elements do not all resolve keeps both kinds, once each and in declaration order:
+	 * the element this context resolves is instantiated, the one it cannot is left declarative.
+	 *
+	 * <p>
+	 * This is the shape the pass used to work on twice over. It replaced the elements of the list
+	 * before the tree iterator descended into it, so a resolved element was visited again as an
+	 * instance reference value, which is not a {@link ReferenceValue} and so was skipped, while an
+	 * unresolved element was still a reference value and was instantiated a second time.
+	 * </p>
+	 */
+	@Test
+	public void aListOfMixedReferencesKeepsBothKindsInOrder() throws Exception {
+		var values = valuesOf("Issue3104Props::Bound_Mixed");
+
+		assertEquals(1, values.size());
+		var elements = elementsOf(values.get(0).getOwnedValue());
+		assertEquals(2, elements.size());
+		assertTrue("not instantiated: " + elements.get(0), elements.get(0) instanceof InstanceReferenceValue);
+		assertEquals(CONNECTION, pathOf(((InstanceReferenceValue) elements.get(0)).getReferencedInstanceObject()));
+		assertEquals(List.of("src", "worker", "startup"), declarativePathOf(elements.get(1)));
 	}
 
 	/**
@@ -179,7 +195,7 @@ public class Issue3104Test extends XtextTest {
 		var instantiated = new ArrayList<String>();
 		var declarative = 0;
 
-		assertEquals(5, connection.getOwnedPropertyAssociations().size());
+		assertEquals(6, connection.getOwnedPropertyAssociations().size());
 		for (var association : connection.getOwnedPropertyAssociations()) {
 			TreeIterator<EObject> contents = EcoreUtil.getAllProperContents(association, false);
 			while (contents.hasNext()) {
@@ -195,12 +211,14 @@ public class Issue3104Test extends XtextTest {
 		}
 		/*
 		 * Sorted, because the order of the associations on the connection is the order of the property
-		 * filter, which is not part of the model. Two references to src.worker and two to dst.worker:
-		 * one each from the list and one each from the modal list.
+		 * filter, which is not part of the model. Two references to src.worker and two to dst.worker,
+		 * one each from the list and one each from the modal list, and two to the connection, one from
+		 * the single reference and one from the mixed list. Declarative: the call sequence, twice, once
+		 * on its own and once in the mixed list.
 		 */
-		assertEquals(List.of("dst.worker", "dst.worker", "src.worker", "src.worker", "src.worker.helper", CONNECTION),
-				instantiated.stream().sorted().toList());
-		assertEquals(1, declarative);
+		assertEquals(List.of("dst.worker", "dst.worker", "src.worker", "src.worker", "src.worker.helper", CONNECTION,
+				CONNECTION), instantiated.stream().sorted().toList());
+		assertEquals(2, declarative);
 	}
 
 	/** The values of the association for this property on the connection of the fixture. */
@@ -221,15 +239,31 @@ public class Issue3104Test extends XtextTest {
 	 * the value holds them. Every reference of the value must have been instantiated.
 	 */
 	private static List<String> referencedPaths(PropertyExpression value) {
-		var expressions = value instanceof ListValue list ? List.copyOf(list.getOwnedListElements())
-				: List.of(value);
 		var paths = new ArrayList<String>();
 
-		for (var expression : expressions) {
+		for (var expression : elementsOf(value)) {
 			assertTrue("not instantiated: " + expression, expression instanceof InstanceReferenceValue);
 			paths.add(pathOf(((InstanceReferenceValue) expression).getReferencedInstanceObject()));
 		}
 		return paths;
+	}
+
+	/** The elements of a list value, or the value itself when it is not a list. */
+	private static List<PropertyExpression> elementsOf(PropertyExpression value) {
+		return value instanceof ListValue list ? List.copyOf(list.getOwnedListElements()) : List.of(value);
+	}
+
+	/**
+	 * The names along the containment path of a value that was left declarative. An instantiated value
+	 * is an {@code InstanceReferenceValue}, which is a {@code PropertyValue} and not a
+	 * {@code ReferenceValue}, so the type test is what says the value was not instantiated.
+	 */
+	private static List<String> declarativePathOf(PropertyExpression value) {
+		assertTrue("instantiated: " + value, value instanceof ReferenceValue);
+		return ((ReferenceValue) value).getContainmentPathElements()
+				.stream()
+				.map(element -> element.getNamedElement().getName())
+				.collect(Collectors.toList());
 	}
 
 	/** The path of an instance object below the system instance, as dot separated names. */


### PR DESCRIPTION
Fixes #3105

## Cause and correction

The issue expects all reference value passes in property caching to agree on leaving a value that is already an `InstanceReferenceValue` alone, and reports that only `CachePropertyAssociationsSwitch.instantiateReferenceValues` does so.

The passes already agree, but not for the reason the guard suggests. `InstanceReferenceValue` derives from `PropertyValue` only (`core/org.osate.aadl2/model/instance.ecore`); it is **not** a `ReferenceValue`, and `ReferenceValueImpl` is the only implementor of `ReferenceValue` in the code base. So `elem instanceof ReferenceValue` already excludes an already instantiated value in every pass, and the extra `!(rv instanceof InstanceReferenceValue)` test can never be false.

Two consequences for the issue as filed:

- The connection retry pass, `instantiateConnectionReferenceValues`, never calls `instantiate` on an `InstanceReferenceValue` and never reaches `EcoreUtil.replace(rv, rv)`. It visits only the references that `fillPropertyValue` could not resolve in the context of the connection reference, which is the point of the retry in the containing component instance.
- The two `instantiateReferenceValues` overloads in `CacheContainedPropertyAssociationsSwitch` need no guard either, for the same reason plus the stronger one already noted in the issue: their values are copies of a declarative association.

Adding the guard to the other three passes would therefore have added dead code in three more places. The correction goes the other way: remove the dead test so the passes read alike, and record in the Javadoc why the type test alone is sufficient, so the guard is not added back. The dead test dates from `b280e29aa2` "Don't re-resolve reference values", where it was written against `elem` rather than `rv` and was equally unreachable.

`InstanceReferenceValueImpl.instantiate` returning `this`, which the issue cites, is also never reached from these passes: it declares `instantiate(ComponentInstance)`, an overload of neither `ReferenceValue.instantiate(InstanceObject)` nor `ReferenceValue.instantiate(FeatureInstance)`, and `InstanceReferenceValueImpl` does not implement `ReferenceValue`.

### Rebased: two dead tests now, not one

This branch has been rebased onto `8a8cb57f2c`, the merge of #3112 for #3104. That fix folded the two visits of `instantiateConnectionReferenceValues` into one loop and, on the premise this issue has since disproved, added the same unreachable conjunct to the folded loop. Both occurrences are removed here, and the Javadoc of the retry pass now states why an already instantiated value cannot reach it. Without this, `master` keeps a dead type test in the very method #3105 is about.

## Regression model and assertion

No test can fail before this change and pass after it: the removed conjunct can never be false, so the change is provably behavior preserving, and adding a seam to force the unreachable branch is exactly the kind of production hook the project's workflow rules out.

The second commit does strengthen the characterization that came in with #3104, in the one place where the premise correction is observable in the fixture. `Issue3104Test` covered lists whose elements all resolve; it did not cover a list in which one element resolves and one does not, which is the shape where the removed inner loop actually did duplicate work — the resolved element was visited a second time as an `InstanceReferenceValue` and skipped, the unresolved one was still a `ReferenceValue` and was instantiated again.

`Issue3104Props::Bound_Mixed`, a `list of reference (connection, subprogram call sequence)`, now holds a connection, which the component instance resolves, and a call sequence, which nothing instantiates. The new test asserts the list keeps both kinds, once each and in declaration order, and the totals over the whole connection account for six instantiated references and two declarative ones. The list-walking helper is shared with the existing assertions, and the "left declarative" check is a named helper that records why the type test alone decides it.

## Validation

Clean root reactor build with tests, run outside the sandbox on the rebased branch:

```
mvn -s releng/osate.releng/settings.xml -Plocal \
  -Dtycho.localArtifacts=ignore \
  -Dpr.build=true -Dsign=false \
  -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
  -DfailIfNoTests=false \
  clean install
```

`BUILD SUCCESS` in 5:11. 13 test bundles, 1429 tests, 0 failures, 0 errors, 0 skipped. `org.osate.core.tests`: 834 tests, including `Issue3104Test` at 7, which also passes with the fold from #3112 reverted.

## Dependencies and merge order

Rebased onto current `master` (`8a8cb57f2c`); no other branch involved. #3104 is closed by #3112, so nothing waits on this.

## Residual risk

Low. Two unreachable conjuncts removed, Javadoc added, one property and one test method added to an existing fixture; no other executable change. The risk is confined to the claim that no type both implements `ReferenceValue` and is an `InstanceReferenceValue`, which holds for the committed metamodel and generated implementation classes. A future metamodel change that made `InstanceReferenceValue` a subtype of `ReferenceValue` would require the guard to come back, which is why the Javadoc states the reason rather than only the conclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
