### PR TITLE
Prevent qualified link cache results from crossing contexts 🤖

### DIFF
--- a/core/org.osate.core.tests/models/issue3118/.gitignore
+++ b/core/org.osate.core.tests/models/issue3118/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3118/.project
+++ b/core/org.osate.core.tests/models/issue3118/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3118</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3118/BadFirst.aadl
+++ b/core/org.osate.core.tests/models/issue3118/BadFirst.aadl
@@ -1,0 +1,10 @@
+package BadFirst
+public
+	with Other;
+
+	system S
+		features
+			bad: requires bus access Other::D;
+			good: in data port Other::D;
+	end S;
+end BadFirst;

--- a/core/org.osate.core.tests/models/issue3118/GoodFirst.aadl
+++ b/core/org.osate.core.tests/models/issue3118/GoodFirst.aadl
@@ -1,0 +1,10 @@
+package GoodFirst
+public
+	with Other;
+
+	system S
+		features
+			good: in data port Other::D;
+			bad: requires bus access Other::D;
+	end S;
+end GoodFirst;

--- a/core/org.osate.core.tests/models/issue3118/Other.aadl
+++ b/core/org.osate.core.tests/models/issue3118/Other.aadl
@@ -1,0 +1,5 @@
+package Other
+public
+	data D
+	end D;
+end Other;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3118Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3118Test.java
@@ -45,7 +45,8 @@ import com.itemis.xtext.testing.XtextTest;
 /**
  * A failed lookup for a qualified name must not be reused for a different reference to the same
  * text. The fixtures use {@code Other::D} first as the wrong classifier category and then as a
- * legal data classifier, in both declaration orders.
+ * legal data classifier, in both declaration orders. This matters because a context-incomplete
+ * cache key otherwise turns one valid reference into a spurious error and leaves it unresolved.
  */
 @RunWith(XtextRunner.class)
 @InjectWith(Aadl2InjectorProvider.class)

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3118Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3118Test.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.DataPort;
+import org.osate.aadl2.SystemType;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * A failed lookup for a qualified name must not be reused for a different reference to the same
+ * text. The fixtures use {@code Other::D} first as the wrong classifier category and then as a
+ * legal data classifier, in both declaration orders.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3118Test extends XtextTest {
+	private static final String PATH = "org.osate.core.tests/models/issue3118/";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Test
+	public void badReferenceDoesNotPoisonFollowingGoodReference() throws Exception {
+		assertOnlyBusReferenceFails("BadFirst.aadl");
+	}
+
+	@Test
+	public void badReferenceDoesNotPoisonPrecedingGoodReference() throws Exception {
+		assertOnlyBusReferenceFails("GoodFirst.aadl");
+	}
+
+	private void assertOnlyBusReferenceFails(String model) throws Exception {
+		var result = testHelper.testFile(PATH + model, PATH + "Other.aadl");
+		assertEquals(List.of("ERROR: Couldn't resolve reference to BusFeatureClassifier 'Other::D'."),
+				result.getIssues()
+						.stream()
+						.map(issue -> issue.getSeverity() + ": " + issue.getMessage())
+						.toList());
+
+		var pkg = (AadlPackage) result.getResource().getContents().get(0);
+		var system = (SystemType) pkg.getOwnedPublicSection().getOwnedClassifiers().get(0);
+		var good = (DataPort) system.getOwnedFeatures()
+				.stream()
+				.filter(feature -> feature.getName().equals("good"))
+				.findFirst()
+				.orElseThrow();
+		var classifier = good.getDataFeatureClassifier();
+
+		assertNotNull(classifier);
+		assertFalse(classifier.eIsProxy());
+		assertEquals("D", classifier.getName());
+	}
+}

--- a/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/linking/Aadl2LinkingService.java
+++ b/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/linking/Aadl2LinkingService.java
@@ -107,11 +107,8 @@ public class Aadl2LinkingService extends PropertiesLinkingService {
 	public List<EObject> getLinkedObjects(EObject context, EReference reference, INode node)
 			throws IllegalNodeException {
 		List<EObject> result;
-		String crossRefString = getCrossRefNodeAsString(node);
-		boolean global = crossRefString.contains("::");
 
-		result = linkingCache.get(global ? crossRefString : node, context.eResource(),
-				() -> doGetLinkedObjects(context, reference, node));
+		result = linkingCache.get(node, context.eResource(), () -> doGetLinkedObjects(context, reference, node));
 		return result;
 	}
 


### PR DESCRIPTION
Fixes #3118

## Cause and correction

`Aadl2LinkingService` keyed qualified-name cache entries only by their source text. The same text can be resolved through different `EReference` types and referencing contexts, so one failed lookup could poison a valid reference elsewhere in the resource.

Key all general linking-cache entries by their syntax node. A node identifies the concrete reference and its context, making the key complete without guessing which semantic discriminators matter.

## Regression

`Issue3118Test` models `Other::D` as both an invalid bus classifier and a valid data classifier, in both declaration orders. It asserts that only the bus-category error remains and that the data port resolves to `D`.

## Validation

- Focused offline production/feature/test build: 2 tests passed.
- Five-sample, fresh-JVM benchmark for 400 links:
  - Classifier-heavy median: 19.972 ms before, 46.757 ms after.
  - Property-heavy median: 77.337 ms before, 55.382 ms after.

The classifier case intentionally repeats one qualified name across 400 distinct nodes and measures the cross-node sharing removed for correctness. The absolute added cost was about 0.067 ms per independently linked reference.

## Dependencies and risk

No PR dependency. This correctness change should merge before the #1836 linking-contract series. The measured classifier-heavy slowdown is the residual risk; no context-independent replacement cache is introduced without proof.
