### PR TITLE
Validate unique record field names 🤖

### DIFF
--- a/core/org.osate.core.tests/models/issue2733/.gitignore
+++ b/core/org.osate.core.tests/models/issue2733/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue2733/.project
+++ b/core/org.osate.core.tests/models/issue2733/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue2733</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue2733/Issue2733.aadl
+++ b/core/org.osate.core.tests/models/issue2733/Issue2733.aadl
@@ -1,0 +1,38 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with this program. The
+-- parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries of this
+-- license with respect to the terms applicable to their Third Party Software. Third Party Software licenses only
+-- apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+property set Issue2733 is
+	-- This record establishes that distinct field names remain valid.
+	unique_record: type record (
+		boolean_field: aadlboolean;
+		integer_field: aadlinteger;
+		real_field: aadlreal;
+	);
+
+	-- Each field after the first repeats a name already declared in this record.
+	duplicate_record: type record (
+		field: aadlboolean;
+		field: aadlinteger;
+		field: aadlreal;
+	);
+end Issue2733;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2733Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2733Test.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with this program. The
+ * parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries of this
+ * license with respect to the terms applicable to their Third Party Software. Third Party Software licenses only
+ * apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Comparator;
+
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.xtext.diagnostics.Severity;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.ModelUnit;
+import org.osate.aadl2.PropertySet;
+import org.osate.aadl2.RecordType;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * Record fields share a namespace within their record type, but the validator did not check that
+ * namespace for duplicate names. This test requires diagnostics on each field that repeats an earlier
+ * field while ensuring a neighboring record with distinct fields remains valid.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue2733Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue2733/Issue2733.aadl";
+	private static final String MESSAGE = "Field 'field' previously declared in record type";
+
+	@Inject
+	private TestHelper<ModelUnit> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void duplicateRecordFieldNamesAreReported() throws Exception {
+		var propertySet = (PropertySet) testHelper.parseFile(MODEL);
+		var issues = validationHelper.validate(propertySet)
+				.stream()
+				.sorted(Comparator.comparingInt(issue -> issue.getOffset() == null ? -1 : issue.getOffset()))
+				.toList();
+		var duplicateRecord = (RecordType) propertySet.getOwnedPropertyTypes().get(1);
+
+		assertEquals(2, issues.size());
+		for (var i = 0; i < issues.size(); i++) {
+			var issue = issues.get(i);
+			assertEquals(Severity.ERROR, issue.getSeverity());
+			assertEquals(MESSAGE, issue.getMessage());
+			assertEquals(EcoreUtil.getURI(duplicateRecord.getOwnedFields().get(i + 1)), issue.getUriToProblem());
+		}
+	}
+}

--- a/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/validation/Aadl2Validator.java
+++ b/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/validation/Aadl2Validator.java
@@ -94,6 +94,7 @@ public class Aadl2Validator extends AbstractAadl2Validator {
 	public static final String MISMATCHED_BEGINNING_AND_ENDING_IDENTIFIERS = "org.osate.xtext.aadl2.mismatched_beginning_and_ending_identifiers";
 	public static final String DUPLICATE_COMPONENT_TYPE_NAME = "org.osate.xtext.aadl2.duplicate_component_type_names";
 	public static final String DUPLICATE_LITERAL_IN_ENUMERATION = "org.osate.xtext.aadl2.duplicate_literal_in_enumeration";
+	public static final String DUPLICATE_FIELD_IN_RECORD_TYPE = "org.osate.xtext.aadl2.duplicate_field_in_record_type";
 	public static final String UNIT_LITERAL_OUT_OF_ORDER = "org.osate.xtext.aadl2.unit_literal_out_of_order";
 	public static final String MODE_NOT_DEFINED_IN_CONTAINER = "org.osate.xtext.aadl2.mode_not_defined_in_container";
 	public static final String SELF_NOT_ALLOWED = "org.osate.xtext.aadl2.self_not_alllowed";
@@ -683,6 +684,15 @@ public class Aadl2Validator extends AbstractAadl2Validator {
 				error("Literal '" + ne.getName() + "' previously declared in enumeration", ne, null,
 						DUPLICATE_LITERAL_IN_ENUMERATION, ne.getName());
 			}
+		}
+	}
+
+	@Check(CheckType.FAST)
+	public void caseRecordType(final RecordType rt) {
+		EList<NamedElement> doubles = AadlUtil.findDoubleNamedElementsInList(rt.getOwnedFields());
+		for (NamedElement ne : doubles) {
+			error("Field '" + ne.getName() + "' previously declared in record type", ne, null,
+					DUPLICATE_FIELD_IN_RECORD_TYPE, ne.getName());
 		}
 	}
 


### PR DESCRIPTION
Fixes #2733

## Cause

Record fields share a namespace within a record type, but Aadl2Validator did not run duplicate-name validation over RecordType owned fields. Repeated field declarations therefore produced no diagnostic.

## Correction

- Add a FAST RecordType validation check using the existing case-insensitive duplicate-name utility.
- Report an error on every field that repeats an earlier declaration.
- Add a dedicated duplicate-field diagnostic identifier.

## Regression

Issue2733.aadl contains a valid record and a record that declares field three times. Issue2733Test asserts exactly two errors and verifies that each diagnostic is attached directly to the repeated field.

Before the fix, the focused test ran once and failed with expected 2 but was 0.

## Validation

- Focused offline Issue2733Test: 1 test, 0 failures, 0 errors.
- Related offline PropertiesJavaValidatorTest: 12 tests, 0 failures, 0 errors.
- Clean offline root-reactor install with local artifacts ignored: all 137 projects succeeded; 1,446 tests, 0 failures, 0 errors, 0 skipped.

## Dependencies

None.

## Residual risk

The check follows the existing case-insensitive duplicate-name behavior and reports only declarations after the first. It does not change the grammar, metamodel, or record value validation.