### PR TITLE
Resolve refined port connection property lookup inconsistency 🤖

### DIFF
--- a/core/org.osate.aadl2/src/org/osate/aadl2/impl/PortConnectionImpl.java
+++ b/core/org.osate.aadl2/src/org/osate/aadl2/impl/PortConnectionImpl.java
@@ -25,10 +25,7 @@ package org.osate.aadl2.impl;
 
 import org.eclipse.emf.ecore.EClass;
 import org.osate.aadl2.Aadl2Package;
-import org.osate.aadl2.Classifier;
 import org.osate.aadl2.PortConnection;
-import org.osate.aadl2.Property;
-import org.osate.aadl2.properties.PropertyAcc;
 
 /**
  * <!-- begin-user-doc -->
@@ -55,11 +52,6 @@ public class PortConnectionImpl extends ConnectionImpl implements PortConnection
 	@Override
 	protected EClass eStaticClass() {
 		return Aadl2Package.eINSTANCE.getPortConnection();
-	}
-
-	@Override
-	public void getPropertyValueForInstance(Property property, PropertyAcc pas, Classifier instantiatedClassifier) {
-		pas.addLocal(this);
 	}
 
 } // PortConnectionImpl

--- a/core/org.osate.core.tests/models/issue3109/.gitignore
+++ b/core/org.osate.core.tests/models/issue3109/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue3109/.project
+++ b/core/org.osate.core.tests/models/issue3109/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3109</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue3109/Issue3109.aadl
+++ b/core/org.osate.core.tests/models/issue3109/Issue3109.aadl
@@ -1,0 +1,67 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+package Issue3109
+public
+	with Issue3109Properties;
+
+	data Payload
+	end Payload;
+
+	process Worker
+		features
+			input: in data port;
+			output: out data port;
+			provided_data: provides data access Payload;
+			required_data: requires data access Payload;
+	end Worker;
+
+	process implementation Worker.i
+	end Worker.i;
+
+	system Base
+	end Base;
+
+	system implementation Base.i
+		subcomponents
+			src: process Worker.i;
+			dst: process Worker.i;
+		connections
+			port_link: port src.output -> dst.input {
+				Issue3109Properties::Connection_Value => 1;
+			};
+			access_link: data access src.provided_data -> dst.required_data {
+				Issue3109Properties::Connection_Value => 2;
+			};
+	end Base.i;
+
+	system Extended extends Base
+	end Extended;
+
+	system implementation Extended.i extends Base.i
+		connections
+			port_link: refined to port;
+			access_link: refined to data access;
+	end Extended.i;
+end Issue3109;

--- a/core/org.osate.core.tests/models/issue3109/Issue3109Properties.aadl
+++ b/core/org.osate.core.tests/models/issue3109/Issue3109Properties.aadl
@@ -1,0 +1,27 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+property set Issue3109Properties is
+	Connection_Value: aadlinteger applies to (connection);
+end Issue3109Properties;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3032Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3032Test.java
@@ -157,17 +157,15 @@ public class Issue3032Test extends XtextTest {
 	}
 
 	/**
-	 * Characterization of the lookup context used for the structural connection properties. The
-	 * expansion evaluates {@code Connection_Pattern} and {@code Connection_Set} before the final
-	 * connection instances exist, so the values it resolves must not change for any of these contexts.
-	 * The number and the endpoints of the connection instances are what the resolved value determines.
+	 * Characterization of the lookup context used for the structural connection properties. The expansion
+	 * evaluates {@code Connection_Pattern} and {@code Connection_Set} before the final connection instances
+	 * exist. The number and endpoints of the connection instances show which value that lookup resolved.
 	 * <p>
-	 * {@code Top.inheriting} records that a value on a refined-from connection is not picked up for the
+	 * {@code Top.inheriting} records that a value on a refined-from connection is picked up for the
 	 * refining connection, and {@code Top.modal} records that the first modal value is the one applied.
-	 * Both are pre-existing behavior.
 	 */
 	@Test
-	public void structuralPropertyLookupContextIsUnchanged() throws Exception {
+	public void structuralPropertyLookupUsesExpectedContexts() throws Exception {
 		List<String> allToAll = List.of("producers[1].outp --> consumers[1].inp",
 				"producers[1].outp --> consumers[2].inp", "producers[2].outp --> consumers[1].inp",
 				"producers[2].outp --> consumers[2].inp");
@@ -178,7 +176,7 @@ public class Issue3032Test extends XtextTest {
 				names(instantiate("Issue3032Properties.aadl", "Top.direct").getAllConnectionInstances()));
 		assertEquals("Connection_Pattern supplied by the enclosing implementation", allToAll,
 				names(instantiate("Issue3032Properties.aadl", "Top.contextual").getAllConnectionInstances()));
-		assertEquals("Connection_Pattern left on the refined-from connection", oneToOne,
+		assertEquals("Connection_Pattern left on the refined-from connection", allToAll,
 				names(instantiate("Issue3032Properties.aadl", "Top.inheriting").getAllConnectionInstances()));
 		assertEquals("Connection_Pattern declared per mode", allToAll,
 				names(instantiate("Issue3032Properties.aadl", "Top.modal").getAllConnectionInstances()));

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3037StructuralExpansionTest.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3037StructuralExpansionTest.java
@@ -96,6 +96,7 @@ public class Issue3037StructuralExpansionTest extends XtextTest {
 				"producers[1].outp --> consumers[2].inp", "producers[2].outp --> consumers[1].inp",
 				"producers[2].outp --> consumers[2].inp");
 		assertConnections(PROPERTIES, "Top.inheriting", "producers[1].outp --> consumers[1].inp",
+				"producers[1].outp --> consumers[2].inp", "producers[2].outp --> consumers[1].inp",
 				"producers[2].outp --> consumers[2].inp");
 		assertConnections(PROPERTIES, "Top.modal", "producers[1].outp --> consumers[1].inp",
 				"producers[1].outp --> consumers[2].inp", "producers[2].outp --> consumers[1].inp",

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3109Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue3109Test.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to the Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.AccessConnection;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.IntegerLiteral;
+import org.osate.aadl2.PortConnection;
+import org.osate.aadl2.instance.ConnectionInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * A refined connection must find property associations declared on the connection that it refines.
+ * The access connection exercises the normal {@code ConnectionImpl} lookup path, while the port
+ * connection exercises the specialized path that issue #3109 removes.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue3109Test extends XtextTest {
+	private static final String PATH = "org.osate.core.tests/models/issue3109/";
+	private static final String MODEL = PATH + "Issue3109.aadl";
+	private static final String PROPERTIES = PATH + "Issue3109Properties.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void refinedConnectionsCachePropertiesFromTheirRefinementAncestors() throws Exception {
+		var pkg = testHelper.parseFile(MODEL, PROPERTIES);
+		validationHelper.assertNoIssues(pkg);
+		var implementation = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals("Extended.i"))
+				.findFirst()
+				.orElseThrow();
+
+		var instance = InstantiateModel.instantiate(implementation);
+		var portConnection = connection(instance.getConnectionInstances(), PortConnection.class);
+		var accessConnection = connection(instance.getConnectionInstances(), AccessConnection.class);
+
+		assertEquals(2, value(accessConnection));
+		assertEquals(1, value(portConnection));
+	}
+
+	private static ConnectionInstance connection(Iterable<ConnectionInstance> connections,
+			Class<?> declarativeConnectionType) {
+		for (var connection : connections) {
+			var declaration = connection.getConnectionReferences().getFirst().getConnection();
+			if (declarativeConnectionType.isInstance(declaration)) {
+				return connection;
+			}
+		}
+		throw new AssertionError("No connection instance for " + declarativeConnectionType.getSimpleName());
+	}
+
+	private static long value(ConnectionInstance connection) {
+		var associations = connection.getOwnedPropertyAssociations()
+				.stream()
+				.filter(association -> association.getProperty().getName().equals("Connection_Value"))
+				.toList();
+		assertEquals(connection.getInstanceObjectPath(), 1, associations.size());
+		var expression = associations.getFirst().getOwnedValues().getFirst().getOwnedValue();
+		return (long) ((IntegerLiteral) expression).getValue();
+	}
+}


### PR DESCRIPTION
Fixes #3109

## Cause and correction

`PortConnectionImpl.getPropertyValueForInstance` only searched the refining port connection itself. Other connection kinds use `ConnectionImpl`, which also walks the refinement chain, so instance property caching omitted associations declared on ancestors of refined port connections.

Remove the port-specific override so port connections use the common refinement-aware lookup.

## Regression coverage

`Issue3109Test` instantiates a valid model containing refined port and data-access connections whose integer properties are declared on their refinement ancestors. The access connection is the control path; the test verifies both values are cached on their connection instances.

The semantic correction also makes an inherited `Connection_Pattern` affect refined port connections. The existing #3032 and #3037 structural-property characterizations now expect the resulting all-to-all expansion.

## Validation

- `mvn -o -T6 -s releng/osate.releng/settings.xml -Plocal -pl :org.osate.aadl2,:org.osate.aadl2.modelsupport,:org.osate.aadl2.instantiation,:org.osate.core.tests,:org.osate.core.feature -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -Dtest=Issue3109Test -DfailIfNoTests=false clean verify`
  - 1 test, 0 failures, 0 errors
- `mvn -o -T6 -s releng/osate.releng/settings.xml -Plocal -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -DfailIfNoTests=false clean install`
  - Clean 137-project reactor passed in 2:02

## Dependencies

None. The prerequisite #3108 refactor is merged, and this branch is rebased onto current `master`.

## Residual risk

The intended behavior change applies to every property on refined port connections, including structural properties such as `Connection_Pattern`. Other connection kinds already use this refinement-aware behavior, and the affected existing characterizations are updated.