### PR TITLE
Return proxies for terminal index links 🤖

### DIFF
--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3119Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3119Test.java
@@ -69,18 +69,18 @@ public class Issue3119Test extends AbstractIncrementalBuilderTest {
 	}
 
 	@Test
-	public void terminalReferenceCurrentlyLoadsPersistedIndexTarget() throws Exception {
+	public void terminalReferenceRemainsProxyWithoutLoadingPersistedIndexTarget() throws Exception {
 		StagedBuild staged = createPersistedIndexReferenceContext();
 		var referenceResource = staged.referenceResourceSet().getResource(staged.referenceUri(), false);
 		EcoreUtil2.resolveLazyCrossReferences(referenceResource, CancelIndicator.NullImpl);
 		assertTrue(referenceResource.getErrors().toString(), referenceResource.getErrors().isEmpty());
 
-		assertNotNull(staged.referenceResourceSet().getResource(staged.targetUri(), false));
+		assertNull(staged.referenceResourceSet().getResource(staged.targetUri(), false));
 
 		DataPort port = findDataPort(staged.referenceResourceSet(), staged.referenceUri());
 		EObject rawClassifier = (EObject) port.eGet(Aadl2Package.eINSTANCE.getDataPort_DataFeatureClassifier(), false);
 		assertNotNull(rawClassifier);
-		assertFalse(rawClassifier.eIsProxy());
+		assertTrue(rawClassifier.eIsProxy());
 	}
 
 	@Test

--- a/core/org.osate.xtext.aadl2.properties/src/org/osate/xtext/aadl2/properties/linking/PropertiesLinkingService.java
+++ b/core/org.osate.xtext.aadl2.properties/src/org/osate/xtext/aadl2/properties/linking/PropertiesLinkingService.java
@@ -233,7 +233,7 @@ public class PropertiesLinkingService extends DefaultLinkingService {
 		if (sct.isSuperTypeOf(requiredType) || cl.isSuperTypeOf(requiredType)) {
 			// XXX: this code can be replicated in Aadl2LinkingService as it is called often in the core
 			// resolve classifier reference
-			EObject e = findClassifier(context, reference, name);
+			EObject e = findClassifierOrProxy(context, reference, name);
 			if (e != null) {
 				// the result satisfied the expected class
 				return Collections.singletonList(e);
@@ -250,24 +250,24 @@ public class PropertiesLinkingService extends DefaultLinkingService {
 				}
 			}
 		} else if (Aadl2Package.eINSTANCE.getModelUnit() == requiredType) {
-			AadlPackage pack = findAadlPackage(context, name, reference);
+			AadlPackage pack = findAadlPackageOrProxy(context, name, reference);
 			if (pack != null) {
 				searchResult = pack;
 			} else {
-				PropertySet ps = findPropertySet(context, name, reference);
+				PropertySet ps = findPropertySetOrProxy(context, name, reference);
 				if (ps != null) {
 					searchResult = ps;
 				}
 			}
 
 		} else if (Aadl2Package.eINSTANCE.getAadlPackage() == requiredType) {
-			AadlPackage pack = findAadlPackage(context, name, reference);
+			AadlPackage pack = findAadlPackageOrProxy(context, name, reference);
 			if (pack != null) {
 				searchResult = pack;
 			}
 
 		} else if (Aadl2Package.eINSTANCE.getPropertySet() == requiredType) {
-			PropertySet ps = findPropertySet(context, name, reference);
+			PropertySet ps = findPropertySetOrProxy(context, name, reference);
 			if (ps != null) {
 				searchResult = ps;
 			}
@@ -315,7 +315,7 @@ public class PropertiesLinkingService extends DefaultLinkingService {
 
 		} else if (Aadl2Package.eINSTANCE.getProperty() == requiredType) {
 			// look for property definition in property set
-			return findPropertyDefinitionAsList(context, reference, name);
+			return findPropertyDefinitionOrProxyAsList(context, reference, name);
 
 		} else if (Aadl2Package.eINSTANCE.getAbstractNamedValue() == requiredType) {
 			// AbstractNamedValue: constant reference, property definition reference, unit literal, enumeration literal
@@ -329,10 +329,10 @@ public class PropertiesLinkingService extends DefaultLinkingService {
 					}
 				}
 				if (res.isEmpty()) {
-					res = findPropertyConstant(context, reference, name);
+					res = findPropertyConstantOrProxy(context, reference, name);
 				}
 				if (res.isEmpty()) {
-					res = findPropertyDefinitionAsList(context, reference, name);
+					res = findPropertyDefinitionOrProxyAsList(context, reference, name);
 				}
 				return res;
 			}
@@ -376,11 +376,11 @@ public class PropertiesLinkingService extends DefaultLinkingService {
 			}
 		} else if (pt.isSuperTypeOf(requiredType)) {
 			// look for property type in property set
-			return findPropertyType(context, reference, name);
+			return findPropertyTypeOrProxy(context, reference, name);
 
 		} else if (Aadl2Package.eINSTANCE.getPropertyConstant() == requiredType) {
 			// look for property constant in property set
-			return findPropertyConstant(context, reference, name);
+			return findPropertyConstantOrProxy(context, reference, name);
 
 		} else if (Aadl2Package.eINSTANCE.getUnitLiteral() == requiredType) {
 			// look for unit literal pointed to by baseUnit
@@ -581,6 +581,11 @@ public class PropertiesLinkingService extends DefaultLinkingService {
 		return null;
 	}
 
+	protected AadlPackage findAadlPackageOrProxy(EObject context, String name, EReference reference) {
+		EObject res = getIndexedObjectOrProxy(context, reference, name);
+		return res instanceof AadlPackage ? (AadlPackage) res : null;
+	}
+
 	/**
 	 * Find referenced Package by resolving renames first and then making sure it is listed in a with clause
 	 * If package name is null or that of the context return containing package
@@ -669,6 +674,11 @@ public class PropertiesLinkingService extends DefaultLinkingService {
 		return null;
 	}
 
+	protected PropertySet findPropertySetOrProxy(EObject context, String name, EReference reference) {
+		EObject res = getIndexedObjectOrProxy(context, reference, name);
+		return res instanceof PropertySet ? (PropertySet) res : null;
+	}
+
 	/**
 	 * find the component classifier taking into account rename aliases
 	 * The name may be qualified with a package name
@@ -744,6 +754,35 @@ public class PropertiesLinkingService extends DefaultLinkingService {
 		return null;
 	}
 
+	protected EObject findClassifierOrProxy(EObject context, EReference reference, String name) {
+		Namespace scope = AadlUtil.getContainingTopLevelNamespace(context);
+		EObject e = getIndexedObjectOrProxy(context, reference, name);
+		if (e != null) {
+			return e;
+		}
+		String packname = null;
+		String cname = name;
+		final int idx = name.lastIndexOf("::");
+		if (idx != -1) {
+			packname = name.substring(0, idx);
+			cname = name.substring(idx + 2);
+			if (cname.equalsIgnoreCase("all")) {
+				return null;
+			}
+		}
+		if (context instanceof NamedElement && ((NamedElement) context).getName() == null
+				&& (packname == null || scope.getName().equalsIgnoreCase(packname))) {
+			return null;
+		}
+		if (scope instanceof PackageSection) {
+			e = findNamedElementInAadlPackage(packname, cname, scope);
+			if (e instanceof Classifier && reference.getEReferenceType().isSuperTypeOf(e.eClass())) {
+				return e;
+			}
+		}
+		return null;
+	}
+
 	/**
 	 * find a named element in a property set based on an optionally qualified name.
 	 * The name is qualified with the property set name, or if unqualified is assumed to be a predeclared property constant
@@ -769,6 +808,20 @@ public class PropertiesLinkingService extends DefaultLinkingService {
 		} else {
 			return getIndexedObject(context, reference, name);
 		}
+	}
+
+	protected EObject findPropertySetElementOrProxy(EObject context, EReference reference, String name) {
+		final int idx = name.lastIndexOf("::");
+		if (idx == -1) {
+			for (String predeclaredPSName : AadlUtil.getPredeclaredPropertySetNames()) {
+				EObject res = getIndexedObjectOrProxy(context, reference, getQualifiedName(predeclaredPSName, name));
+				if (res != null) {
+					return res;
+				}
+			}
+			return null;
+		}
+		return getIndexedObjectOrProxy(context, reference, name);
 	}
 
 	/**
@@ -798,6 +851,11 @@ public class PropertiesLinkingService extends DefaultLinkingService {
 		return Collections.<EObject> emptyList();
 	}
 
+	protected List<EObject> findPropertyConstantOrProxy(EObject context, EReference reference, String name) {
+		EObject e = findPropertySetElementOrProxy(context, reference, name);
+		return e instanceof PropertyConstant ? Collections.singletonList(e) : Collections.emptyList();
+	}
+
 	/**
 	 * find property type based on property name.
 	 * The name is qualified with the property set name, or if unqualified is assumed to be a predeclared property type
@@ -823,6 +881,11 @@ public class PropertiesLinkingService extends DefaultLinkingService {
 			return Collections.singletonList(e);
 		}
 		return Collections.<EObject> emptyList();
+	}
+
+	protected List<EObject> findPropertyTypeOrProxy(EObject context, EReference reference, String name) {
+		EObject e = findPropertySetElementOrProxy(context, reference, name);
+		return e instanceof PropertyType ? Collections.singletonList(e) : Collections.emptyList();
 	}
 
 	/**
@@ -866,6 +929,11 @@ public class PropertiesLinkingService extends DefaultLinkingService {
 			return Collections.singletonList(e);
 		}
 		return Collections.<EObject> emptyList();
+	}
+
+	protected List<EObject> findPropertyDefinitionOrProxyAsList(EObject context, EReference reference, String name) {
+		EObject e = findPropertySetElementOrProxy(context, reference, name);
+		return e instanceof Property ? Collections.singletonList(e) : Collections.emptyList();
 	}
 
 	/**

--- a/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/linking/Aadl2LinkingService.java
+++ b/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/linking/Aadl2LinkingService.java
@@ -143,7 +143,7 @@ public class Aadl2LinkingService extends PropertiesLinkingService {
 		if (sct.isSuperTypeOf(requiredType) || cl.isSuperTypeOf(requiredType)) {
 			// XXX: this code can be replicated in Aadl2LinkingService as it is called often in the core
 			// resolve classifier reference
-			EObject e = findClassifier(context, reference, name);
+			EObject e = findClassifierOrProxy(context, reference, name);
 			if (e != null) {
 				// the result satisfied the expected class
 				return Collections.singletonList(e);
@@ -170,7 +170,7 @@ public class Aadl2LinkingService extends PropertiesLinkingService {
 			return Collections.emptyList();
 		} else if (Aadl2Package.eINSTANCE.getFeatureClassifier().isSuperTypeOf(requiredType)) {
 			// prototype for feature or component, or data,bus,subprogram, subprogram group classifier
-			EObject e = findClassifier(context, reference, name);
+			EObject e = findClassifierOrProxy(context, reference, name);
 			if (Aadl2Util.isNull(e) && !(context instanceof Generalization)
 					&& !Aadl2Package.eINSTANCE.getComponentType().isSuperTypeOf(requiredType)) {
 				// look for prototype
@@ -266,7 +266,7 @@ public class Aadl2LinkingService extends PropertiesLinkingService {
 			if (searchResult != null && requiredType.isSuperTypeOf(searchResult.eClass())) {
 				return Collections.singletonList(searchResult);
 			}
-			searchResult = findClassifier(context, reference, name);
+			searchResult = findClassifierOrProxy(context, reference, name);
 			if (searchResult != null) {
 				return Collections.singletonList(searchResult);
 			}
@@ -278,7 +278,7 @@ public class Aadl2LinkingService extends PropertiesLinkingService {
 			if (!(context instanceof SubprogramCall)
 					|| (context instanceof SubprogramCall && ((SubprogramCall) context).getContext() == null)) {
 				// first check whether it is a reference to a classifier
-				searchResult = findClassifier(context, reference, name);
+				searchResult = findClassifierOrProxy(context, reference, name);
 				if (searchResult != null && requiredType.isSuperTypeOf(searchResult.eClass())) {
 					return Collections.singletonList(searchResult);
 				}
@@ -304,7 +304,7 @@ public class Aadl2LinkingService extends PropertiesLinkingService {
 					// first try to find subprogram implementation
 					ComponentType ct = (ComponentType) callContext;
 					String implname = ct.getQualifiedName() + "." + name;
-					searchResult = findClassifier(context, reference, implname);
+					searchResult = findClassifierOrProxy(context, reference, implname);
 					if (searchResult != null && searchResult instanceof ComponentImplementation) {
 						return Collections.singletonList(searchResult);
 					}
@@ -337,7 +337,7 @@ public class Aadl2LinkingService extends PropertiesLinkingService {
 				// it might be a component implementation. The type is already recorded in the context
 				if (callContext instanceof SubprogramType) {
 					String contextName = ((SubprogramType) callContext).getName();
-					searchResult = findClassifier(context, reference, contextName + "." + name);
+					searchResult = findClassifierOrProxy(context, reference, contextName + "." + name);
 					if (!Aadl2Util.isNull(searchResult)) {
 						return Collections.singletonList(searchResult);
 					}


### PR DESCRIPTION
Part of #1836. PR 3 of 4.

## Cause and correction

Terminal index links were routed through resolving helpers, so linking a referencing file loaded every cross-file target immediately. A failed load was also reported as a missing name.

Route terminal classifier, model-unit, property-set, property-definition, property-constant, and property-type links through proxy-returning lookup variants. Keep local fallbacks and navigational helpers resolving because they must inspect the target model.

## Regression

The staged #3119 test now requires lazy linking to store a proxy and leave the indexed target absent from the fresh resource set.

## Validation

- `Issue3119Test`: 5 tests passed.
- The deterministic resource-load assertion proves the target is not loaded for the terminal classifier link.
- Final-stack five-sample performance medians for 400 links:
  - classifier-heavy: 19.518 ms versus 19.972 ms baseline;
  - property-heavy: 75.387 ms versus 77.337 ms baseline.

## Dependencies and merge order

- Base: PR #3125 (`1836_deterministic_index_selection`).
- Requires PRs #3121 through #3125.
- Followed by PR 4, `1836_restore_proxy_caching`.

## Residual risk

Navigational references intentionally remain eager. Re-enabling indexed URI fragments is outside this PR and requires separate reproduction.
