### PR TITLE
Separate resolving and proxy index lookups 🤖

### DIFF
--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3119Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3119Test.java
@@ -36,6 +36,7 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.build.BuildRequest;
+import org.eclipse.xtext.linking.lazy.LazyLinkingResource;
 import org.eclipse.xtext.resource.IResourceServiceProvider;
 import org.eclipse.xtext.resource.XtextResourceSet;
 import org.eclipse.xtext.testing.InjectWith;
@@ -49,6 +50,7 @@ import org.osate.aadl2.AadlPackage;
 import org.osate.aadl2.DataPort;
 import org.osate.aadl2.SystemType;
 import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.xtext.aadl2.properties.linking.PropertiesLinkingService;
 
 /**
  * Tests AADL linking against serialized descriptions from an earlier build while the target package
@@ -68,7 +70,10 @@ public class Issue3119Test extends AbstractIncrementalBuilderTest {
 
 	@Test
 	public void terminalReferenceCurrentlyLoadsPersistedIndexTarget() throws Exception {
-		StagedBuild staged = buildTargetThenReference();
+		StagedBuild staged = createPersistedIndexReferenceContext();
+		var referenceResource = staged.referenceResourceSet().getResource(staged.referenceUri(), false);
+		EcoreUtil2.resolveLazyCrossReferences(referenceResource, CancelIndicator.NullImpl);
+		assertTrue(referenceResource.getErrors().toString(), referenceResource.getErrors().isEmpty());
 
 		assertNotNull(staged.referenceResourceSet().getResource(staged.targetUri(), false));
 
@@ -76,6 +81,26 @@ public class Issue3119Test extends AbstractIncrementalBuilderTest {
 		EObject rawClassifier = (EObject) port.eGet(Aadl2Package.eINSTANCE.getDataPort_DataFeatureClassifier(), false);
 		assertNotNull(rawClassifier);
 		assertFalse(rawClassifier.eIsProxy());
+	}
+
+	@Test
+	public void resolvingAndNonResolvingIndexLookupsStayDistinct() throws Exception {
+		StagedBuild staged = createPersistedIndexReferenceContext();
+		LazyLinkingResource resource = (LazyLinkingResource) staged.referenceResourceSet()
+				.getResource(staged.referenceUri(), false);
+		DataPort port = findDataPort(staged.referenceResourceSet(), staged.referenceUri());
+		var linkingService = (PropertiesLinkingService) resource.getLinkingService();
+		var reference = Aadl2Package.eINSTANCE.getDataPort_DataFeatureClassifier();
+
+		EObject proxy = linkingService.getIndexedObjectOrProxy(port, reference, "Other::D");
+		assertNotNull(proxy);
+		assertTrue(proxy.eIsProxy());
+		assertNull(staged.referenceResourceSet().getResource(staged.targetUri(), false));
+
+		EObject resolved = linkingService.getIndexedObject(port, reference, "Other::D");
+		assertNotNull(resolved);
+		assertFalse(resolved.eIsProxy());
+		assertNotNull(staged.referenceResourceSet().getResource(staged.targetUri(), false));
 	}
 
 	@Test
@@ -99,7 +124,7 @@ public class Issue3119Test extends AbstractIncrementalBuilderTest {
 		assertCleanBuildHasNoIssues(List.of("Other.aadl", "Issue3119.aadl"));
 	}
 
-	private StagedBuild buildTargetThenReference() throws Exception {
+	private StagedBuild createPersistedIndexReferenceContext() throws Exception {
 		URI target = newFile("Other.aadl", readModel("Other.aadl"));
 		build(newBuildRequest(request -> request.setDirtyFiles(List.of(target))));
 		assertTrue(describeIssues().toString(), describeIssues().isEmpty());
@@ -108,9 +133,7 @@ public class Issue3119Test extends AbstractIncrementalBuilderTest {
 		BuildRequest referenceContext = newBuildRequest(request -> request.setIndexOnly(true));
 		XtextResourceSet referenceResourceSet = referenceContext.getResourceSet();
 		assertNull(referenceResourceSet.getResource(target, false));
-		var referenceResource = referenceResourceSet.getResource(reference, true);
-		EcoreUtil2.resolveLazyCrossReferences(referenceResource, CancelIndicator.NullImpl);
-		assertTrue(referenceResource.getErrors().toString(), referenceResource.getErrors().isEmpty());
+		referenceResourceSet.getResource(reference, true);
 		return new StagedBuild(target, reference, referenceResourceSet);
 	}
 

--- a/core/org.osate.xtext.aadl2.properties/src/org/osate/xtext/aadl2/properties/linking/PropertiesLinkingService.java
+++ b/core/org.osate.xtext.aadl2.properties/src/org/osate/xtext/aadl2/properties/linking/PropertiesLinkingService.java
@@ -26,14 +26,12 @@ package org.osate.xtext.aadl2.properties.linking;
 import java.util.Collections;
 import java.util.List;
 
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
+import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.ui.statushandlers.StatusManager;
 import org.eclipse.xtext.linking.impl.DefaultLinkingService;
 import org.eclipse.xtext.linking.impl.IllegalNodeException;
 import org.eclipse.xtext.naming.IQualifiedNameConverter;
@@ -110,6 +108,7 @@ import org.osate.xtext.aadl2.properties.util.PSNode;
 import com.google.inject.Inject;
 
 public class PropertiesLinkingService extends DefaultLinkingService {
+	private static final Logger LOG = Logger.getLogger(PropertiesLinkingService.class);
 
 	@Inject
 	private IQualifiedNameConverter qualifiedNameConverter;
@@ -118,31 +117,43 @@ public class PropertiesLinkingService extends DefaultLinkingService {
 		super();
 	}
 
-	private final String PLUGIN_ID = "org.osate.xtext.aadl2";
-
 	public EObject getIndexedObject(EObject context, EReference reference, String crossRefString) {
-		PSNode psNode = new PSNode(crossRefString);
-		EObject res = null;
 		try {
-			List<EObject> el;
-			el = super.getLinkedObjects(context, reference, psNode);
-			res = (el.isEmpty() ? null : el.get(0));
+			EObject res = getIndexedObjectOrProxy(context, reference, crossRefString);
 			if (res != null && res.eIsProxy()) {
 				res = EcoreUtil.resolve(res, context);
 				if (res.eIsProxy()) {
 					return null;
 				}
 			}
+			return res;
 		} catch (Exception e) {
-			IStatus status = new Status(IStatus.ERROR, PLUGIN_ID, e.getMessage(), e);
-			StatusManager manager = StatusManager.getManager();
-			manager.handle(status, StatusManager.LOG);
+			LOG.error("Could not resolve indexed object '" + crossRefString + "'.", e);
+			return null;
 		}
-		return res;
 		// XXX phf: lookup in global index without regard to project dependencies
 		// EObject res = EMFIndexRetrieval.getEObjectOfType(context,reference.getEReferenceType(), crossRefString);
 		// return res;
 
+	}
+
+	protected IEObjectDescription getIndexedDescription(EObject context, EReference reference, String crossRefString) {
+		if (crossRefString == null || crossRefString.isEmpty()) {
+			return null;
+		}
+		IScope scope = getScope(context, reference);
+		if (scope == null) {
+			throw new AssertionError("Scope provider " + getScopeProvider().getClass().getName()
+					+ " must not return null for context " + context + ", reference " + reference
+					+ "! Consider to return IScope.NULLSCOPE instead.");
+		}
+		QualifiedName qualifiedLinkName = qualifiedNameConverter.toQualifiedName(crossRefString);
+		return scope.getSingleElement(qualifiedLinkName);
+	}
+
+	public EObject getIndexedObjectOrProxy(EObject context, EReference reference, String crossRefString) {
+		IEObjectDescription description = getIndexedDescription(context, reference, crossRefString);
+		return description == null ? null : description.getEObjectOrProxy();
 	}
 
 	/**
@@ -155,26 +166,12 @@ public class PropertiesLinkingService extends DefaultLinkingService {
 	*/
 	public Iterable<IEObjectDescription> getIndexedObjects(EObject context, EReference reference,
 			String crossRefString) {
-		// List<EObject> el;
-		try {
-
-			if (crossRefString != null && !crossRefString.equals("")) {
-
-				final IScope scope = getScope(context, reference);
-				QualifiedName qualifiedLinkName = qualifiedNameConverter.toQualifiedName(crossRefString);
-				Iterable<IEObjectDescription> eObjectDescriptions = scope.getElements(qualifiedLinkName);
-				return eObjectDescriptions;
-			}
-			// el = super.getLinkedObjects(context, reference, psNode);
-		} catch (Exception e) {
-			return null;
+		if (crossRefString == null || crossRefString.isEmpty()) {
+			return Collections.emptyList();
 		}
-		// EObject res = (el.isEmpty()?null: el.get(0));
-		// if (res != null&&res.eIsProxy()){
-		// res = EcoreUtil.resolve(res,context);
-		// if (res.eIsProxy()) return null;
-		// }
-		return null;
+		IScope scope = getScope(context, reference);
+		QualifiedName qualifiedLinkName = qualifiedNameConverter.toQualifiedName(crossRefString);
+		return scope.getElements(qualifiedLinkName);
 	}
 
 	@Override


### PR DESCRIPTION
Part of #1836. PR 1 of 4.

## Cause and correction

The existing index helper combined candidate lookup, proxy extraction, eager resolution, and UI-only error reporting in one method.

This PR separates those responsibilities without changing existing caller behavior:

- adds a description lookup primitive;
- adds `getIndexedObjectOrProxy`;
- keeps `getIndexedObject` eager and behavior-compatible;
- makes multi-candidate lookup return an empty iterable for empty input and stops swallowing its failures; and
- replaces the undeclared workbench `StatusManager` dependency with Log4j.

## Regression and validation

The #3119 persisted-index model remains the regression fixture. A new assertion verifies that non-resolving lookup returns a proxy without loading the target while the existing resolving API still loads and returns the object.

- Maven `-T5` focused build: `Issue3119Test` passed with 5 tests on the completed stack.
- No intended user-visible linking behavior change in this PR.

## Dependencies and merge order

- Base: PR #3122 (`3119_persisted_index_linking_tests`).
- Merge PR #3121, PR #3122, and PR #3123 first.
- After those merge, retarget or rebase this PR onto `master`.
- Followed by PR 2, `1836_deterministic_index_selection`.

## Residual risk

Existing exported resolving APIs retain their semantics. The uninjected fallback in `Aadl2Visitors` remains unchanged and does not call the new index methods.
