### PR TITLE
Declare Safety Tutorial classifier substitution rules 🤖

### DIFF
--- a/core/org.osate.core.tests/models/issue2805/.gitignore
+++ b/core/org.osate.core.tests/models/issue2805/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue2805/.project
+++ b/core/org.osate.core.tests/models/issue2805/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue2805</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue2805/Issue2805.aadl
+++ b/core/org.osate.core.tests/models/issue2805/Issue2805.aadl
@@ -46,16 +46,19 @@ public
 
 	system implementation GPS.BasicRedundancy extends GPS.basic
 		subcomponents
-			processing: refined to process GPSProcessing_redundancy;
+			processing: refined to process GPSProcessing_redundancy
+				{Classifier_Substitution_Rule => Type_Extension;};
 	end GPS.BasicRedundancy;
 
 	system implementation GPS.BasicState extends GPS.basic
 		subcomponents
-			processing: refined to process GPSProcessing_redundancyState;
+			processing: refined to process GPSProcessing_redundancyState
+				{Classifier_Substitution_Rule => Type_Extension;};
 	end GPS.BasicState;
 
 	system implementation GPS.computeerror extends GPS.basic
 		subcomponents
-			processing: refined to process GPSProcessing_computeError;
+			processing: refined to process GPSProcessing_computeError
+				{Classifier_Substitution_Rule => Type_Extension;};
 	end GPS.computeerror;
 end Issue2805;

--- a/core/org.osate.core.tests/models/issue2805/Issue2805.aadl
+++ b/core/org.osate.core.tests/models/issue2805/Issue2805.aadl
@@ -1,0 +1,61 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to their Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+package Issue2805
+public
+	abstract GPSProcessing
+	end GPSProcessing;
+
+	abstract GPSProcessing_redundancy extends GPSProcessing
+	end GPSProcessing_redundancy;
+
+	abstract GPSProcessing_redundancyState extends GPSProcessing
+	end GPSProcessing_redundancyState;
+
+	abstract GPSProcessing_computeError extends GPSProcessing
+	end GPSProcessing_computeError;
+
+	system GPS
+	end GPS;
+
+	system implementation GPS.basic
+		subcomponents
+			processing: process GPSProcessing;
+	end GPS.basic;
+
+	system implementation GPS.BasicRedundancy extends GPS.basic
+		subcomponents
+			processing: refined to process GPSProcessing_redundancy;
+	end GPS.BasicRedundancy;
+
+	system implementation GPS.BasicState extends GPS.basic
+		subcomponents
+			processing: refined to process GPSProcessing_redundancyState;
+	end GPS.BasicState;
+
+	system implementation GPS.computeerror extends GPS.basic
+		subcomponents
+			processing: refined to process GPSProcessing_computeError;
+	end GPS.computeerror;
+end Issue2805;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2805Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2805Test.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to the Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.EnumerationLiteral;
+import org.osate.aadl2.NamedValue;
+import org.osate.aadl2.SystemImplementation;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * Checks the classifier substitutions reported by issue #2805. The current predeclared-property
+ * default can suppress the original warnings, so the regression requires each refined processing
+ * subcomponent to declare the intended Type_Extension rule explicitly.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue2805Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue2805/Issue2805.aadl";
+	private static final List<String> REFINED_IMPLEMENTATIONS = List.of("GPS.BasicRedundancy", "GPS.BasicState",
+			"GPS.computeerror");
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void refinedProcessingClassifiersDeclareTypeExtension() {
+		var pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+
+		for (var implementationName : REFINED_IMPLEMENTATIONS) {
+			var implementation = (SystemImplementation) pkg.getOwnedPublicSection()
+					.getOwnedClassifiers()
+					.stream()
+					.filter(classifier -> classifier.getName().equals(implementationName))
+					.findFirst()
+					.orElseThrow();
+			var processing = implementation.getOwnedSubcomponents()
+					.stream()
+					.filter(subcomponent -> subcomponent.getName().equals("processing"))
+					.findFirst()
+					.orElseThrow();
+			var substitutionRules = processing.getOwnedPropertyAssociations()
+					.stream()
+					.filter(association -> association.getProperty().getName().equals("Classifier_Substitution_Rule"))
+					.toList();
+
+			assertEquals(implementationName, 1, substitutionRules.size());
+			var value = substitutionRules.getFirst().getOwnedValues().getFirst().getOwnedValue();
+			assertTrue(implementationName, value instanceof NamedValue);
+			var literal = ((NamedValue) value).getNamedValue();
+			assertTrue(implementationName, literal instanceof EnumerationLiteral);
+			assertEquals(implementationName, "Type_Extension", ((EnumerationLiteral) literal).getName());
+		}
+	}
+}

--- a/examples/org.osate.examples/examples/safety-tutorial/packages/GPSSystem.aadl
+++ b/examples/org.osate.examples/examples/safety-tutorial/packages/GPSSystem.aadl
@@ -164,20 +164,23 @@ public
 	-- Now with the GPSProcessing specification that includes the redundancy logic for the sensor inputs.
 	system implementation GPS.BasicRedundancy extends GPS.Basic
 		subcomponents
-			processing: refined to process GPSParts::GPSProcessing_redundancy;
+			processing: refined to process GPSParts::GPSProcessing_redundancy
+				{Classifier_Substitution_Rule => Type_Extension;};
 	end GPS.BasicRedundancy;
 
 	-- here with the GPSProcessing specification that includes the redundancy logic for the sensor inputs via an error state.
 	-- Should produce the same fault tree as BasicRedundancy
 	system implementation GPS.BasicState extends GPS.basic
 		subcomponents
-			processing: refined to process GPSParts::GPSProcessing_redundancyState;
+			processing: refined to process GPSParts::GPSProcessing_redundancyState
+				{Classifier_Substitution_Rule => Type_Extension;};
 	end GPS.BasicState;
 
 	-- In this configuration we include software errors as compute errors that result in
 	system implementation GPS.computeerror extends GPS.basic
 		subcomponents
-			processing: refined to process GPSParts::GPSProcessing_computeError;
+			processing: refined to process GPSParts::GPSProcessing_computeError
+				{Classifier_Substitution_Rule => Type_Extension;};
 		annex EMV2 {**
 			component error behavior
 				-- mapping of GPS producing GPS output to the GPS out propagation


### PR DESCRIPTION
Fixes #2805

## Cause and correction

The three refined GPS processing subcomponents in the Safety Tutorial omitted `Classifier_Substitution_Rule`. The current predeclared-property default is `Type_Extension`, so the historical warnings are no longer emitted, but the example still depended on that default instead of recording its intended classifier relationship.

This change declares `Type_Extension` explicitly on `GPS.BasicRedundancy`, `GPS.BasicState`, and `GPS.computeerror`.

## Regression

- Adds `Issue2805Test` under `core/org.osate.core.tests` with a separate `models/issue2805` OSATE project.
- Confirms all three refined processing subcomponents own exactly one `Classifier_Substitution_Rule` association whose value is `Type_Extension`.
- The regression failed before the fix with `GPS.BasicRedundancy expected:<1> but was:<0>`.

## Validation

- Focused offline test: `mvn -o -s releng/osate.releng/settings.xml -Plocal -pl :org.osate.core.tests -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -Dtest=Issue2805Test -DfailIfNoTests=false clean verify`
  - 1 test, 0 failures, 0 errors, 0 skipped
- Clean offline root reactor: `mvn -o -s releng/osate.releng/settings.xml -Plocal -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -DfailIfNoTests=false clean install`
  - `BUILD SUCCESS` across 137 projects
  - 1,446 tests, 0 failures, 0 errors, 0 skipped

## Dependencies

None.

## Residual risk

Low. The production change is limited to three AADL property associations in the tutorial example; the regression validates the same refinement shape in the core test suite.