### PR TITLE
Use a per-call node for indexed name lookups 🤖

### DIFF
--- a/core/org.osate.core.tests/models/issue3120/.gitignore
+++ b/core/org.osate.core.tests/models/issue3120/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3120/.project
+++ b/core/org.osate.core.tests/models/issue3120/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3120</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3120/Issue3120.aadl
+++ b/core/org.osate.core.tests/models/issue3120/Issue3120.aadl
@@ -1,0 +1,10 @@
+package Issue3120
+public
+	with Other;
+
+	system S
+		features
+			d: in data port Other::D;
+			e: in data port Other::E;
+	end S;
+end Issue3120;

--- a/core/org.osate.core.tests/models/issue3120/Other.aadl
+++ b/core/org.osate.core.tests/models/issue3120/Other.aadl
@@ -1,0 +1,8 @@
+package Other
+public
+	data D
+	end D;
+
+	data E
+	end E;
+end Other;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3120Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3120Test.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.xtext.linking.impl.IllegalNodeException;
+import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.Aadl2Package;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.DataPort;
+import org.osate.aadl2.NamedElement;
+import org.osate.aadl2.SystemType;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+import org.osate.xtext.aadl2.properties.linking.PropertiesLinkingService;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3120Test {
+	private static final String PATH = "org.osate.core.tests/models/issue3120/";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Inject
+	private Injector injector;
+
+	@Test
+	public void concurrentIndexLookupsKeepTheirOwnReferenceText() throws Exception {
+		var pkg = testHelper.parseFile(PATH + "Issue3120.aadl", PATH + "Other.aadl");
+		validationHelper.assertNoIssues(pkg);
+		var system = (SystemType) pkg.getOwnedPublicSection().getOwnedClassifiers().get(0);
+		var portD = findPort(system, "d");
+		var portE = findPort(system, "e");
+		var linkingService = injector.getInstance(CoordinatedPropertiesLinkingService.class);
+		var reference = Aadl2Package.eINSTANCE.getDataPort_DataFeatureClassifier();
+
+		try (var executor = Executors.newFixedThreadPool(2)) {
+			var resultD = executor.submit(() -> linkingService.getIndexedObject(portD, reference, "Other::D"));
+			var resultE = executor.submit(() -> linkingService.getIndexedObject(portE, reference, "Other::E"));
+
+			assertEquals("D", ((NamedElement) resultD.get(10, TimeUnit.SECONDS)).getName());
+			assertEquals("E", ((NamedElement) resultE.get(10, TimeUnit.SECONDS)).getName());
+		}
+	}
+
+	private static DataPort findPort(SystemType system, String name) {
+		return (DataPort) system.getOwnedFeatures()
+				.stream()
+				.filter(feature -> feature.getName().equals(name))
+				.findFirst()
+				.orElseThrow();
+	}
+
+	public static class CoordinatedPropertiesLinkingService extends PropertiesLinkingService {
+		private final CyclicBarrier barrier = new CyclicBarrier(2);
+
+		@Override
+		public String getCrossRefNodeAsString(INode node) throws IllegalNodeException {
+			try {
+				barrier.await(10, TimeUnit.SECONDS);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new AssertionError(e);
+			} catch (BrokenBarrierException | TimeoutException e) {
+				throw new AssertionError(e);
+			}
+			return super.getCrossRefNodeAsString(node);
+		}
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3120Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3120Test.java
@@ -50,6 +50,11 @@ import org.osate.xtext.aadl2.properties.linking.PropertiesLinkingService;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 
+/**
+ * Tests two concurrent index lookups that pause after supplying different names but before the
+ * synthetic nodes are read. The coordinated interleaving matters because a shared mutable node can
+ * make one thread resolve the other thread's name, producing intermittent and incorrect links.
+ */
 @RunWith(XtextRunner.class)
 @InjectWith(Aadl2InjectorProvider.class)
 public class Issue3120Test {

--- a/core/org.osate.xtext.aadl2.properties/src/org/osate/xtext/aadl2/properties/linking/PropertiesLinkingService.java
+++ b/core/org.osate.xtext.aadl2.properties/src/org/osate/xtext/aadl2/properties/linking/PropertiesLinkingService.java
@@ -118,11 +118,10 @@ public class PropertiesLinkingService extends DefaultLinkingService {
 		super();
 	}
 
-	private static PSNode psNode = new PSNode();
 	private final String PLUGIN_ID = "org.osate.xtext.aadl2";
 
 	public EObject getIndexedObject(EObject context, EReference reference, String crossRefString) {
-		psNode.setText(crossRefString);
+		PSNode psNode = new PSNode(crossRefString);
 		EObject res = null;
 		try {
 			List<EObject> el;


### PR DESCRIPTION
Fixes #3120

## Cause and correction

`PropertiesLinkingService` reused one static mutable `PSNode` for every indexed-name lookup. Concurrent editor and builder activity could overwrite one lookup's text with another's.

Create the synthetic node per call instead. Each invocation now retains its own text and lifetime.

## Regression

`Issue3120Test` uses a test-only linking-service subclass with a barrier in `getCrossRefNodeAsString`. Two threads deterministically pause after supplying `Other::D` and `Other::E`, reproducing the shared-node overwrite without scheduler timing assumptions.

Before the fix, the `D` lookup returned `E`. After the fix, both lookups return their requested classifier.

## Validation

- Focused offline production/feature/test build: 1 test passed.

## Dependencies and risk

No PR dependency. This should merge before the #1836 lookup API is reshaped. The change only replaces shared mutable scratch state with per-call state.
