### PR TITLE
Use virtual dispatch for declarative property lookup 🤖

### DIFF
--- a/core/org.osate.aadl2/src/org/osate/aadl2/NamedElement.java
+++ b/core/org.osate.aadl2/src/org/osate/aadl2/NamedElement.java
@@ -290,6 +290,18 @@ public interface NamedElement extends Element {
 			throws InvalidModelException;
 
 	/**
+	 * Add property values from this declarative element to an instance-model lookup.
+	 *
+	 * @param property The property whose value is being retrieved.
+	 * @param pas The working property value accumulator to add results to.
+	 * @param instantiatedClassifier The classifier instantiated for the instance object, or {@code null} if none.
+	 * @throws InvalidModelException Thrown if the property value cannot be retrieved because the model is incomplete
+	 *             or otherwise invalid.
+	 */
+	void getPropertyValueForInstance(Property property, PropertyAcc pas, Classifier instantiatedClassifier)
+			throws InvalidModelException;
+
+	/**
 	 * Set property association for given property definition with specified
 	 * value list. The property association is assumed to apply to all modes;
 	 * all previous property associations for this property are removed from the

--- a/core/org.osate.aadl2/src/org/osate/aadl2/impl/FeatureImpl.java
+++ b/core/org.osate.aadl2/src/org/osate/aadl2/impl/FeatureImpl.java
@@ -562,47 +562,39 @@ public abstract class FeatureImpl extends StructuralFeatureImpl implements Featu
 		}
 	}
 
-	public void getPropertyValue(Property prop, PropertyAcc pas, Classifier cl, final boolean all) {
+	@Override
+	public void getPropertyValueForInstance(Property prop, PropertyAcc pas, Classifier instantiatedClassifier) {
 		Classifier owner = getContainingClassifier();
 
 		// local contained value
-		if (pas.addLocalContained(this, owner) && !all || pas.addLocal(this)) {
-			if (!all) {
-				return;
-			}
+		if (pas.addLocalContained(this, owner) || pas.addLocal(this)) {
+			return;
 		}
 
 		// values from refined features
 		Feature refined = getRefined();
 		while (refined != null) {
 			if (pas.addLocal(refined)) {
-				if (!all) {
-					return;
-				}
+				return;
 			}
 			refined = refined.getRefined();
 		}
 
-		getPropertyValueHelper(prop, pas, cl, all);
+		// values from classifier
+		Classifier classifier = getClassifier();
+		// TODO: Check if the property applies to the classifier? (->
+		// property.checkAppliesTo(NamedElement)?)
+		if (classifier != null) {
+			classifier.getPropertyValueInternal(prop, pas, true);
+		} else if (instantiatedClassifier != null) {
+			instantiatedClassifier.getPropertyValueInternal(prop, pas, true);
+		}
 
 		// values from container
 		// Ignore fromInstanceSlaveCall because the classifier is a component or
 		// feature group TYPE, not an implementation.
 		if (prop.isInherit()) {
-			owner.getPropertyValueInternal(prop, pas, true, all);
-		}
-	}
-
-	public void getPropertyValueHelper(final Property prop, final PropertyAcc pas, Classifier cl, final boolean all)
-			throws InvalidModelException {
-		// values from classifier
-		Classifier c = getClassifier();
-		// TODO: Check if the property applies to the classifier? (->
-		// property.checkAppliesTo(NamedElement)?)
-		if (c != null) {
-			c.getPropertyValueInternal(prop, pas, true, all);
-		} else if (cl != null) {
-			cl.getPropertyValueInternal(prop, pas, true, all);
+			owner.getPropertyValueInternal(prop, pas, true);
 		}
 	}
 

--- a/core/org.osate.aadl2/src/org/osate/aadl2/impl/NamedElementImpl.java
+++ b/core/org.osate.aadl2/src/org/osate/aadl2/impl/NamedElementImpl.java
@@ -40,6 +40,7 @@ import org.eclipse.emf.ecore.util.EObjectContainmentEList;
 import org.eclipse.emf.ecore.util.InternalEList;
 import org.osate.aadl2.Aadl2Factory;
 import org.osate.aadl2.Aadl2Package;
+import org.osate.aadl2.Classifier;
 import org.osate.aadl2.ClassifierValue;
 import org.osate.aadl2.ContainedNamedElement;
 import org.osate.aadl2.ListValue;
@@ -532,6 +533,12 @@ public abstract class NamedElementImpl extends ElementImpl implements NamedEleme
 	public void getPropertyValueInternal(Property property, PropertyAcc pas, boolean fromInstanceSlaveCall)
 			throws InvalidModelException {
 		getPropertyValueInternal(property, pas, fromInstanceSlaveCall, false);
+	}
+
+	@Override
+	public void getPropertyValueForInstance(Property property, PropertyAcc pas, Classifier instantiatedClassifier)
+			throws InvalidModelException {
+		NamedElementOperations.getPropertyValueForInstance(this, property, pas, instantiatedClassifier);
 	}
 
 	public final PropertyAssociation setPropertyValue(final Property pd, final List<? extends PropertyExpression> pes) {

--- a/core/org.osate.aadl2/src/org/osate/aadl2/impl/PortConnectionImpl.java
+++ b/core/org.osate.aadl2/src/org/osate/aadl2/impl/PortConnectionImpl.java
@@ -25,6 +25,7 @@ package org.osate.aadl2.impl;
 
 import org.eclipse.emf.ecore.EClass;
 import org.osate.aadl2.Aadl2Package;
+import org.osate.aadl2.Classifier;
 import org.osate.aadl2.PortConnection;
 import org.osate.aadl2.Property;
 import org.osate.aadl2.properties.PropertyAcc;
@@ -56,13 +57,9 @@ public class PortConnectionImpl extends ConnectionImpl implements PortConnection
 		return Aadl2Package.eINSTANCE.getPortConnection();
 	}
 
-	public void getPropertyValue(Property prop, PropertyAcc pas) {
-
-		// local contained value
-		if (pas.addLocal(this)) {
-			return;
-		}
-
+	@Override
+	public void getPropertyValueForInstance(Property property, PropertyAcc pas, Classifier instantiatedClassifier) {
+		pas.addLocal(this);
 	}
 
 } // PortConnectionImpl

--- a/core/org.osate.aadl2/src/org/osate/aadl2/impl/PropertyImpl.java
+++ b/core/org.osate.aadl2/src/org/osate/aadl2/impl/PropertyImpl.java
@@ -39,15 +39,12 @@ import org.eclipse.emf.ecore.util.InternalEList;
 import org.osate.aadl2.Aadl2Package;
 import org.osate.aadl2.AbstractNamedValue;
 import org.osate.aadl2.Classifier;
-import org.osate.aadl2.Feature;
 import org.osate.aadl2.MetaclassReference;
 import org.osate.aadl2.NamedElement;
-import org.osate.aadl2.PortConnection;
 import org.osate.aadl2.Property;
 import org.osate.aadl2.PropertyAssociation;
 import org.osate.aadl2.PropertyExpression;
 import org.osate.aadl2.PropertyOwner;
-import org.osate.aadl2.Subcomponent;
 import org.osate.aadl2.instance.InstanceObject;
 import org.osate.aadl2.instance.util.InstanceUtil.InstantiatedClassifier;
 import org.osate.aadl2.properties.EvaluatedProperty;
@@ -569,15 +566,7 @@ public class PropertyImpl extends BasicPropertyImpl implements Property {
 			Classifier cl = (ic == null) ? null : ic.getClassifier();
 			// OsateDebug.osateDebug("compDecls" + compDecl);
 
-			if (compDecl instanceof Subcomponent) {
-				((SubcomponentImpl) compDecl).getPropertyValue(this, pas, cl, false);
-			} else if (compDecl instanceof Feature) {
-				((FeatureImpl) compDecl).getPropertyValue(this, pas, cl, false);
-			} else if (compDecl instanceof PortConnection) {
-				((PortConnectionImpl) compDecl).getPropertyValue(this, pas);
-			} else {
-				compDecl.getPropertyValueInternal(this, pas, true);
-			}
+			compDecl.getPropertyValueForInstance(this, pas, cl);
 		}
 	}
 

--- a/core/org.osate.aadl2/src/org/osate/aadl2/impl/SubcomponentImpl.java
+++ b/core/org.osate.aadl2/src/org/osate/aadl2/impl/SubcomponentImpl.java
@@ -915,7 +915,8 @@ public abstract class SubcomponentImpl extends StructuralFeatureImpl implements 
 		return null;
 	}
 
-	public void getPropertyValue(Property prop, PropertyAcc pas, Classifier cl, final boolean all) {
+	@Override
+	public void getPropertyValueForInstance(Property prop, PropertyAcc pas, Classifier instantiatedClassifier) {
 		final ComponentImplementation owner = (ComponentImplementation) getContainingClassifier();
 
 		// get local value
@@ -933,12 +934,12 @@ public abstract class SubcomponentImpl extends StructuralFeatureImpl implements 
 		}
 
 		// get values from classifier
-		if (cl != null) {
-			cl.getPropertyValueInternal(prop, pas, true, all);
+		if (instantiatedClassifier != null) {
+			instantiatedClassifier.getPropertyValueInternal(prop, pas, true);
 		} else {
 			final ComponentClassifier cc = getClassifier();
 			if (cc != null) {
-				cc.getPropertyValueInternal(prop, pas, true, all);
+				cc.getPropertyValueInternal(prop, pas, true);
 			}
 		}
 	}

--- a/core/org.osate.aadl2/src/org/osate/aadl2/operations/NamedElementOperations.java
+++ b/core/org.osate.aadl2/src/org/osate/aadl2/operations/NamedElementOperations.java
@@ -25,11 +25,15 @@ package org.osate.aadl2.operations;
 
 import org.eclipse.emf.common.util.EList;
 import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.Classifier;
 import org.osate.aadl2.NamedElement;
 import org.osate.aadl2.Namespace;
 import org.osate.aadl2.PackageSection;
+import org.osate.aadl2.Property;
 import org.osate.aadl2.PropertyExpression;
 import org.osate.aadl2.PropertySet;
+import org.osate.aadl2.properties.InvalidModelException;
+import org.osate.aadl2.properties.PropertyAcc;
 
 /**
  * <!-- begin-user-doc -->
@@ -97,6 +101,22 @@ public class NamedElementOperations extends ElementOperations {
 		} else {
 			return null;
 		}
+	}
+
+	/**
+	 * Add property values from a declarative element that has no specialized instance-model lookup behavior.
+	 *
+	 * @param namedElement The declarative element being searched.
+	 * @param property The property whose value is being retrieved.
+	 * @param pas The working property value accumulator to add results to.
+	 * @param instantiatedClassifier The classifier instantiated for the instance object, or {@code null} if none.
+	 * @throws InvalidModelException Thrown if the property value cannot be retrieved because the model is incomplete
+	 *             or otherwise invalid.
+	 * @generated NOT
+	 */
+	public static void getPropertyValueForInstance(NamedElement namedElement, Property property, PropertyAcc pas,
+			Classifier instantiatedClassifier) throws InvalidModelException {
+		namedElement.getPropertyValueInternal(property, pas, true);
 	}
 
 	/**

--- a/core/org.osate.core.tests/models/issue3108/.gitignore
+++ b/core/org.osate.core.tests/models/issue3108/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3108/.project
+++ b/core/org.osate.core.tests/models/issue3108/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3108</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3108/Issue3108.aadl
+++ b/core/org.osate.core.tests/models/issue3108/Issue3108.aadl
@@ -1,0 +1,56 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+package Issue3108
+public
+	with Issue3108Properties;
+
+	process Worker
+		features
+			input: in data port;
+			output: out data port {
+				Issue3108Properties::Feature_Value => 3;
+			};
+	end Worker;
+
+	process implementation Worker.i
+	end Worker.i;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			src: process Worker.i {
+				Issue3108Properties::Subcomponent_Value => 2;
+			};
+			dst: process Worker.i;
+		connections
+			c: port src.output -> dst.input {
+				Issue3108Properties::Connection_Value => 4;
+			};
+		properties
+			Issue3108Properties::Root_Value => 1;
+	end Top.i;
+end Issue3108;

--- a/core/org.osate.core.tests/models/issue3108/Issue3108Properties.aadl
+++ b/core/org.osate.core.tests/models/issue3108/Issue3108Properties.aadl
@@ -1,0 +1,30 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+property set Issue3108Properties is
+	Root_Value: aadlinteger applies to (system);
+	Subcomponent_Value: aadlinteger applies to (process);
+	Feature_Value: aadlinteger applies to (data port);
+	Connection_Value: aadlinteger applies to (connection);
+end Issue3108Properties;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3108Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3108Test.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.Feature;
+import org.osate.aadl2.IntegerLiteral;
+import org.osate.aadl2.PortConnection;
+import org.osate.aadl2.Subcomponent;
+import org.osate.aadl2.instance.ComponentInstance;
+import org.osate.aadl2.instance.InstanceObject;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * Declarative property lookup uses distinct behavior for component implementations, subcomponents,
+ * features, and port connections. This test reaches every case through instance-model property caching
+ * and pins both the declarative dispatch target and the value that the lookup contributes.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3108Test extends XtextTest {
+	private static final String PATH = "org.osate.core.tests/models/issue3108/";
+	private static final String MODEL = PATH + "Issue3108.aadl";
+	private static final String PROPERTIES = PATH + "Issue3108Properties.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void declarativeLookupDispatchesThroughEachNamedElementKind() throws Exception {
+		var pkg = testHelper.parseFile(MODEL, PROPERTIES);
+		validationHelper.assertNoIssues(pkg);
+		var implementation = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals("Top.i"))
+				.findFirst()
+				.orElseThrow();
+
+		var instance = InstantiateModel.instantiate(implementation);
+		var source = component(instance, "src");
+		var output = source.getFeatureInstances()
+				.stream()
+				.filter(feature -> feature.getName().equals("output"))
+				.findFirst()
+				.orElseThrow();
+		var connection = instance.getConnectionInstances().getFirst();
+
+		assertTrue(instance.getInstantiatedObjects().getFirst() instanceof ComponentImplementation);
+		assertEquals(1, value(instance, "Root_Value"));
+
+		assertTrue(source.getInstantiatedObjects().getFirst() instanceof Subcomponent);
+		assertEquals(2, value(source, "Subcomponent_Value"));
+
+		assertTrue(output.getInstantiatedObjects().getFirst() instanceof Feature);
+		assertEquals(3, value(output, "Feature_Value"));
+
+		assertTrue(connection.getConnectionReferences().getFirst().getConnection() instanceof PortConnection);
+		assertEquals(4, value(connection, "Connection_Value"));
+	}
+
+	private static ComponentInstance component(ComponentInstance container, String name) {
+		return container.getComponentInstances()
+				.stream()
+				.filter(component -> component.getName().equals(name))
+				.findFirst()
+				.orElseThrow();
+	}
+
+	private static long value(InstanceObject instanceObject, String propertyName) {
+		var associations = instanceObject.getOwnedPropertyAssociations()
+				.stream()
+				.filter(association -> association.getProperty().getName().equals(propertyName))
+				.toList();
+		assertEquals(instanceObject.getInstanceObjectPath(), 1, associations.size());
+		var expression = associations.getFirst().getOwnedValues().getFirst().getOwnedValue();
+		return (long) ((IntegerLiteral) expression).getValue();
+	}
+}


### PR DESCRIPTION
## Summary

- add `NamedElement.getPropertyValueForInstance` and put the generic behavior in `NamedElementOperations`
- override the operation for subcomponents, features, and port connections
- replace the `PropertyImpl` type-and-cast chain with one virtual call
- remove the unreferenced implementation overloads and dead `all` parameter plumbing

## Regression coverage

`Issue3108Test` instantiates a valid external AADL model with declarative values on a component implementation, subcomponent, feature, and port connection. It asserts both the declarative element kind behind each instance and the property value cached through that lookup path.

The test passed at the test-only commit before the refactor and after the production change.

## Validation

- `mvn -o -T5 -s releng/osate.releng/settings.xml -Plocal -pl :org.osate.aadl2,:org.osate.core.tests,:org.osate.core.feature -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -Dtest=Issue3108Test -DfailIfNoTests=false clean verify`
  - 1 test, 0 failures, 0 errors
- `mvn -o -T5 -s releng/osate.releng/settings.xml -Plocal -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -DfailIfNoTests=false clean install`
  - all 137 reactor projects succeeded

## Dependency

Depends on #3116. This PR is based on `3107_remove_dead_property_lookup`; after #3116 merges, it can be retargeted to `master`.

## Compatibility and residual risk

The old public methods on the exported implementation classes are removed, which is a deliberate binary-incompatible choice relative to the 2.18.0 API baseline. This follows the preferred option in #3108; the new interface operation is additive, and the test pins the lookup results for every moved dispatch case.

Fixes #3108