### PR TITLE
Remove dead code from declarative property lookup 🤖

### DIFF
--- a/core/org.osate.aadl2/src/org/osate/aadl2/impl/FeatureGroupImpl.java
+++ b/core/org.osate.aadl2/src/org/osate/aadl2/impl/FeatureGroupImpl.java
@@ -385,18 +385,6 @@ public class FeatureGroupImpl extends DirectedFeatureImpl implements FeatureGrou
 		}
 	}
 
-	public void getPropertyValueTestHelper(Property prop, PropertyAcc pas, Classifier cl) {
-		// values from feature group type
-		FeatureGroupType fgt = getFeatureGroupType();
-		// TODO: Check if the property applies to the feature group type? (->
-		// property.checkAppliesTo(NamedElement)?)
-		if (fgt != null) {
-			fgt.getPropertyValueInternal(prop, pas, true, false);
-		} else if (cl != null) {
-			cl.getPropertyValueInternal(prop, pas, true, false);
-		}
-	}
-
 	/**
 	 * check for inverseof between two features.
 	 * If they are feature groups then we check both the inverse of on the feature group and whether the feature group type is inverseof.

--- a/core/org.osate.aadl2/src/org/osate/aadl2/impl/PropertyImpl.java
+++ b/core/org.osate.aadl2/src/org/osate/aadl2/impl/PropertyImpl.java
@@ -40,7 +40,6 @@ import org.osate.aadl2.Aadl2Package;
 import org.osate.aadl2.AbstractNamedValue;
 import org.osate.aadl2.Classifier;
 import org.osate.aadl2.Feature;
-import org.osate.aadl2.FeatureGroup;
 import org.osate.aadl2.MetaclassReference;
 import org.osate.aadl2.NamedElement;
 import org.osate.aadl2.PortConnection;
@@ -558,11 +557,8 @@ public class PropertyImpl extends BasicPropertyImpl implements Property {
 			throws InvalidModelException {
 		InstanceObject io = ctx.getInstanceObject();
 		List<? extends NamedElement> compDecls = io.getInstantiatedObjects();
-		// FIXME: compDecls == null for connection instances
 		// OsateDebug.osateDebug("[PropertyImpl] getPropertyValueFromDeclarativeModel" + compDecls);
 
-		if (compDecls == null) {
-		}
 		// Here we assume compDecls is empty or has only one element
 		if (!compDecls.isEmpty()) {
 			NamedElement compDecl = compDecls.get(0);
@@ -575,8 +571,6 @@ public class PropertyImpl extends BasicPropertyImpl implements Property {
 
 			if (compDecl instanceof Subcomponent) {
 				((SubcomponentImpl) compDecl).getPropertyValue(this, pas, cl, false);
-			} else if (compDecl instanceof FeatureGroup) {
-				((FeatureGroupImpl) compDecl).getPropertyValue(this, pas, cl, false);
 			} else if (compDecl instanceof Feature) {
 				((FeatureImpl) compDecl).getPropertyValue(this, pas, cl, false);
 			} else if (compDecl instanceof PortConnection) {


### PR DESCRIPTION
## Summary

- Remove the redundant `FeatureGroup` branch from declarative-model property lookup. Feature groups now reach the same inherited `FeatureImpl.getPropertyValue` implementation through the following `Feature` branch.
- Remove `FeatureGroupImpl.getPropertyValueTestHelper`, which has no repository caller and duplicates the inherited lookup behavior.
- Remove the empty `compDecls == null` block and its stale FIXME.

This is intentionally a behavior-preserving cleanup. No new regression test was added because none of the removed code could produce distinct behavior; the existing property lookup and caching tests were run before and after the change.

Fixes #3107

## Validation

Focused pre-change and post-change validation:

```text
mvn -o -T6 -s releng/osate.releng/settings.xml -Plocal \
  -pl :org.osate.aadl2,:org.osate.core.tests,:org.osate.core.feature \
  -Dtycho.localArtifacts=default \
  -Dpr.build=true -Dsign=false \
  -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
  -Dtest=PropertyTests,PropertyCachingInstantiationTest \
  -DfailIfNoTests=false clean verify
```

Both runs passed 4 tests with no failures, errors, or skips.

Clean root validation:

```text
mvn -o -T6 -s releng/osate.releng/settings.xml -Plocal \
  -Dtycho.localArtifacts=ignore \
  -Dpr.build=true -Dsign=false \
  -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
  -DfailIfNoTests=false clean install
```

All 137 reactor projects succeeded. Surefire reports contained 1,429 tests with no failures, errors, or skips.

## Dependencies and residual risk

There are no dependent PRs; the branch is based directly on current `master` at `7729ae9476`.

Removing the public `FeatureGroupImpl.getPropertyValueTestHelper` method is binary-incompatible for an external caller of the exported implementation package. A repository-wide search found no caller, and the method never participated in property lookup, so the practical risk is limited to an unknown external consumer directly calling this unused implementation helper.
