### PR TITLE
Expand flow specifications over feature group arrays 🤖

### DIFF
--- a/core/org.osate.aadl2.instance.textual.tests/src/org/osate/aadl2/instance/textual/tests/Serializer1Test.java
+++ b/core/org.osate.aadl2.instance.textual.tests/src/org/osate/aadl2/instance/textual/tests/Serializer1Test.java
@@ -721,10 +721,10 @@ public class Serializer1Test extends AbstractSerializerTest {
 
 	/**
 	 * {@code f4} is a flow sink on a feature array, so it has one flow specification instance per array
-	 * element, named {@code f4_1} and {@code f4_2} (issue #2787). {@code f6} and {@code f7} are not
-	 * expanded: {@code p5} is an array declared inside a feature group type, where an array is not allowed
-	 * and is instantiated as a single feature, and {@code f7}'s end is a feature reached through an array
-	 * feature group rather than an array feature itself.
+	 * element, named {@code f4_1} and {@code f4_2} (issue #2787). {@code f7} is expanded the same way from
+	 * the array feature group its end is reached through (issue #3113). {@code f6} is not expanded:
+	 * {@code p5} is an array declared inside a feature group type, where an array is not allowed and is
+	 * instantiated as a single feature.
 	 */
 	@Test
 	public void testFlowSpecification() throws Exception {
@@ -804,7 +804,8 @@ public class Serializer1Test extends AbstractSerializerTest {
 					flow f4_2 ( p3[2] -> ) : pkg1::s:f4
 					flow f5 ( fg1.p4 -> ) : pkg1::s:f5
 					flow f6 ( fg1.p5 -> ) : pkg1::s:f6
-					flow f7 ( fg2[1].p6 -> ) : pkg1::s:f7
+					flow f7_1 ( fg2[1].p6 -> ) : pkg1::s:f7
+					flow f7_2 ( fg2[2].p6 -> ) : pkg1::s:f7
 					som "No Modes"
 				}""");
 	}

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/FlowSpecArrayExpander.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/internal/FlowSpecArrayExpander.java
@@ -24,11 +24,13 @@
 package org.osate.aadl2.instantiation.internal;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.osate.aadl2.Feature;
 import org.osate.aadl2.PropertyExpression;
 import org.osate.aadl2.instance.ComponentInstance;
 import org.osate.aadl2.instance.FeatureInstance;
@@ -37,7 +39,7 @@ import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
 
 /**
  * Expands the provisional flow specification instances of one instance model root into the final set. A
- * flow specification whose in or out end is a feature array stands for one flow specification instance
+ * flow specification whose in or out end is in a feature array stands for one flow specification instance
  * per pair of elements that {@code Connection_Pattern}, {@code Connection_Set} or the default pattern
  * pairs up, so a flow that goes through such a component goes through one element of it.
  * <p>
@@ -47,8 +49,9 @@ import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
  * of indices becomes. When the property is not set, {@code One_To_One} applies, which is why a model that
  * declares nothing still gets one flow specification instance per element.
  * <p>
- * Only an end that is a feature array itself is expanded. An end reached through a feature group that is
- * an array keeps the first element of that group, as it always did.
+ * An end is an array element either because it is a feature array itself or because it is reached through
+ * a feature group that is an array; in the second case the index sits on the enclosing feature group
+ * instance and the paired-up element is the corresponding feature of that element of the group.
  * <p>
  * {@code Connection_Pattern} and {@code Connection_Set} have to be cached on the provisional flow
  * specification instances before the expansion runs, the same window the connection expansion needs, see
@@ -183,39 +186,98 @@ public final class FlowSpecArrayExpander {
 	}
 
 	/**
+	 * The array element a flow specification end belongs to, and how to get from that element back down to
+	 * the end.
+	 * <p>
+	 * The element is the end itself when the end is a feature array, and the enclosing feature group
+	 * instance when the end is a feature reached through a feature group that is an array. Only one step of
+	 * a path can be an array element: a feature declared inside a feature group type may not be an array
+	 * (AS5506D section 8 legality rule 3, which the validator enforces and which
+	 * {@code InstantiateModel.instantiateFGFeatures} reports), so no feature instance below an indexed
+	 * feature group instance is indexed in turn.
+	 *
+	 * @param element the feature instance that is the array element
+	 * @param descent the features that lead from that element down to the end, empty if the end is the
+	 *            element itself
+	 */
+	private record ArrayEnd(FeatureInstance element, List<Feature> descent) {
+	}
+
+	/**
+	 * The array element a flow specification end belongs to, or {@code null} if the end is not in an array.
+	 *
+	 * @param end the source or destination of a flow specification instance, {@code null} for the end a flow
+	 *            source or a flow sink does not have
+	 */
+	private static ArrayEnd arrayEnd(FeatureInstance end) {
+		var descent = new ArrayList<Feature>();
+		for (var current = end; current != null; current = enclosingFeatureGroup(current)) {
+			if (current.getIndex() != 0) {
+				Collections.reverse(descent);
+				return new ArrayEnd(current, List.copyOf(descent));
+			}
+			descent.add(current.getFeature());
+		}
+		return null;
+	}
+
+	/** The feature group instance a feature instance is a feature of, or {@code null} if it is not in one. */
+	private static FeatureInstance enclosingFeatureGroup(FeatureInstance fi) {
+		return fi.eContainer() instanceof FeatureInstance featureGroup ? featureGroup : null;
+	}
+
+	/**
 	 * The sizes of the array dimensions of a flow specification end. A feature array has at most one
-	 * dimension, so this is one size or none at all. The size is the number of feature instances the
-	 * feature was instantiated into, which is what the array bound evaluated to.
+	 * dimension, so this is one size or none at all. The size is the number of feature instances the array
+	 * element was instantiated into, which is what the array bound evaluated to.
 	 *
 	 * @param end the source or destination of a flow specification instance, {@code null} for the end a
 	 *            flow source or a flow sink does not have
-	 * @return the size of the dimension of the end, or an empty list if the end is not an array element
+	 * @return the size of the dimension of the end, or an empty list if the end is not in an array
 	 */
 	private List<Integer> arraySizes(FeatureInstance end) {
-		if (end == null || end.getIndex() == 0) {
+		var arrayEnd = end == null ? null : arrayEnd(end);
+		if (arrayEnd == null) {
 			return List.of();
 		}
-		var elements = siblings(end).stream().filter(sibling -> sibling.getFeature() == end.getFeature()).count();
+		var element = arrayEnd.element();
+		var elements = siblings(element).stream().filter(sibling -> sibling.getFeature() == element.getFeature())
+				.count();
 		return List.of((int) elements);
 	}
 
 	/**
-	 * The feature instance of one element of a flow specification end.
+	 * The feature instance of one element of a flow specification end. When the array element is a feature
+	 * group that encloses the end, this is the corresponding feature of the other element of that group,
+	 * reached by following the same features down again.
 	 *
-	 * @param end the end the provisional instance was created with, which is the first element of the
-	 *            array when the end is one
-	 * @param indices the index of the element, empty if the end is not an array
-	 * @return the feature instance of that element, or {@code end} itself if the end is not an array
+	 * @param end the end the provisional instance was created with, which is in the first element of the
+	 *            array when the end is in one
+	 * @param indices the index of the element, empty if the end is not in an array
+	 * @return the feature instance for that element, or {@code end} itself if the end is not in an array
 	 */
 	private FeatureInstance elementAt(FeatureInstance end, List<Long> indices) {
-		if (end == null || indices.isEmpty()) {
+		var arrayEnd = end == null || indices.isEmpty() ? null : arrayEnd(end);
+		if (arrayEnd == null) {
 			return end;
 		}
+		var declaration = arrayEnd.element().getFeature();
 		var index = indices.getFirst();
-		return siblings(end).stream()
-				.filter(sibling -> sibling.getFeature() == end.getFeature() && sibling.getIndex() == index)
+		var current = siblings(arrayEnd.element()).stream()
+				.filter(sibling -> sibling.getFeature() == declaration && sibling.getIndex() == index)
 				.findFirst()
-				.orElse(end);
+				.orElse(null);
+		for (var feature : arrayEnd.descent()) {
+			if (current == null) {
+				break;
+			}
+			current = current.getFeatureInstances()
+					.stream()
+					.filter(child -> child.getFeature() == feature)
+					.findFirst()
+					.orElse(null);
+		}
+		return current == null ? end : current;
 	}
 
 	/**
@@ -223,8 +285,8 @@ public final class FlowSpecArrayExpander {
 	 * a feature of a component type, and those of the enclosing feature group instance for a feature of a
 	 * feature group type.
 	 */
-	private List<FeatureInstance> siblings(FeatureInstance end) {
-		EObject owner = end.eContainer();
+	private List<FeatureInstance> siblings(FeatureInstance element) {
+		EObject owner = element.eContainer();
 		if (owner instanceof FeatureInstance featureGroup) {
 			return featureGroup.getFeatureInstances();
 		}

--- a/core/org.osate.core.tests/models/issue3113/.gitignore
+++ b/core/org.osate.core.tests/models/issue3113/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3113/.project
+++ b/core/org.osate.core.tests/models/issue3113/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3113</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3113/Issue3113.aadl
+++ b/core/org.osate.core.tests/models/issue3113/Issue3113.aadl
@@ -1,0 +1,70 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with this program. The
+-- parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries of this
+-- license with respect to the terms applicable to their Third Party Software. Third Party Software licenses only
+-- apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- A feature group that is itself an array. The flow specification ends are features of the feature
+-- group type, so the array index sits on the enclosing feature group instance rather than on the end
+-- itself, which is the distinction the expansion has to see through.
+package Issue3113
+public
+	data D
+	end D;
+
+	feature group Bundle
+		features
+			signal: out event data port D;
+			ack: in event data port D;
+	end Bundle;
+
+	-- A device may declare feature arrays, so an array of feature groups is legal here. 'emit' has one
+	-- array end and 'relay' has two, which is the pairing the default One_To_One applies to.
+	device Emitter
+		features
+			bundles: feature group Bundle [2];
+		flows
+			emit: flow source bundles.signal;
+			relay: flow path bundles.ack -> bundles.signal;
+	end Emitter;
+
+	device Absorber
+		features
+			bundles: feature group inverse of Bundle [2];
+		flows
+			absorb: flow sink bundles.signal;
+	end Absorber;
+
+	system Top
+	end Top;
+
+	-- The connection joins the two feature group arrays, and is expanded per element. The end to end
+	-- flow over it has to have one instance per element as well.
+	system implementation Top.i
+		subcomponents
+			e: device Emitter;
+			a: device Absorber;
+		connections
+			link: feature group e.bundles <-> a.bundles;
+		flows
+			ete: end to end flow e.emit -> link -> a.absorb;
+	end Top.i;
+end Issue3113;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3113Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3113Test.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with this program. The
+ * parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries of this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.aadl2.instance.EndToEndFlowInstance;
+import org.osate.aadl2.instance.FeatureInstance;
+import org.osate.aadl2.instance.InstanceObject;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * A flow specification end reached through a feature group that is an array became a single flow
+ * specification instance on the first element of that group, because the expansion decided whether an end
+ * was an array element from the index of the end itself, which is zero for a feature of a feature group
+ * type. The index of such an end sits on the enclosing feature group instance.
+ * <p>
+ * Connection instantiation expands a connection across the elements of such a group, so the connection
+ * set covered every element while the flow specifications covered only the first, and the end to end
+ * flows built over them inherited that. Nothing was reported for the dropped elements.
+ * <p>
+ * This is the case issue #2787 left out; it expanded an end that is a feature array itself.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3113Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3113/Issue3113.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	private AnalysisErrorReporterManager errorManager;
+
+	/**
+	 * Every element of the feature group array gets its own flow specification instance. {@code emit} has
+	 * one array end and {@code relay} has two, which the default {@code One_To_One} pairs up by index.
+	 */
+	@Test
+	public void flowSpecificationsAreExpandedPerFeatureGroupElement() throws Exception {
+		var instance = instantiate("Top.i");
+
+		assertEquals(List.of("a.absorb_1 : bundles[1].signal -> <none>", "a.absorb_2 : bundles[2].signal -> <none>",
+				"e.emit_1 : <none> -> bundles[1].signal", "e.emit_2 : <none> -> bundles[2].signal",
+				"e.relay_1 : bundles[1].ack -> bundles[1].signal",
+				"e.relay_2 : bundles[2].ack -> bundles[2].signal"), flowSpecifications(instance));
+		assertEquals(List.of(), diagnostics(instance));
+	}
+
+	/**
+	 * The end to end flow over the connection between the two feature group arrays has one instance per
+	 * element, each through the element of its own index. The connection instances are asserted alongside
+	 * them: they always covered both elements, and the flows now agree with them.
+	 */
+	@Test
+	public void endToEndFlowIsBuiltPerFeatureGroupElement() throws Exception {
+		var instance = instantiate("Top.i");
+
+		assertEquals(List.of("a.bundles[1].ack --> e.bundles[1].ack", "a.bundles[2].ack --> e.bundles[2].ack",
+				"e.bundles[1].signal --> a.bundles[1].signal", "e.bundles[2].signal --> a.bundles[2].signal"),
+				names(instance.getAllConnectionInstances()));
+		assertEquals(List.of(
+				"ete_1 : e.emit_1 -> e.bundles[1].signal --> a.bundles[1].signal -> a.absorb_1",
+				"ete_2 : e.emit_2 -> e.bundles[2].signal --> a.bundles[2].signal -> a.absorb_2"), flows(instance));
+		assertEquals(List.of(), diagnostics(instance));
+	}
+
+	/**
+	 * The flow specification instances of a model, as {@code path : source -> destination} relative to the
+	 * system instance, sorted. The name carries the pairing and the two ends carry the array elements.
+	 */
+	private List<String> flowSpecifications(SystemInstance instance) {
+		return collect(instance, ComponentInstance::getFlowSpecifications, new ArrayList<>()).stream()
+				.map(fsi -> relative(instance, fsi) + " : " + end(fsi.getSource()) + " -> "
+						+ end(fsi.getDestination()))
+				.sorted()
+				.toList();
+	}
+
+	/** The end to end flow instances of a model, as {@code name : element -> element -> ...}, sorted. */
+	private List<String> flows(SystemInstance instance) {
+		return collect(instance, ComponentInstance::getEndToEndFlows, new ArrayList<>()).stream()
+				.map(flow -> flow.getName() + " : " + String.join(" -> ",
+						flow.getFlowElements().stream().map(element -> relative(instance, element)).toList()))
+				.sorted()
+				.toList();
+	}
+
+	/** A flow specification end, relative to the component instance whose flow specification it is. */
+	private static String end(FeatureInstance fi) {
+		if (fi == null) {
+			return "<none>";
+		}
+		var prefix = fi.getContainingComponentInstance().getInstanceObjectPath() + ".";
+		var path = fi.getInstanceObjectPath();
+		return path.startsWith(prefix) ? path.substring(prefix.length()) : path;
+	}
+
+	/**
+	 * The path of an instance object relative to the system instance, so which array element it belongs to
+	 * is part of what is asserted.
+	 */
+	private static String relative(SystemInstance instance, InstanceObject object) {
+		var prefix = instance.getInstanceObjectPath() + ".";
+		var path = object.getInstanceObjectPath();
+		return path.startsWith(prefix) ? path.substring(prefix.length()) : path;
+	}
+
+	private static <T> List<T> collect(ComponentInstance ci, Function<ComponentInstance, List<T>> reader,
+			List<T> result) {
+		result.addAll(reader.apply(ci));
+		ci.getComponentInstances().forEach(child -> collect(child, reader, result));
+		return result;
+	}
+
+	private SystemInstance instantiate(String implementationName) throws Exception {
+		var pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+		var implementation = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals(implementationName))
+				.findFirst()
+				.orElseThrow();
+		errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+
+		var instance = InstantiateModel.instantiate(implementation, errorManager);
+
+		assertNotNull(instance);
+		return instance;
+	}
+
+	private static List<String> names(List<? extends InstanceObject> objects) {
+		return objects.stream().map(InstanceObject::getName).sorted().toList();
+	}
+
+	private List<String> diagnostics(SystemInstance instance) {
+		return ((QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource())).getErrors()
+				.stream()
+				.map(message -> message.kind + ": " + message.message)
+				.sorted()
+				.toList();
+	}
+}


### PR DESCRIPTION
Fixes #3113

## Cause and correction

`FlowSpecArrayExpander` decided whether a flow specification end was an array element by testing
`FeatureInstance.getIndex()` on the end itself. A feature declared inside a feature group type is never
indexed — the index sits on the enclosing feature group instance — so an end reached through a feature
group that is an array looked like a scalar, the pairing was skipped, and every element but the first was
left without a flow specification instance. Nothing was reported.

`ConnectionArrayExpander` already treats an indexed enclosing feature group instance as a dimension of a
connection end, so the connection set covered every element while the flow specifications covered only
the first, and the end-to-end flows built over them inherited the disagreement.

The fix adds `arrayEnd`, which walks up from an end to the indexed feature instance — the end itself when
it is a feature array, the enclosing feature group instance otherwise — recording the features that lead
back down. The dimension size is the number of elements of that feature instance, and `elementAt` takes
the sibling with the paired-up index and follows the recorded features down again. A direct feature array
has an empty descent, so it behaves exactly as before.

At most one step of a path is ever indexed, because a feature declared inside a feature group type may not
be an array (AS5506D section 8 legality rule 3, enforced by the validator and reported by
`InstantiateModel.instantiateFGFeatures`). The nearest indexed ancestor is therefore the only one, which
the code and its javadoc state explicitly.

Nothing else needed changing. The pairing arithmetic in `ArrayPatternExpansion` does not care where an
index came from, and the end-to-end flows already fork over the flow specification instances of a
specification and keep a branch on its element by requiring the next connection instance to start exactly
at the previous element's destination feature instance.

## Regression model and assertions

`core/org.osate.core.tests/models/issue3113/Issue3113.aadl` declares an array of feature groups on two
devices, a flow source and a flow path over it on one and a flow sink on the other, a feature group
connection that joins the two arrays, and an end-to-end flow over that connection. `emit` has one array
end and `relay` has two, which is the pairing the default `One_To_One` applies to.

`Issue3113Test` asserts:

- one flow specification instance per element, named and paired the way #2787 established for an end that
  is a feature array itself: `emit_1`/`emit_2`, `relay_1`/`relay_2`, `absorb_1`/`absorb_2`;
- one end-to-end flow instance per element, `ete_1` and `ete_2`, each over the connection instance of its
  own element;
- the four connection instances, alongside the flows, so the assertions show the two sides agreeing rather
  than a bare count;
- no diagnostics, so the silence is not traded for a warning.

Before the fix both tests failed with everything pinned to element 1: three flow specification instances
instead of six, and a single `ete`. The connection assertion passed before the fix, which is what
localizes the defect to the flow side.

## Supporting change

`Serializer1Test.testFlowSpecification` recorded the old behavior for the one array feature group in its
fixture, so its `f7` becomes `f7_1` and `f7_2`. Its `f6`, an array declared inside a feature group type, is
still instantiated as a single feature and still a single flow. Folded into the fix commit so that every
commit on the branch is green.

## Validation

- `mvn -Dtest=Issue3113Test -DfailIfNoTests=false`: 2/2 pass; both fail before the fix for the intended
  reason.
- Full `org.osate.core.tests`: 836 tests, 0 failures. Per-class non-zero counts confirmed for
  `Issue2787Test` (6), `Issue1833Test` (9), `Issue3037ArrayFeatureGroupTest` (7),
  `Issue3037FeatureArrayTest` (4), `FlowSpecificationInstantiationTest` (4),
  `FeatureArrayInstantiationTest` (3), `FeatureGroupInstantiationTest` (6), `Issue3048Test`, `Issue3049Test`.
- Clean root-reactor build, `mvn -s releng/osate.releng/settings.xml -Plocal -Dtycho.localArtifacts=ignore
  -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -DfailIfNoTests=false
  clean install`: BUILD SUCCESS, 2862 tests, 0 failures, 0 errors. Reproduced with `-T6`.

## Dependencies

None. Branched from `master` at 7729ae9476 and independent of the other open issue branches.

## Residual risk

`elementAt` still falls back to the original end when a lookup misses, as it always did, so an internal
inconsistency would pin the element rather than fail. No diagnostic was added, to keep the fix narrow.

Nested feature group arrays are not a concern for the reason above: a feature inside a feature group type
may not be an array, so no path has two indexed steps. Note that `ConnectionArrayExpander` carries a single
`fgidx` and makes the same assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
