### PR TITLE
Select indexed classifiers by package visibility 🤖

### DIFF
--- a/core/org.osate.aadl2.modelsupport/src/org/osate/aadl2/modelsupport/scoping/Aadl2IndexMetadata.java
+++ b/core/org.osate.aadl2.modelsupport/src/org/osate/aadl2/modelsupport/scoping/Aadl2IndexMetadata.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.aadl2.modelsupport.scoping;
+
+public final class Aadl2IndexMetadata {
+	public static final String PACKAGE_NAME = "aadl.packageName";
+	public static final String VISIBILITY = "aadl.visibility";
+	public static final String PUBLIC = "public";
+	public static final String PRIVATE = "private";
+
+	private Aadl2IndexMetadata() {
+	}
+}

--- a/core/org.osate.core.tests/models/issue1836/.gitignore
+++ b/core/org.osate.core.tests/models/issue1836/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue1836/.project
+++ b/core/org.osate.core.tests/models/issue1836/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue1836</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue1836/Issue1836.aadl
+++ b/core/org.osate.core.tests/models/issue1836/Issue1836.aadl
@@ -1,0 +1,12 @@
+package Issue1836
+public
+	with Library;
+
+	system Top
+	end Top;
+
+	system implementation Top.i
+		subcomponents
+			external: system Library::Service.i;
+	end Top.i;
+end Issue1836;

--- a/core/org.osate.core.tests/models/issue1836/Library.aadl
+++ b/core/org.osate.core.tests/models/issue1836/Library.aadl
@@ -1,0 +1,19 @@
+package Library
+public
+	system Service
+	end Service;
+
+	system implementation Service.i
+	end Service.i;
+private
+	system implementation Service.i
+	end Service.i;
+
+	system Holder
+	end Holder;
+
+	system implementation Holder.i
+		subcomponents
+			local_service: system Service.i;
+	end Holder.i;
+end Library;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue1836Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue1836Test.java
@@ -23,14 +23,24 @@
  */
 package org.osate.core.tests.issues;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.testing.validation.ValidationTestHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.osate.aadl2.Aadl2Package;
 import org.osate.aadl2.AadlPackage;
 import org.osate.aadl2.ComponentImplementation;
 import org.osate.aadl2.PackageSection;
@@ -39,8 +49,10 @@ import org.osate.aadl2.PublicPackageSection;
 import org.osate.aadl2.SystemSubcomponent;
 import org.osate.testsupport.Aadl2InjectorProvider;
 import org.osate.testsupport.TestHelper;
+import org.osate.xtext.aadl2.properties.linking.PropertiesLinkingService;
 
 import com.google.inject.Inject;
+import com.google.inject.Injector;
 import com.itemis.xtext.testing.XtextTest;
 
 /**
@@ -60,15 +72,14 @@ public class Issue1836Test extends XtextTest {
 	@Inject
 	private ValidationTestHelper validationHelper;
 
+	@Inject
+	private Injector injector;
+
 	@Test
 	public void publicAndPrivateImplementationDeclarationsAreSelectedByContext() throws Exception {
-		AadlPackage client = testHelper.parseFile(PATH + "Issue1836.aadl", PATH + "Library.aadl");
+		AadlPackage client = parseModel();
 		validationHelper.assertNoIssues(client);
-		AadlPackage library = (AadlPackage) client.eResource()
-				.getResourceSet()
-				.getResource(URI.createURI(PATH + "Library.aadl"), false)
-				.getContents()
-				.get(0);
+		AadlPackage library = getLibrary(client);
 
 		SystemSubcomponent external = findSubcomponent(client.getOwnedPublicSection(), "Top.i", "external");
 		assertTrue(external.getSystemSubcomponentType().eContainer() instanceof PublicPackageSection);
@@ -77,17 +88,65 @@ public class Issue1836Test extends XtextTest {
 		assertTrue(internal.getSystemSubcomponentType().eContainer() instanceof PrivatePackageSection);
 	}
 
+	@Test
+	public void publicAndPrivateSelectionDoesNotDependOnIndexOrder() throws Exception {
+		AadlPackage client = parseModel();
+		AadlPackage library = getLibrary(client);
+		SystemSubcomponent external = findSubcomponent(client.getOwnedPublicSection(), "Top.i", "external");
+		SystemSubcomponent internal = findSubcomponent(library.getOwnedPrivateSection(), "Holder.i", "local_service");
+		var service = injector.getInstance(ExposedPropertiesLinkingService.class);
+		var reference = Aadl2Package.eINSTANCE.getSystemSubcomponent_SystemSubcomponentType();
+		List<IEObjectDescription> descriptions = new ArrayList<>();
+		service.getIndexedObjects(external, reference, "Library::Service.i").forEach(descriptions::add);
+		assertEquals(2, descriptions.size());
+
+		URI publicUri = EcoreUtil.getURI(findImplementation(library.getOwnedPublicSection(), "Service.i"));
+		URI privateUri = EcoreUtil.getURI(findImplementation(library.getOwnedPrivateSection(), "Service.i"));
+		assertSelections(service, external, internal, reference, descriptions, publicUri, privateUri);
+		Collections.reverse(descriptions);
+		assertSelections(service, external, internal, reference, descriptions, publicUri, privateUri);
+	}
+
+	private AadlPackage parseModel() {
+		return testHelper.parseFile(PATH + "Issue1836.aadl", PATH + "Library.aadl");
+	}
+
+	private static AadlPackage getLibrary(AadlPackage client) {
+		return (AadlPackage) client.eResource()
+				.getResourceSet()
+				.getResource(URI.createURI(PATH + "Library.aadl"), false)
+				.getContents()
+				.get(0);
+	}
+
+	private static void assertSelections(ExposedPropertiesLinkingService service, EObject external, EObject internal,
+			EReference reference, List<IEObjectDescription> descriptions, URI publicUri, URI privateUri) {
+		assertEquals(publicUri, service.select(external, reference, descriptions).getEObjectURI());
+		assertEquals(privateUri, service.select(internal, reference, descriptions).getEObjectURI());
+	}
+
 	private static SystemSubcomponent findSubcomponent(PackageSection section, String implementationName,
 			String subcomponentName) {
-		var implementation = (ComponentImplementation) section.getOwnedClassifiers()
-				.stream()
-				.filter(classifier -> classifier.getName().equals(implementationName))
-				.findFirst()
-				.orElseThrow();
+		var implementation = findImplementation(section, implementationName);
 		return (SystemSubcomponent) implementation.getOwnedSubcomponents()
 				.stream()
 				.filter(subcomponent -> subcomponent.getName().equals(subcomponentName))
 				.findFirst()
 				.orElseThrow();
+	}
+
+	private static ComponentImplementation findImplementation(PackageSection section, String implementationName) {
+		return (ComponentImplementation) section.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals(implementationName))
+				.findFirst()
+				.orElseThrow();
+	}
+
+	public static class ExposedPropertiesLinkingService extends PropertiesLinkingService {
+		public IEObjectDescription select(EObject context, EReference reference,
+				Iterable<IEObjectDescription> descriptions) {
+			return selectIndexedDescription(context, reference, descriptions);
+		}
 	}
 }

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue1836Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue1836Test.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.PackageSection;
+import org.osate.aadl2.PrivatePackageSection;
+import org.osate.aadl2.PublicPackageSection;
+import org.osate.aadl2.SystemSubcomponent;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * Tests selection between the public and private declarations of one component implementation.
+ * This matters because both declarations have the same qualified name, but external references may
+ * see only the public declaration while references in the package's private section need its private
+ * realization rather than whichever index entry happens to appear first.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue1836Test extends XtextTest {
+	private static final String PATH = "org.osate.core.tests/models/issue1836/";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void publicAndPrivateImplementationDeclarationsAreSelectedByContext() throws Exception {
+		AadlPackage client = testHelper.parseFile(PATH + "Issue1836.aadl", PATH + "Library.aadl");
+		validationHelper.assertNoIssues(client);
+		AadlPackage library = (AadlPackage) client.eResource()
+				.getResourceSet()
+				.getResource(URI.createURI(PATH + "Library.aadl"), false)
+				.getContents()
+				.get(0);
+
+		SystemSubcomponent external = findSubcomponent(client.getOwnedPublicSection(), "Top.i", "external");
+		assertTrue(external.getSystemSubcomponentType().eContainer() instanceof PublicPackageSection);
+
+		SystemSubcomponent internal = findSubcomponent(library.getOwnedPrivateSection(), "Holder.i", "local_service");
+		assertTrue(internal.getSystemSubcomponentType().eContainer() instanceof PrivatePackageSection);
+	}
+
+	private static SystemSubcomponent findSubcomponent(PackageSection section, String implementationName,
+			String subcomponentName) {
+		var implementation = (ComponentImplementation) section.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals(implementationName))
+				.findFirst()
+				.orElseThrow();
+		return (SystemSubcomponent) implementation.getOwnedSubcomponents()
+				.stream()
+				.filter(subcomponent -> subcomponent.getName().equals(subcomponentName))
+				.findFirst()
+				.orElseThrow();
+	}
+}

--- a/core/org.osate.xtext.aadl2.properties/src/org/osate/xtext/aadl2/properties/linking/PropertiesLinkingService.java
+++ b/core/org.osate.xtext.aadl2.properties/src/org/osate/xtext/aadl2/properties/linking/PropertiesLinkingService.java
@@ -102,6 +102,7 @@ import org.osate.aadl2.ThreadSubcomponent;
 import org.osate.aadl2.UnitLiteral;
 import org.osate.aadl2.UnitsType;
 import org.osate.aadl2.modelsupport.ResolvePrototypeUtil;
+import org.osate.aadl2.modelsupport.scoping.Aadl2IndexMetadata;
 import org.osate.aadl2.modelsupport.util.AadlUtil;
 import org.osate.xtext.aadl2.properties.util.PSNode;
 
@@ -141,14 +142,39 @@ public class PropertiesLinkingService extends DefaultLinkingService {
 		if (crossRefString == null || crossRefString.isEmpty()) {
 			return null;
 		}
-		IScope scope = getScope(context, reference);
-		if (scope == null) {
-			throw new AssertionError("Scope provider " + getScopeProvider().getClass().getName()
-					+ " must not return null for context " + context + ", reference " + reference
-					+ "! Consider to return IScope.NULLSCOPE instead.");
+		return selectIndexedDescription(context, reference, getIndexedObjects(context, reference, crossRefString));
+	}
+
+	protected IEObjectDescription selectIndexedDescription(EObject context, EReference reference,
+			Iterable<IEObjectDescription> descriptions) {
+		EClass requiredType = reference.getEReferenceType();
+		Namespace namespace = AadlUtil.getContainingTopLevelNamespace(context);
+		boolean privateContext = namespace instanceof PrivatePackageSection;
+		String contextPackage = namespace instanceof PackageSection
+				? ((AadlPackage) ((PackageSection) namespace).getOwner()).getName()
+				: null;
+		IEObjectDescription selected = null;
+		int selectedRank = Integer.MAX_VALUE;
+
+		for (IEObjectDescription description : descriptions) {
+			if (requiredType != null && !requiredType.isSuperTypeOf(description.getEClass())) {
+				continue;
+			}
+			boolean privateCandidate = Aadl2IndexMetadata.PRIVATE
+					.equals(description.getUserData(Aadl2IndexMetadata.VISIBILITY));
+			if (privateCandidate && (!privateContext || contextPackage == null
+					|| !contextPackage.equalsIgnoreCase(description.getUserData(Aadl2IndexMetadata.PACKAGE_NAME)))) {
+				continue;
+			}
+			int rank = privateCandidate ? 0 : 1;
+			if (rank < selectedRank) {
+				selected = description;
+				selectedRank = rank;
+			} else if (rank == selectedRank) {
+				selected = null;
+			}
 		}
-		QualifiedName qualifiedLinkName = qualifiedNameConverter.toQualifiedName(crossRefString);
-		return scope.getSingleElement(qualifiedLinkName);
+		return selected;
 	}
 
 	public EObject getIndexedObjectOrProxy(EObject context, EReference reference, String crossRefString) {
@@ -170,6 +196,11 @@ public class PropertiesLinkingService extends DefaultLinkingService {
 			return Collections.emptyList();
 		}
 		IScope scope = getScope(context, reference);
+		if (scope == null) {
+			throw new AssertionError("Scope provider " + getScopeProvider().getClass().getName()
+					+ " must not return null for context " + context + ", reference " + reference
+					+ "! Consider to return IScope.NULLSCOPE instead.");
+		}
 		QualifiedName qualifiedLinkName = qualifiedNameConverter.toQualifiedName(crossRefString);
 		return scope.getElements(qualifiedLinkName);
 	}

--- a/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/scoping/AnnexAwareResourceDescriptionStrategy.java
+++ b/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/scoping/AnnexAwareResourceDescriptionStrategy.java
@@ -33,11 +33,17 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.parser.IParseResult;
 import org.eclipse.xtext.resource.IDefaultResourceDescriptionStrategy;
+import org.eclipse.xtext.resource.EObjectDescription;
 import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.resource.IReferenceDescription;
 import org.eclipse.xtext.resource.impl.DefaultResourceDescriptionStrategy;
 import org.eclipse.xtext.util.IAcceptor;
+import org.osate.aadl2.AadlPackage;
 import org.osate.aadl2.NamedElement;
+import org.osate.aadl2.PackageSection;
+import org.osate.aadl2.PrivatePackageSection;
+import org.osate.aadl2.modelsupport.scoping.Aadl2IndexMetadata;
+import org.osate.aadl2.modelsupport.util.AadlUtil;
 import org.osate.annexsupport.AnnexUtil;
 import org.osate.annexsupport.ParseResultHolder;
 
@@ -58,6 +64,16 @@ public class AnnexAwareResourceDescriptionStrategy extends DefaultResourceDescri
 
 		if (rds != null) {
 			return rds.createEObjectDescriptions(eObject, acceptor);
+		}
+		var namespace = AadlUtil.getContainingTopLevelNamespace(eObject);
+		if (namespace instanceof PackageSection packageSection) {
+			Map<String, String> userData = Map.of(
+					Aadl2IndexMetadata.PACKAGE_NAME, ((AadlPackage) packageSection.getOwner()).getName(),
+					Aadl2IndexMetadata.VISIBILITY,
+					packageSection instanceof PrivatePackageSection ? Aadl2IndexMetadata.PRIVATE
+							: Aadl2IndexMetadata.PUBLIC);
+			return super.createEObjectDescriptions(eObject, description -> acceptor
+					.accept(EObjectDescription.create(description.getName(), eObject, userData)));
 		}
 		return super.createEObjectDescriptions(eObject, acceptor);
 


### PR DESCRIPTION
Part of #1836. PR 2 of 4.

## Cause and correction

Public and private component implementation declarations can share one qualified name. Selecting one description before checking visibility makes the result depend on index order and can discard an eligible candidate.

Export package name and public/private visibility as index metadata. Retrieve all matching descriptions, filter by reference type and context visibility, and apply deterministic precedence:

- private declarations win only from the same package's private section;
- public declarations remain visible externally; and
- equally eligible duplicates are treated as ambiguous rather than selected arbitrarily.

## Regression

`Issue1836Test` models a valid implementation declared in both public and private sections. It asserts public selection from another package and private selection from the package's private section. A second test reverses the candidate list and requires identical results.

## Validation

- Focused five-module offline build: 2 tests passed.
- Maven `-T5` post-rebase run: 2 tests passed.

## Dependencies and merge order

- Base: PR #3124 (`1836_split_index_lookup_api`).
- Requires PR #3121, PR #3122, PR #3123, and PR #3124.
- Followed by PR 3, `1836_return_terminal_proxies`.

## Residual risk

The new index metadata requires an index rebuild for existing workspaces. Users may need Clean All after upgrading.
