### PR TITLE
Report broken references in contained connection properties 🤖

### DIFF
--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CacheContainedPropertyAssociationsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/CacheContainedPropertyAssociationsSwitch.java
@@ -278,6 +278,7 @@ public class CacheContainedPropertyAssociationsSwitch extends AadlProcessingSwit
 							reportConstantOverride(io, prop, pa, "");
 						} else {
 							scProps.recordSCProperty((ConnectionInstance) io, prop, conn, newPA);
+							report(issues, io);
 						}
 					} else {
 						final var existingPA = io.getPropertyValue(prop, false).first();
@@ -384,6 +385,16 @@ public class CacheContainedPropertyAssociationsSwitch extends AadlProcessingSwit
 			switch (issue.severity()) {
 			case ERROR -> error(issue.element(), issue.message());
 			case WARNING -> warning(issue.element(), issue.message());
+			}
+		}
+	}
+
+	/** Report problems on an attached instance object when their copied value is not in the instance resource. */
+	private void report(final List<Issue> issues, final InstanceObject instanceObject) {
+		for (var issue : issues) {
+			switch (issue.severity()) {
+			case ERROR -> error(instanceObject, issue.message());
+			case WARNING -> warning(instanceObject, issue.message());
 			}
 		}
 	}

--- a/core/org.osate.core.tests/models/issue3106/.gitignore
+++ b/core/org.osate.core.tests/models/issue3106/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3106/.project
+++ b/core/org.osate.core.tests/models/issue3106/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3106</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3106/Issue3106.aadl
+++ b/core/org.osate.core.tests/models/issue3106/Issue3106.aadl
@@ -1,0 +1,87 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to the Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+-- Refining platform changes the implementation so that the declaratively valid platform.core paths
+-- no longer denote instance objects. Both contained associations remain in the instance model, but
+-- each uninstantiated reference must produce an error.
+package Issue3106
+public
+	processor Core
+	end Core;
+
+	processor implementation Core.impl
+	end Core.impl;
+
+	system Platform
+	end Platform;
+
+	system implementation Platform.impl
+		subcomponents
+			core: processor Core.impl;
+	end Platform.impl;
+
+	system ExtendedPlatform extends Platform
+	end ExtendedPlatform;
+
+	system implementation ExtendedPlatform.impl
+		subcomponents
+			original: system Platform.impl;
+	end ExtendedPlatform.impl;
+
+	process Sender
+		features
+			out_p: out event port;
+	end Sender;
+
+	process implementation Sender.impl
+	end Sender.impl;
+
+	process Receiver
+		features
+			in_p: in event port;
+	end Receiver;
+
+	process implementation Receiver.impl
+	end Receiver.impl;
+
+	system top
+	end top;
+
+	system implementation top.impl
+		subcomponents
+			platform: system Platform.impl;
+			snd: process Sender.impl;
+			rcv: process Receiver.impl;
+		connections
+			c1: port snd.out_p -> rcv.in_p;
+		properties
+			Actual_Connection_Binding => (reference (platform.core)) applies to c1;
+			Actual_Processor_Binding => (reference (platform.core)) applies to snd;
+	end top.impl;
+
+	system implementation top.refined_platform extends top.impl
+		subcomponents
+			platform: refined to system ExtendedPlatform.impl;
+	end top.refined_platform;
+end Issue3106;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3106Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3106Test.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to the Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.ListValue;
+import org.osate.aadl2.PropertyAssociation;
+import org.osate.aadl2.ReferenceValue;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter.Message;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * A contained property association with an unresolvable reference must report the problem whether
+ * the association applies to a component or to a connection.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3106Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue3106/Issue3106.aadl";
+	private static final String ERROR = "Referenced element does not exist in the instance model";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void aMissingReferenceIsReportedForBothComponentAndConnectionAssociations() throws Exception {
+		var result = instantiate("top.refined_platform");
+		var sender = result.instance().getComponentInstances()
+				.stream()
+				.filter(component -> component.getName().equals("snd"))
+				.findFirst()
+				.orElseThrow();
+		var connection = result.instance().getConnectionInstances().getFirst();
+
+		assertEquals(List.of("platform", "core"), declarativeReferencePath(sender.getOwnedPropertyAssociations()
+				.stream()
+				.filter(association -> association.getProperty().getName().equals("Actual_Processor_Binding"))
+				.findFirst()
+				.orElseThrow()));
+		assertEquals(List.of("platform", "core"), declarativeReferencePath(connection.getOwnedPropertyAssociations()
+				.stream()
+				.filter(association -> association.getProperty().getName().equals("Actual_Connection_Binding"))
+				.findFirst()
+				.orElseThrow()));
+		assertEquals(2, result.errors().size());
+		assertTrue(result.errors().stream().allMatch(message -> message.kind == QueuingAnalysisErrorReporter.Kind.ERROR));
+		assertEquals(List.of(ERROR, ERROR), result.errors().stream().map(message -> message.message).toList());
+	}
+
+	@Test
+	public void resolvableReferencesProduceNoInstantiationErrors() throws Exception {
+		assertEquals(List.of(), instantiate("top.impl").errors());
+	}
+
+	private Result instantiate(String implementationName) throws Exception {
+		var pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+		var implementation = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals(implementationName))
+				.findFirst()
+				.orElseThrow();
+		var errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+		var instance = InstantiateModel.instantiate(implementation, errorManager);
+		var reporter = (QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource());
+
+		return new Result(instance, reporter.getErrors());
+	}
+
+	private static List<String> declarativeReferencePath(PropertyAssociation association) {
+		var list = (ListValue) association.getOwnedValues().getFirst().getOwnedValue();
+		var reference = (ReferenceValue) list.getOwnedListElements().getFirst();
+
+		return reference.getContainmentPathElements()
+				.stream()
+				.map(element -> element.getNamedElement().getName())
+				.toList();
+	}
+
+	private record Result(SystemInstance instance, List<Message> errors) {
+	}
+}


### PR DESCRIPTION
Fixes #3106

## Cause

CacheContainedPropertyAssociationsSwitch collected reference-instantiation problems for copied contained associations, but the semantic-connection branch recorded the association in SCProperties without reporting those problems. The equivalent component branch reported them.

## Correction

Report the collected problems after retaining the semantic-connection association. The diagnostic is attached to the connection instance because the copied association in SCProperties is detached from the instance resource at that point.

## Regression

Issue3106Test uses a valid external AADL model with matching Actual_Processor_Binding and Actual_Connection_Binding references. A refinement removes the referenced instance object. The test verifies that both associations retain the declarative platform.core path and that instantiation reports two missing-reference errors. An unrefined control verifies that resolvable references produce no errors.

The regression failed before the production change with one reported error instead of two.

## Validation

- Focused Issue3106Test offline Maven -T6 verify: 2 tests, 0 failures, 0 errors
- Related Issue2929Test offline Maven -T6 verify: 3 tests, 0 failures, 0 errors
- Related Issue3104Test offline Maven -T6 verify: 7 tests, 0 failures, 0 errors
- Clean root-reactor offline Maven -T6 install with tycho.localArtifacts=ignore: all 137 projects succeeded

## Dependencies

None. The branch is based directly on origin/master at 7729ae9476.

## Residual risk

The new diagnostic is located on the connection instance rather than the copied ReferenceValue because that copied value is not attached to a resource when the problem is reported. Reporting is limited to associations that are retained; constant overrides keep their existing behavior.