### PR TITLE
Validate property constant declarations 🤖

### DIFF
--- a/core/org.osate.core.tests/models/issue2732/.gitignore
+++ b/core/org.osate.core.tests/models/issue2732/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue2732/.project
+++ b/core/org.osate.core.tests/models/issue2732/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue2732</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue2732/Issue2732.aadl
+++ b/core/org.osate.core.tests/models/issue2732/Issue2732.aadl
@@ -1,0 +1,40 @@
+property set Issue2732 is
+	with Issue2732Classifiers;
+
+	bool_property: aadlboolean applies to (all);
+
+	bool_record_type: type record (
+		field1: aadlboolean;
+		field2: aadlboolean;
+		field3: list of aadlboolean;
+	);
+
+	direct_property: constant aadlboolean => Issue2732::bool_property;
+	list_property: constant list of aadlboolean => (true, false, Issue2732::bool_property);
+	record_property: constant Issue2732::bool_record_type => [
+		field1 => true;
+		field2 => Issue2732::bool_property;
+		field3 => (true, false, Issue2732::bool_property);
+	];
+
+	property_source: constant aadlboolean => Issue2732::bool_property;
+	indirect_property: constant aadlboolean => Issue2732::property_source;
+	double_indirect_property: constant aadlboolean => Issue2732::indirect_property;
+
+	classifier_type: type classifier;
+	reference_type: type reference;
+	compound_type: type record (
+		classifier_field: Issue2732::classifier_type;
+		reference_field: Issue2732::reference_type;
+	);
+
+	reference_property: Issue2732::reference_type applies to (all);
+	compound_property: Issue2732::compound_type applies to (all);
+
+	classifier_constant: constant Issue2732::classifier_type =>
+		classifier (Issue2732Classifiers::Payload);
+	classifier_list_constant: constant list of Issue2732::classifier_type =>
+		(classifier (Issue2732Classifiers::Payload), classifier (Issue2732Classifiers::Payload));
+	reference_type_constant: constant Issue2732::reference_type => Issue2732::reference_property;
+	compound_type_constant: constant Issue2732::compound_type => Issue2732::compound_property;
+end Issue2732;

--- a/core/org.osate.core.tests/models/issue2732/Issue2732Classifiers.aadl
+++ b/core/org.osate.core.tests/models/issue2732/Issue2732Classifiers.aadl
@@ -1,0 +1,5 @@
+package Issue2732Classifiers
+public
+	data Payload
+	end Payload;
+end Issue2732Classifiers;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue1366Test.xtend
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue1366Test.xtend
@@ -44,6 +44,10 @@ class Issue1366Test extends XtextTest {
 	val static PROJECT_LOCATION = "org.osate.core.tests/models/issue1366/"
 	val static PACKAGE = PROJECT_LOCATION + "Issue1366.aadl"
 	val static PROPERTY_SET = PROJECT_LOCATION + "PS1.aadl"
+	val static PROPERTY_REFERENCE_ERROR = "Property constant expressions may not directly or indirectly reference " +
+		"properties, classifiers, or model elements"
+	val static TYPE_ERROR = "Property constants may not have classifier or reference property types, including within " +
+		"lists or records"
 
 	@Inject
 	TestHelper<AadlPackage> testHelper
@@ -80,6 +84,12 @@ class Issue1366Test extends XtextTest {
 
 		testFileResult.resource.contents.head as PropertySet => [
 			"PS1".assertEquals(name)
+			ownedPropertyConstants.get(1) => [
+				assertError(testFileResult.issues, issueCollection, TYPE_ERROR)
+				constantValue => [
+					assertError(testFileResult.issues, issueCollection, PROPERTY_REFERENCE_ERROR)
+				]
+			]
 			ownedPropertyConstants.get(2).constantValue => [
 				assertError(testFileResult.issues, issueCollection, "Number value is missing a unit")
 			]

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2732Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2732Test.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.eclipse.xtext.xbase.lib.CollectionLiterals.newArrayList;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ClassifierValue;
+import org.osate.aadl2.ListValue;
+import org.osate.aadl2.NamedValue;
+import org.osate.aadl2.PropertyConstant;
+import org.osate.aadl2.PropertySet;
+import org.osate.aadl2.RecordValue;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.AssertHelper;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.FluentIssueCollection;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * Tests the property-constant legality rules from issue #2732 and saeaadl/aadlv2.2#37. Property constants
+ * have no model-element context, so their expressions must not directly or indirectly reference properties,
+ * classifiers, or model elements, and their types must not contain classifier or reference types.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue2732Test extends XtextTest {
+	private static final String MODEL_DIR = "org.osate.core.tests/models/issue2732/";
+	private static final String PROPERTY_REFERENCE_ERROR = "Property constant expressions may not directly or indirectly "
+			+ "reference properties, classifiers, or model elements";
+	private static final String TYPE_ERROR = "Property constants may not have classifier or reference property types, "
+			+ "including within lists or records";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Test
+	public void propertyConstantLegalityIsValidated() throws Exception {
+		var result = validate();
+		var expected = emptyExpectedIssues(result);
+		var propertySet = propertySet(result);
+
+		assertPropertyReferences(propertySet, result, expected);
+		assertIndirectReferences(propertySet, result, expected);
+		assertClassifierReferences(propertySet, result, expected);
+		assertProhibitedTypes(propertySet, result, expected);
+
+		expected.sizeIs(result.getIssues().size());
+		assertConstraints(expected);
+	}
+
+	private static void assertPropertyReferences(PropertySet propertySet, FluentIssueCollection result,
+			FluentIssueCollection expected) {
+		AssertHelper.assertError(constant(propertySet, "direct_property").getConstantValue(), result.getIssues(),
+				expected, PROPERTY_REFERENCE_ERROR);
+
+		var list = (ListValue) constant(propertySet, "list_property").getConstantValue();
+		AssertHelper.assertError(list.getOwnedListElements().get(2), result.getIssues(), expected,
+				PROPERTY_REFERENCE_ERROR);
+
+		var record = (RecordValue) constant(propertySet, "record_property").getConstantValue();
+		AssertHelper.assertError(record.getOwnedFieldValues().get(1).getOwnedValue(), result.getIssues(), expected,
+				PROPERTY_REFERENCE_ERROR);
+		var nestedList = (ListValue) record.getOwnedFieldValues().get(2).getOwnedValue();
+		AssertHelper.assertError(nestedList.getOwnedListElements().get(2), result.getIssues(), expected,
+				PROPERTY_REFERENCE_ERROR);
+	}
+
+	private static void assertIndirectReferences(PropertySet propertySet, FluentIssueCollection result,
+			FluentIssueCollection expected) {
+		AssertHelper.assertError(constant(propertySet, "property_source").getConstantValue(), result.getIssues(),
+				expected, PROPERTY_REFERENCE_ERROR);
+		AssertHelper.assertError(constant(propertySet, "indirect_property").getConstantValue(), result.getIssues(),
+				expected, PROPERTY_REFERENCE_ERROR);
+		AssertHelper.assertError(constant(propertySet, "double_indirect_property").getConstantValue(),
+				result.getIssues(), expected, PROPERTY_REFERENCE_ERROR);
+	}
+
+	private static void assertClassifierReferences(PropertySet propertySet, FluentIssueCollection result,
+			FluentIssueCollection expected) {
+		var direct = constant(propertySet, "classifier_constant");
+		AssertHelper.assertError(direct, result.getIssues(), expected, TYPE_ERROR);
+		AssertHelper.assertError((ClassifierValue) direct.getConstantValue(), result.getIssues(), expected,
+				PROPERTY_REFERENCE_ERROR);
+
+		var listConstant = constant(propertySet, "classifier_list_constant");
+		AssertHelper.assertError(listConstant, result.getIssues(), expected, TYPE_ERROR);
+		var values = (ListValue) listConstant.getConstantValue();
+		AssertHelper.assertError(values.getOwnedListElements().get(0), result.getIssues(), expected,
+				PROPERTY_REFERENCE_ERROR);
+		AssertHelper.assertError(values.getOwnedListElements().get(1), result.getIssues(), expected,
+				PROPERTY_REFERENCE_ERROR);
+	}
+
+	private static void assertProhibitedTypes(PropertySet propertySet, FluentIssueCollection result,
+			FluentIssueCollection expected) {
+		var reference = constant(propertySet, "reference_type_constant");
+		AssertHelper.assertError(reference, result.getIssues(), expected, TYPE_ERROR);
+		AssertHelper.assertError((NamedValue) reference.getConstantValue(), result.getIssues(), expected,
+				PROPERTY_REFERENCE_ERROR);
+
+		var compound = constant(propertySet, "compound_type_constant");
+		AssertHelper.assertError(compound, result.getIssues(), expected, TYPE_ERROR);
+		AssertHelper.assertError((NamedValue) compound.getConstantValue(), result.getIssues(), expected,
+				PROPERTY_REFERENCE_ERROR);
+	}
+
+	private FluentIssueCollection validate() throws Exception {
+		return issues = testHelper.testFile(MODEL_DIR + "Issue2732.aadl",
+				MODEL_DIR + "Issue2732Classifiers.aadl");
+	}
+
+	private static FluentIssueCollection emptyExpectedIssues(FluentIssueCollection result) {
+		return new FluentIssueCollection(result.getResource(), newArrayList(), newArrayList());
+	}
+
+	private static PropertySet propertySet(FluentIssueCollection result) {
+		return (PropertySet) result.getResource().getContents().get(0);
+	}
+
+	private static PropertyConstant constant(PropertySet propertySet, String name) {
+		return propertySet.getOwnedPropertyConstants()
+				.stream()
+				.filter(constant -> name.equals(constant.getName()))
+				.findFirst()
+				.orElseThrow();
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/propertiesjavavalidator/Issue2222Test.xtend
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/propertiesjavavalidator/Issue2222Test.xtend
@@ -45,6 +45,8 @@ class Issue2222Test extends XtextTest {
 	val static PROJECT_LOCATION = "org.osate.core.tests/models/Issue2222/"
 	val static PACKAGE = PROJECT_LOCATION + "P.aadl"
 	val static PROPERTY_SET = PROJECT_LOCATION + "Props.aadl"
+	val static PROPERTY_REFERENCE_ERROR = "Property constant expressions may not directly or indirectly reference " +
+		"properties, classifiers, or model elements"
 
 	@Inject
 	TestHelper<AadlPackage> testHelper
@@ -194,11 +196,21 @@ class Issue2222Test extends XtextTest {
 				]
 			]
 
+			ownedPropertyConstants.findFirst[name == "GoodPropRefConstant1"].constantValue => [
+				assertError(testFileResult.issues, issueCollection, PROPERTY_REFERENCE_ERROR)
+			]
+			ownedPropertyConstants.findFirst[name == "GoodPropRefConstant2"].constantValue => [
+				assertError(testFileResult.issues, issueCollection, PROPERTY_REFERENCE_ERROR)
+			]
 			ownedPropertyConstants.findFirst[name == "BadPropRefConstant1"].constantValue => [
-				assertError(testFileResult.issues, issueCollection, "Property value of type Props::RecordType2; expected type Props::RecordType1");
+				assertError(testFileResult.issues, issueCollection,
+					"Property value of type Props::RecordType2; expected type Props::RecordType1",
+					PROPERTY_REFERENCE_ERROR)
 			]
 			ownedPropertyConstants.findFirst[name == "BadPropRefConstant2"].constantValue => [
-				assertError(testFileResult.issues, issueCollection, "Property value of type Props::RecordType1; expected type Props::RecordType2");
+				assertError(testFileResult.issues, issueCollection,
+					"Property value of type Props::RecordType1; expected type Props::RecordType2",
+					PROPERTY_REFERENCE_ERROR)
 			]
 
 			ownedProperties.findFirst[name == "BadPropRefDefault1"].defaultValue => [
@@ -208,11 +220,31 @@ class Issue2222Test extends XtextTest {
 				assertError(testFileResult.issues, issueCollection, "Property value of type Props::RecordType1; expected type Props::RecordType2");
 			]
 
-			(ownedPropertyConstants.findFirst[name == "BadListOfPropRefConstant1"].constantValue as ListValue).ownedListElements.get(1) => [
-				assertError(testFileResult.issues, issueCollection, "Property value of type Props::RecordType2; expected type Props::RecordType1");
+			(ownedPropertyConstants.findFirst[name == "GoodListOfPropRefConstant1"].constantValue as ListValue).ownedListElements.get(0) => [
+				assertError(testFileResult.issues, issueCollection, PROPERTY_REFERENCE_ERROR)
 			]
-			(ownedPropertyConstants.findFirst[name == "BadListOfPropRefConstant2"].constantValue as ListValue).ownedListElements.get(0) => [
-				assertError(testFileResult.issues, issueCollection, "Property value of type Props::RecordType1; expected type Props::RecordType2");
+			(ownedPropertyConstants.findFirst[name == "GoodListOfPropRefConstant2"].constantValue as ListValue).ownedListElements.get(0) => [
+				assertError(testFileResult.issues, issueCollection, PROPERTY_REFERENCE_ERROR)
+			]
+
+			val badListConstant1 = ownedPropertyConstants.findFirst[name == "BadListOfPropRefConstant1"].constantValue as ListValue
+			badListConstant1.ownedListElements.get(0) => [
+				assertError(testFileResult.issues, issueCollection, PROPERTY_REFERENCE_ERROR)
+			]
+			badListConstant1.ownedListElements.get(1) => [
+				assertError(testFileResult.issues, issueCollection,
+					"Property value of type Props::RecordType2; expected type Props::RecordType1",
+					PROPERTY_REFERENCE_ERROR)
+			]
+
+			val badListConstant2 = ownedPropertyConstants.findFirst[name == "BadListOfPropRefConstant2"].constantValue as ListValue
+			badListConstant2.ownedListElements.get(0) => [
+				assertError(testFileResult.issues, issueCollection,
+					"Property value of type Props::RecordType1; expected type Props::RecordType2",
+					PROPERTY_REFERENCE_ERROR)
+			]
+			badListConstant2.ownedListElements.get(1) => [
+				assertError(testFileResult.issues, issueCollection, PROPERTY_REFERENCE_ERROR)
 			]
 			
 			(ownedProperties.findFirst[name == "BadListOfPropRefDefault1"].defaultValue as ListValue).ownedListElements.get(1) => [

--- a/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/validation/Aadl2Validator.java
+++ b/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/validation/Aadl2Validator.java
@@ -124,6 +124,14 @@ public class Aadl2Validator extends AbstractAadl2Validator {
 	public static final String MAKE_CONNECTION_BIDIRECTIONAL = "org.osate.xtext.aadl2.make_connection_bidirectional";
 	public static final String WITH_NOT_USED = "org.osate.xtext.aadl2.with_not_used";
 	public static final String DATA_SIZE_INCONSISTENT = "org.osate.xtext.aadl2.data_size_inconsistent";
+	public static final String INVALID_PROPERTY_CONSTANT_EXPRESSION =
+			"org.osate.xtext.aadl2.invalid_property_constant_expression";
+	public static final String INVALID_PROPERTY_CONSTANT_TYPE = "org.osate.xtext.aadl2.invalid_property_constant_type";
+	private static final String INVALID_PROPERTY_CONSTANT_EXPRESSION_MESSAGE =
+			"Property constant expressions may not directly or indirectly reference properties, classifiers, "
+					+ "or model elements";
+	private static final String INVALID_PROPERTY_CONSTANT_TYPE_MESSAGE =
+			"Property constants may not have classifier or reference property types, including within lists or records";
 
 	@Inject
 	private Aadl2GrammarAccess grammarAccess;
@@ -7113,6 +7121,92 @@ public class Aadl2Validator extends AbstractAadl2Validator {
 		 */
 		typeCheckPropertyValues(pc.getPropertyType(), pc.getConstantValue(), pc.getConstantValue(),
 				pc.getQualifiedName(), 0);
+
+		if (containsClassifierOrReferenceType(pc.getPropertyType(), new HashSet<>())) {
+			error(INVALID_PROPERTY_CONSTANT_TYPE_MESSAGE, pc,
+					Aadl2Package.eINSTANCE.getPropertyConstant_PropertyType(), INVALID_PROPERTY_CONSTANT_TYPE);
+		}
+
+		checkPropertyConstantExpression(pc.getConstantValue());
+	}
+
+	private void checkPropertyConstantExpression(PropertyExpression expression) {
+		checkPropertyConstantExpressionNode(expression);
+
+		TreeIterator<EObject> contents = expression.eAllContents();
+		while (contents.hasNext()) {
+			EObject content = contents.next();
+			if (content instanceof PropertyExpression nestedExpression) {
+				checkPropertyConstantExpressionNode(nestedExpression);
+			}
+		}
+	}
+
+	private void checkPropertyConstantExpressionNode(PropertyExpression expression) {
+		if (expressionNodeReferencesForbiddenElement(expression, new HashSet<>())) {
+			error(INVALID_PROPERTY_CONSTANT_EXPRESSION_MESSAGE, expression, null,
+					INVALID_PROPERTY_CONSTANT_EXPRESSION);
+		}
+	}
+
+	private boolean namedValueReferencesForbiddenElement(NamedValue namedValue, Set<PropertyConstant> visited) {
+		AbstractNamedValue referencedValue = namedValue.getNamedValue();
+		if (referencedValue instanceof Property) {
+			return true;
+		}
+
+		if (referencedValue instanceof PropertyConstant propertyConstant && visited.add(propertyConstant)) {
+			return expressionReferencesForbiddenElement(propertyConstant.getConstantValue(), visited);
+		}
+
+		return false;
+	}
+
+	private boolean expressionReferencesForbiddenElement(PropertyExpression expression,
+			Set<PropertyConstant> visited) {
+		if (expressionNodeReferencesForbiddenElement(expression, visited)) {
+			return true;
+		}
+
+		TreeIterator<EObject> contents = expression.eAllContents();
+		while (contents.hasNext()) {
+			EObject content = contents.next();
+			if (content instanceof PropertyExpression nestedExpression
+					&& expressionNodeReferencesForbiddenElement(nestedExpression, visited)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean expressionNodeReferencesForbiddenElement(PropertyExpression expression,
+			Set<PropertyConstant> visited) {
+		return expression instanceof ClassifierValue || expression instanceof ReferenceValue
+				|| expression instanceof NamedValue namedValue
+						&& namedValueReferencesForbiddenElement(namedValue, visited);
+	}
+
+	private boolean containsClassifierOrReferenceType(PropertyType propertyType, Set<PropertyType> visited) {
+		if (propertyType == null || !visited.add(propertyType)) {
+			return false;
+		}
+
+		if (propertyType instanceof ClassifierType || propertyType instanceof ReferenceType) {
+			return true;
+		}
+
+		if (propertyType instanceof ListType listType) {
+			return containsClassifierOrReferenceType(listType.getElementType(), visited);
+		}
+
+		if (propertyType instanceof RecordType recordType) {
+			return recordType.getOwnedFields()
+					.stream()
+					.anyMatch(field -> containsClassifierOrReferenceType(field.getPropertyType(), visited));
+		}
+
+		return false;
 	}
 
 	//


### PR DESCRIPTION
Fixes #2732

## Cause and correction

`Aadl2Validator.checkPropertyConstant` only checked whether a constant value matched its declared property type. It did not enforce the property-constant legality rules, so constants could refer to properties or classifiers even though they have no model-element context.

This change keeps the production scope entirely in validation:

- reject property, classifier, and model-element references at the exact expression that contains them;
- follow references to other property constants so indirect illegal references are also reported;
- reject classifier and reference property types, including when nested in lists or record fields; and
- track visited constants and property types so recursive declarations cannot make validation loop.

No grammar, scoping, linking, metamodel, or property-evaluation behavior is changed.

## Standards scope

The regression covers the original property-reference examples from #2732 and the broader legality rules recorded in saeaadl/aadlv2.2#37, including indirect references and classifier/reference types.

## Regression coverage

`Issue2732Test` uses a separate AADL model project and checks:

- direct property references;
- property references nested in list and record values;
- indirect and doubly indirect references through other constants;
- classifier values, including values nested in a list; and
- classifier/reference types nested through named types, lists, and record fields.

The test asserts all 16 diagnostics at their specific expression or constant declaration. Existing issue #2222 and #1366 expectations are updated for constants that are newly and intentionally invalid.

## Validation

- Focused offline reactor with `-T6`:
  `mvn -o -T6 -s releng/osate.releng/settings.xml -Plocal -pl :org.osate.xtext.aadl2,:org.osate.core.tests,:org.osate.core.feature -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -Dtest=Issue2732Test,Issue2222Test,Issue1366Test -DfailIfNoTests=false clean install`
  - 5 tests, 0 failures, 0 errors, 0 skipped
- Clean root reactor with `-T6` and local artifacts ignored:
  `mvn -o -T6 -s releng/osate.releng/settings.xml -Plocal -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -DfailIfNoTests=false clean install`
  - 137 projects, 1,446 tests, 0 failures, 0 errors, 0 skipped

## Dependencies and residual risk

This PR is based directly on `master` and has no PR dependencies. Models that currently use property constants forbidden by the AADL legality rules will now receive validation errors; the affected in-repository characterization tests are included in this change.
