### PR TITLE
Instantiate each connection reference value once 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CachePropertyAssociationsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CachePropertyAssociationsSwitch.java
@@ -245,10 +245,11 @@ public class CachePropertyAssociationsSwitch extends AadlProcessingSwitchWithPro
 						continue;
 					}
 					/*
-					 * FIXME JD
-					 *
-					 * Try to look if the property references a component or not.
-					 * This was done to fix the issue related to the Bound Bus analysis plugin
+					 * The values were instantiated in the context of the connection reference, which
+					 * resolves nothing that a containment path names, because a connection reference
+					 * contains no instance objects. Retry what is left in the context of the connection's
+					 * component instance, which is where a reference to a bus, a connection, or another
+					 * part of the enclosing component resolves.
 					 */
 					instantiateConnectionReferenceValues(newPA, conni.getContainingComponentInstance());
 
@@ -408,30 +409,20 @@ public class CachePropertyAssociationsSwitch extends AadlProcessingSwitchWithPro
 	}
 
 	/**
-	 * Replace the reference values of a property association cached on a semantic connection with
-	 * references to the instance objects they denote in the context of the connection's component
-	 * instance.
+	 * Retry the reference values of a property association cached on a semantic connection that the
+	 * connection reference could not resolve, this time in the context of the connection's component
+	 * instance. A value that is already instantiated is left alone, and so is one that this context
+	 * cannot resolve either.
 	 */
 	private static void instantiateConnectionReferenceValues(final PropertyAssociationInstance pa,
 			final ComponentInstance context) {
 		for (var elem : properContentsOf(pa)) {
-			if (elem instanceof ModalPropertyValue mpv && mpv.getOwnedValue() instanceof ListValue lv) {
-				for (var listElement : lv.getOwnedListElements()) {
-					if (listElement instanceof ReferenceValue rv) {
-						instantiateInPlace(rv, context);
-					}
+			if (elem instanceof ReferenceValue rv && !(rv instanceof InstanceReferenceValue)) {
+				var irv = rv.instantiate(context);
+				if (irv != null) {
+					EcoreUtil.replace(rv, irv);
 				}
 			}
-			if (elem instanceof ReferenceValue rv) {
-				instantiateInPlace(rv, context);
-			}
-		}
-	}
-
-	private static void instantiateInPlace(final ReferenceValue rv, final ComponentInstance context) {
-		var irv = rv.instantiate(context);
-		if (irv != null) {
-			EcoreUtil.replace(rv, irv);
 		}
 	}
 

--- a/core/org.osate.core.tests/models/issue3104/.gitignore
+++ b/core/org.osate.core.tests/models/issue3104/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3104/.project
+++ b/core/org.osate.core.tests/models/issue3104/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3104</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3104/Issue3104.aadl
+++ b/core/org.osate.core.tests/models/issue3104/Issue3104.aadl
@@ -1,0 +1,75 @@
+package Issue3104
+public
+	with Issue3104Props;
+
+	system Top
+		features
+			trigger: in event port;
+	end Top;
+
+	--  The properties on connection c hold every shape of reference value that the connection
+	--  property cache instantiates: a list, a modal list, a single reference that resolves two
+	--  levels down, a reference to a connection, and a reference to a call sequence, which is
+	--  not instantiated and so stays unresolved.
+	system implementation Top.i
+		subcomponents
+			src: process Sender.i;
+			dst: process Receiver.i;
+		connections
+			c: port src.output -> dst.input {
+				Issue3104Props::Bound_Threads => (reference (src.worker), reference (dst.worker));
+				Issue3104Props::Modal_Threads => (reference (src.worker)) in modes (running),
+					(reference (dst.worker)) in modes (degraded);
+				Issue3104Props::Bound_Subprogram => reference (src.worker.helper);
+				Issue3104Props::Bound_Connection => reference (src.inner);
+				Issue3104Props::Bound_Call_Sequence => reference (src.worker.startup);
+			};
+		modes
+			running: initial mode;
+			degraded: mode;
+			toDegraded: running -[trigger]-> degraded;
+	end Top.i;
+
+	process Sender
+		features
+			output: out event data port;
+	end Sender;
+
+	process implementation Sender.i
+		subcomponents
+			worker: thread W.i;
+		connections
+			inner: port worker.output -> output;
+	end Sender.i;
+
+	process Receiver
+		features
+			input: in event data port;
+	end Receiver;
+
+	process implementation Receiver.i
+		subcomponents
+			worker: thread W.i;
+		connections
+			inner: port input -> worker.input;
+	end Receiver.i;
+
+	thread W
+		features
+			input: in event data port;
+			output: out event data port;
+	end W;
+
+	thread implementation W.i
+		subcomponents
+			helper: subprogram Helper;
+		calls
+			startup: {
+				runHelper: subprogram Helper;
+			};
+	end W.i;
+
+	subprogram Helper
+	end Helper;
+
+end Issue3104;

--- a/core/org.osate.core.tests/models/issue3104/Issue3104Props.aadl
+++ b/core/org.osate.core.tests/models/issue3104/Issue3104Props.aadl
@@ -1,0 +1,19 @@
+property set Issue3104Props is
+	-- A list of references that the connection reference cannot resolve, but the connection's
+	-- component instance can.
+	Bound_Threads: list of reference (thread) applies to (connection);
+
+	-- The same, modal, so that the modes a value applies in can be pinned as well.
+	Modal_Threads: list of reference (thread) applies to (connection);
+
+	-- A single reference two levels down, resolved in the same context.
+	Bound_Subprogram: reference (subprogram) applies to (connection);
+
+	-- A reference to a connection, which only a component instance resolves, because only a
+	-- component instance looks for connection instances.
+	Bound_Connection: reference (connection) applies to (connection);
+
+	-- A reference to a call sequence, which no context resolves because call sequences are not
+	-- instantiated.
+	Bound_Call_Sequence: reference (subprogram call sequence) applies to (connection);
+end Issue3104Props;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3104Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3104Test.java
@@ -1,0 +1,267 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.emf.common.util.TreeIterator;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.ListValue;
+import org.osate.aadl2.ModalPropertyValue;
+import org.osate.aadl2.PropertyExpression;
+import org.osate.aadl2.ReferenceValue;
+import org.osate.aadl2.instance.ConnectionInstance;
+import org.osate.aadl2.instance.InstanceObject;
+import org.osate.aadl2.instance.InstanceReferenceValue;
+import org.osate.aadl2.instance.ModeInstance;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instance.SystemOperationMode;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.core.tests.instantiation.InstanceLookup;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * Characterizes the reference values that property caching leaves on a semantic connection.
+ *
+ * <p>
+ * A reference value of a property association cached on a connection cannot be resolved from the
+ * connection reference the value was looked up on, because a connection reference contains no
+ * instance objects a containment path could name. The values are therefore resolved by a second
+ * pass over the association in the context of the connection's enclosing component instance, and
+ * that pass used to visit the values of a list twice (issue #3104). These tests pin what the pass
+ * produces for every shape of reference value a connection property can hold - a list, a modal
+ * list, a reference that resolves two levels down, a reference to a connection, and a reference
+ * that no context resolves - so that folding the two visits into one is held to producing exactly
+ * them.
+ * </p>
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3104Test extends XtextTest {
+	private static final String PROJECT = "org.osate.core.tests/models/issue3104/";
+	private static final String MODEL = PROJECT + "Issue3104.aadl";
+	private static final String PROPERTIES = PROJECT + "Issue3104Props.aadl";
+
+	/** The one semantic connection of the fixture, named after the two thread ports it connects. */
+	private static final String CONNECTION = "src.worker.output -> dst.worker.input";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	/**
+	 * Every element of a list of references is instantiated, exactly once: the list holds one
+	 * instance reference per declared element, in declaration order.
+	 */
+	@Test
+	public void everyElementOfAReferenceListIsInstantiatedOnce() throws Exception {
+		var values = valuesOf("Issue3104Props::Bound_Threads");
+
+		assertEquals(1, values.size());
+		assertTrue(values.get(0).getInModes().isEmpty());
+		assertEquals(List.of("src.worker", "dst.worker"), referencedPaths(values.get(0).getOwnedValue()));
+	}
+
+	/**
+	 * The same for a modal list: each value keeps its own list of one instance reference, and each
+	 * applies in the system operation modes of the mode it was declared in.
+	 */
+	@Test
+	public void aModalReferenceListKeepsOneInstanceReferencePerValue() throws Exception {
+		var values = valuesOf("Issue3104Props::Modal_Threads");
+
+		assertEquals(2, values.size());
+		assertEquals(List.of("src.worker"), referencedPaths(values.get(0).getOwnedValue()));
+		assertEquals(Set.of("running"), modeNames(values.get(0)));
+		assertEquals(List.of("dst.worker"), referencedPaths(values.get(1).getOwnedValue()));
+		assertEquals(Set.of("degraded"), modeNames(values.get(1)));
+	}
+
+	/** A single reference value is instantiated too, however deep the path it names. */
+	@Test
+	public void aSingleReferenceIsInstantiated() throws Exception {
+		var values = valuesOf("Issue3104Props::Bound_Subprogram");
+
+		assertEquals(1, values.size());
+		assertEquals(List.of("src.worker.helper"), referencedPaths(values.get(0).getOwnedValue()));
+	}
+
+	/**
+	 * A reference that names a connection resolves to the semantic connection that the named
+	 * connection is part of. This is a value that only the component instance can resolve: looking
+	 * for connection instances is something a component instance does and a connection reference does
+	 * not, which is why the second pass exists.
+	 */
+	@Test
+	public void aReferenceToAConnectionIsInstantiated() throws Exception {
+		var values = valuesOf("Issue3104Props::Bound_Connection");
+
+		assertEquals(1, values.size());
+		assertEquals(List.of(CONNECTION), referencedPaths(values.get(0).getOwnedValue()));
+	}
+
+	/**
+	 * A reference that no context resolves, here a call sequence, which is not instantiated, is left
+	 * declarative: the pass keeps a value it cannot resolve rather than dropping it.
+	 */
+	@Test
+	public void aReferenceNoContextResolvesIsLeftDeclarative() throws Exception {
+		var values = valuesOf("Issue3104Props::Bound_Call_Sequence");
+
+		assertEquals(1, values.size());
+		PropertyExpression value = values.get(0).getOwnedValue();
+		assertTrue(value instanceof ReferenceValue);
+		assertFalse(value instanceof InstanceReferenceValue);
+		assertEquals(List.of("src", "worker", "startup"), ((ReferenceValue) value).getContainmentPathElements()
+				.stream()
+				.map(element -> element.getNamedElement().getName())
+				.collect(Collectors.toList()));
+	}
+
+	/**
+	 * The connection carries one association per property of the fixture, the associations hold as
+	 * many instance references as the fixture declares references that resolve, and every part of
+	 * them is still rooted in the system instance.
+	 *
+	 * <p>
+	 * Instantiating a value replaces it in a containment list, so a value that is visited a second
+	 * time is replaced a second time. This is what would notice a replacement that drops a value or
+	 * detaches the subtree it belongs to.
+	 * </p>
+	 */
+	@Test
+	public void theCachedAssociationsHoldExactlyTheInstantiatedReferences() throws Exception {
+		SystemInstance instance = instantiate();
+		ConnectionInstance connection = InstanceLookup.connection(instance, CONNECTION);
+		var instantiated = new ArrayList<String>();
+		var declarative = 0;
+
+		assertEquals(5, connection.getOwnedPropertyAssociations().size());
+		for (var association : connection.getOwnedPropertyAssociations()) {
+			TreeIterator<EObject> contents = EcoreUtil.getAllProperContents(association, false);
+			while (contents.hasNext()) {
+				EObject element = contents.next();
+
+				assertSame(instance, EcoreUtil.getRootContainer(element));
+				if (element instanceof InstanceReferenceValue irv) {
+					instantiated.add(pathOf(irv.getReferencedInstanceObject()));
+				} else if (element instanceof ReferenceValue) {
+					declarative++;
+				}
+			}
+		}
+		/*
+		 * Sorted, because the order of the associations on the connection is the order of the property
+		 * filter, which is not part of the model. Two references to src.worker and two to dst.worker:
+		 * one each from the list and one each from the modal list.
+		 */
+		assertEquals(List.of("dst.worker", "dst.worker", "src.worker", "src.worker", "src.worker.helper", CONNECTION),
+				instantiated.stream().sorted().toList());
+		assertEquals(1, declarative);
+	}
+
+	/** The values of the association for this property on the connection of the fixture. */
+	private List<ModalPropertyValue> valuesOf(String qualifiedPropertyName) throws Exception {
+		ConnectionInstance connection = InstanceLookup.connection(instantiate(), CONNECTION);
+		var matches = connection.getOwnedPropertyAssociations()
+				.stream()
+				.filter(association -> qualifiedPropertyName.equalsIgnoreCase(
+						association.getProperty().getQualifiedName()))
+				.toList();
+
+		assertEquals("associations for " + qualifiedPropertyName, 1, matches.size());
+		return List.copyOf(matches.get(0).getOwnedValues());
+	}
+
+	/**
+	 * The instance objects a value refers to, as paths relative to the system instance, in the order
+	 * the value holds them. Every reference of the value must have been instantiated.
+	 */
+	private static List<String> referencedPaths(PropertyExpression value) {
+		var expressions = value instanceof ListValue list ? List.copyOf(list.getOwnedListElements())
+				: List.of(value);
+		var paths = new ArrayList<String>();
+
+		for (var expression : expressions) {
+			assertTrue("not instantiated: " + expression, expression instanceof InstanceReferenceValue);
+			paths.add(pathOf(((InstanceReferenceValue) expression).getReferencedInstanceObject()));
+		}
+		return paths;
+	}
+
+	/** The path of an instance object below the system instance, as dot separated names. */
+	private static String pathOf(InstanceObject io) {
+		var names = new ArrayList<String>();
+
+		for (InstanceObject current = io; !(current instanceof SystemInstance); current = (InstanceObject) current
+				.eContainer()) {
+			names.add(0, current.getName());
+		}
+		return String.join(".", names);
+	}
+
+	/** The names of the modes that the system operation modes of a value are made of. */
+	private static Set<String> modeNames(ModalPropertyValue value) {
+		return value.getInModes()
+				.stream()
+				.flatMap(mode -> ((SystemOperationMode) mode).getCurrentModes().stream())
+				.map(ModeInstance::getName)
+				.collect(Collectors.toSet());
+	}
+
+	private SystemInstance instantiate() throws Exception {
+		AadlPackage pkg = testHelper.parseFile(MODEL, PROPERTIES);
+		validationHelper.assertNoIssues(pkg);
+		ComponentImplementation top = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow(() -> new IllegalStateException("No system implementation Top.i"));
+
+		return InstantiateModel.instantiate(top);
+	}
+}


### PR DESCRIPTION
Fixes #3104

## Cause and correction

`CachePropertyAssociationsSwitch.instantiateConnectionReferenceValues` is the retry pass that instantiates the reference values of a property association cached on a semantic connection in the context of the connection's component instance. It walked the association twice over: the branch for a `ModalPropertyValue` replaced the reference values of an owned `ListValue` before the tree iterator descended into that list, and the branch for a `ReferenceValue` then saw the `InstanceReferenceValue`s the first branch had just created and instantiated them again. `InstanceReferenceValueImpl.instantiate` returns `this`, so the second call degenerated to `EcoreUtil.replace(rv, rv)` on a containment list.

The branch for the list is dropped. The tree iterator reaches the elements of a list on its own, so the remaining loop covers the same values — including the elements of a list nested in a list, which the dropped branch did not reach. The loop now also skips a value that is already an `InstanceReferenceValue`, the way the pass over the values of a regular association does, so no value is instantiated twice; a value can arrive already instantiated when the association was evaluated from one this pass has already been through. A value that this context cannot resolve either is still left alone rather than dropped.

The `FIXME JD` at the call site, which asked what the pass was for, is replaced by a comment that says what it does. The helper `instantiateInPlace` is inlined, since the one branch that remains is its only caller. Cached values, diagnostics, and the API of the class are unchanged.

This is the connection half of #3105's missing guard as well. The two `instantiateReferenceValues` overloads in `CacheContainedPropertyAssociationsSwitch` are untouched, so #3105 stays open.

## Regression model and assertion

`core/org.osate.core.tests/models/issue3104/` puts every shape of reference value a connection property can hold on one connection `c`: a `list of reference (thread)`, a modal `list of reference (thread)` with one value per mode of the enclosing implementation, a `reference (subprogram)` that resolves two levels down, a `reference (connection)`, and a `reference (subprogram call sequence)`, which is not instantiated.

`Issue3104Test` asserts, per property, how many values the association has, what each value refers to, in which order, and for the modal values which modes each applies in; and, across the connection, that the five associations hold exactly the six instance references the fixture declares — none instantiated twice, none dropped — with exactly one value left declarative, and that every part of them is still rooted in the system instance.

Two of the fixture's values are resolvable only from the component instance, which is what the retry pass is for: the reference to a connection, because only a component instance looks for connection instances, and the call sequence reference, which no context resolves and which therefore stays declarative.

These tests pass before and after the fix — #3104 is redundant work, not a wrong result — so they are characterization, not a failing regression. That they constrain the fold was confirmed by removing the loop that reaches values outside a list: three of the six then fail.

## Validation

- `mvn -o -pl :org.osate.aadl2.instantiation,:org.osate.plugins.feature,:org.osate.core.tests -Dtest=Issue3104Test -DfailIfNoTests=false clean install` — 6 tests, 0 failures, with and without the fix.
- `org.osate.core.tests` in full — 832 tests, 0 failures (826 before this branch plus the 6 new ones).
- Clean root reactor, `-Dtycho.localArtifacts=ignore -Dpr.build=true`, `clean install` — BUILD SUCCESS, 0 failures and 0 errors across all 13 test bundles (`org.osate.core.tests` 832, `org.osate.aadl2.errormodel.tests` 290, `org.osate.slicer.tests` 50, `org.osate.analysis.flows.tests` 40, `org.osate.ba.tests` 36, `org.osate.aadl2.instance.textual.tests` 25, `org.osate.analysis.resource.budgets.tests` 17, and the rest).

## Dependencies

None. The branch is based on `master` at d8f4dd3 (the merge of #3102) and touches only the retry pass that #3101 left in place.

## Residual risk

The order in which the pass calls `instantiate` changes: the elements of a list are now instantiated when the iterator reaches them rather than before it descends. Resolution does not depend on that order, and the values that survive are pinned per property by the new test and unchanged across the reactor's tests. The new guard changes behavior only for a value that is already an `InstanceReferenceValue`, where the previous call was a no-op replacement. Reference values inside an annex subclause of a connection property are out of scope here, as before: `getAllProperContents` skips cross-resource contained children, which is what the pass already used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
