### PR TITLE
Expand array reference values 🤖

### DIFF
--- a/core/org.osate.aadl2/src/org/osate/aadl2/impl/ReferenceValueImpl.java
+++ b/core/org.osate.aadl2/src/org/osate/aadl2/impl/ReferenceValueImpl.java
@@ -29,7 +29,10 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.osate.aadl2.Aadl2Factory;
 import org.osate.aadl2.Aadl2Package;
+import org.osate.aadl2.ArrayableElement;
+import org.osate.aadl2.Feature;
 import org.osate.aadl2.ListValue;
+import org.osate.aadl2.NamedElement;
 import org.osate.aadl2.PropertyExpression;
 import org.osate.aadl2.ReferenceValue;
 import org.osate.aadl2.Subcomponent;
@@ -73,7 +76,7 @@ public class ReferenceValueImpl extends ContainedNamedElementImpl implements Ref
 		if (iol.size() == 0) {
 			// reference to a non-instantiated element, e.g., subprogram or call sequence
 			return null;
-		} else if (selectsMultipleSubcomponentArrayElements()) {
+		} else if (selectsMultipleArrayElements()) {
 			return createInstanceReferenceList(iol);
 		} else if (iol.size() > 1) {
 			throw new InvalidModelException(this, "Reference refers to more than one instance object");
@@ -86,7 +89,7 @@ public class ReferenceValueImpl extends ContainedNamedElementImpl implements Ref
 		final List<InstanceObject> iol = root.findInstanceObjects(getContainmentPathElements());
 		if (iol.size() == 0) {
 			throw new InvalidModelException(this, "Reference does not refer to a nested feature");
-		} else if (selectsMultipleSubcomponentArrayElements()) {
+		} else if (selectsMultipleArrayElements()) {
 			return createInstanceReferenceList(iol);
 		} else if (iol.size() > 1) {
 			throw new InvalidModelException(this, "Reference refers to more than one feature");
@@ -96,13 +99,14 @@ public class ReferenceValueImpl extends ContainedNamedElementImpl implements Ref
 	}
 
 	/**
-	 * A reference term evaluates to a list when any subcomponent-array path element denotes the whole
-	 * array or an array range rather than an individual indexed element.
+	 * A reference term evaluates to a list when any subcomponent- or feature-array path element
+	 * denotes the whole array or an array range rather than an individual indexed element.
 	 */
-	private boolean selectsMultipleSubcomponentArrayElements() {
+	private boolean selectsMultipleArrayElements() {
 		for (var pathElement : getContainmentPathElements()) {
-			if (pathElement.getNamedElement() instanceof Subcomponent subcomponent
-					&& !subcomponent.getArrayDimensions().isEmpty()) {
+			NamedElement namedElement = pathElement.getNamedElement();
+			if (isExpandableArrayElement(namedElement)
+					&& !((ArrayableElement) namedElement).getArrayDimensions().isEmpty()) {
 				if (pathElement.getArrayRanges().isEmpty()
 						|| pathElement.getArrayRanges().stream().anyMatch(range -> range.getUpperBound() != 0)) {
 					return true;
@@ -110,6 +114,10 @@ public class ReferenceValueImpl extends ContainedNamedElementImpl implements Ref
 			}
 		}
 		return false;
+	}
+
+	private static boolean isExpandableArrayElement(NamedElement namedElement) {
+		return namedElement instanceof Subcomponent || namedElement instanceof Feature;
 	}
 
 	/** Create one reference per selected instance object, preserving instance-model order. */

--- a/core/org.osate.aadl2/src/org/osate/aadl2/impl/ReferenceValueImpl.java
+++ b/core/org.osate.aadl2/src/org/osate/aadl2/impl/ReferenceValueImpl.java
@@ -27,9 +27,12 @@ import java.util.List;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.osate.aadl2.Aadl2Factory;
 import org.osate.aadl2.Aadl2Package;
+import org.osate.aadl2.ListValue;
 import org.osate.aadl2.PropertyExpression;
 import org.osate.aadl2.ReferenceValue;
+import org.osate.aadl2.Subcomponent;
 import org.osate.aadl2.instance.FeatureInstance;
 import org.osate.aadl2.instance.InstanceFactory;
 import org.osate.aadl2.instance.InstanceObject;
@@ -70,13 +73,12 @@ public class ReferenceValueImpl extends ContainedNamedElementImpl implements Ref
 		if (iol.size() == 0) {
 			// reference to a non-instantiated element, e.g., subprogram or call sequence
 			return null;
+		} else if (selectsMultipleSubcomponentArrayElements()) {
+			return createInstanceReferenceList(iol);
 		} else if (iol.size() > 1) {
 			throw new InvalidModelException(this, "Reference refers to more than one instance object");
 		} else {
-			final InstanceObject io = iol.get(0);
-			final InstanceReferenceValue irv = InstanceFactory.eINSTANCE.createInstanceReferenceValue();
-			irv.setReferencedInstanceObject(io);
-			return irv;
+			return createInstanceReference(iol.get(0));
 		}
 	}
 
@@ -84,14 +86,45 @@ public class ReferenceValueImpl extends ContainedNamedElementImpl implements Ref
 		final List<InstanceObject> iol = root.findInstanceObjects(getContainmentPathElements());
 		if (iol.size() == 0) {
 			throw new InvalidModelException(this, "Reference does not refer to a nested feature");
+		} else if (selectsMultipleSubcomponentArrayElements()) {
+			return createInstanceReferenceList(iol);
 		} else if (iol.size() > 1) {
 			throw new InvalidModelException(this, "Reference refers to more than one feature");
 		} else {
-			final InstanceObject io = iol.get(0);
-			final InstanceReferenceValue irv = InstanceFactory.eINSTANCE.createInstanceReferenceValue();
-			irv.setReferencedInstanceObject(io);
-			return irv;
+			return createInstanceReference(iol.get(0));
 		}
+	}
+
+	/**
+	 * A reference term evaluates to a list when any subcomponent-array path element denotes the whole
+	 * array or an array range rather than an individual indexed element.
+	 */
+	private boolean selectsMultipleSubcomponentArrayElements() {
+		for (var pathElement : getContainmentPathElements()) {
+			if (pathElement.getNamedElement() instanceof Subcomponent subcomponent
+					&& !subcomponent.getArrayDimensions().isEmpty()) {
+				if (pathElement.getArrayRanges().isEmpty()
+						|| pathElement.getArrayRanges().stream().anyMatch(range -> range.getUpperBound() != 0)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	/** Create one reference per selected instance object, preserving instance-model order. */
+	private static ListValue createInstanceReferenceList(List<InstanceObject> instanceObjects) {
+		final ListValue list = Aadl2Factory.eINSTANCE.createListValue();
+		for (final InstanceObject instanceObject : instanceObjects) {
+			list.getOwnedListElements().add(createInstanceReference(instanceObject));
+		}
+		return list;
+	}
+
+	private static InstanceReferenceValue createInstanceReference(InstanceObject instanceObject) {
+		final InstanceReferenceValue reference = InstanceFactory.eINSTANCE.createInstanceReferenceValue();
+		reference.setReferencedInstanceObject(instanceObject);
+		return reference;
 	}
 
 	// TODO: LW features can have reference properties too

--- a/core/org.osate.core.tests/models/issue1769/ps1.aadl
+++ b/core/org.osate.core.tests/models/issue1769/ps1.aadl
@@ -1,18 +1,18 @@
 property set ps1 is
 	const1: constant aadlinteger => 5;
-	def1: reference applies to (all);
+	def1: list of reference applies to (all);
 	def2: reference applies to (all);
-	def3: reference applies to (all);
+	def3: list of reference applies to (all);
 	def4: reference applies to (all);
 	def5: reference applies to (all);
 	def6: reference applies to (all);
 	def7: reference applies to (all);
 	def8: reference applies to (all);
 	def9: reference applies to (all);
-	def10: reference applies to (all);
-	def11: reference applies to (all);
-	def12: reference applies to (all);
-	def13: reference applies to (all);
+	def10: list of reference applies to (all);
+	def11: list of reference applies to (all);
+	def12: list of reference applies to (all);
+	def13: list of reference applies to (all);
 	def14: reference applies to (all);
-	def15: reference applies to (all);
+	def15: list of reference applies to (all);
 end ps1;

--- a/core/org.osate.core.tests/models/issue2159/ps1.aadl
+++ b/core/org.osate.core.tests/models/issue2159/ps1.aadl
@@ -1,5 +1,5 @@
 property set ps1 is
 	ref1: reference applies to (all);
-	ref2: reference applies to (all);
+	ref2: list of reference applies to (all);
 	str: aadlstring applies to (all);
 end ps1;

--- a/core/org.osate.core.tests/models/issue721/.gitignore
+++ b/core/org.osate.core.tests/models/issue721/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue721/.project
+++ b/core/org.osate.core.tests/models/issue721/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue721</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue721/Issue721.aadl
+++ b/core/org.osate.core.tests/models/issue721/Issue721.aadl
@@ -31,6 +31,14 @@ public
 			output: out event port;
 	end Worker;
 
+	system Container
+	end Container;
+
+	system implementation Container.with_inner_array
+		subcomponents
+			inner: system Worker[3];
+	end Container.with_inner_array;
+
 	system Top
 	end Top;
 
@@ -57,4 +65,44 @@ public
 		properties
 			Issue721Properties::Target => reference (workers[2]);
 	end Top.single_element;
+
+	-- A multidimensional array expands with the last dimension changing fastest.
+	system implementation Top.multidimensional_whole
+		subcomponents
+			grid: system Worker[2][3];
+		properties
+			Issue721Properties::Targets => reference (grid);
+	end Top.multidimensional_whole;
+
+	-- Fully indexing every dimension still denotes exactly one array element.
+	system implementation Top.multidimensional_single
+		subcomponents
+			grid: system Worker[2][3];
+		properties
+			Issue721Properties::Target => reference (grid[2][3]);
+	end Top.multidimensional_single;
+
+	-- Every non-single array path element contributes to the flat result list.
+	system implementation Top.nested_arrays
+		subcomponents
+			outer: system Container.with_inner_array [2];
+		properties
+			Issue721Properties::Targets => reference (outer.inner);
+	end Top.nested_arrays;
+
+	-- Indexing the outer array limits expansion to the inner array of one outer element.
+	system implementation Top.indexed_outer_array
+		subcomponents
+			outer: system Container.with_inner_array [2];
+		properties
+			Issue721Properties::Targets => reference (outer[2].inner);
+	end Top.indexed_outer_array;
+
+	-- Indexing the inner array leaves one selected element under every outer array element.
+	system implementation Top.indexed_inner_array
+		subcomponents
+			outer: system Container.with_inner_array [2];
+		properties
+			Issue721Properties::Targets => reference (outer.inner[2]);
+	end Top.indexed_inner_array;
 end Issue721;

--- a/core/org.osate.core.tests/models/issue721/Issue721.aadl
+++ b/core/org.osate.core.tests/models/issue721/Issue721.aadl
@@ -1,0 +1,60 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to the Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+package Issue721
+public
+	with Issue721Properties;
+
+	system Worker
+		features
+			output: out event port;
+	end Worker;
+
+	system Top
+	end Top;
+
+	-- An unindexed array identifier denotes every array element.
+	system implementation Top.whole_array
+		subcomponents
+			workers: system Worker[3];
+		properties
+			Issue721Properties::Targets => reference (workers);
+	end Top.whole_array;
+
+	-- Expansion must continue along the rest of the contained model element path.
+	system implementation Top.nested_path
+		subcomponents
+			workers: system Worker[3];
+		properties
+			Issue721Properties::Feature_Targets => reference (workers.output);
+	end Top.nested_path;
+
+	-- A path that selects one array element must remain a single reference.
+	system implementation Top.single_element
+		subcomponents
+			workers: system Worker[3];
+		properties
+			Issue721Properties::Target => reference (workers[2]);
+	end Top.single_element;
+end Issue721;

--- a/core/org.osate.core.tests/models/issue721/Issue721.aadl
+++ b/core/org.osate.core.tests/models/issue721/Issue721.aadl
@@ -39,6 +39,18 @@ public
 			inner: system Worker[3];
 	end Container.with_inner_array;
 
+	system FeatureArrayComponent
+		features
+			ports: out event port [4];
+		properties
+			Issue721Properties::Feature_Targets => reference (ports);
+			Issue721Properties::Feature_Range_Targets => reference (ports[2 .. 3]);
+			Issue721Properties::Feature_Target => reference (ports[2]);
+	end FeatureArrayComponent;
+
+	system implementation FeatureArrayComponent.i
+	end FeatureArrayComponent.i;
+
 	system Top
 	end Top;
 
@@ -105,4 +117,20 @@ public
 		properties
 			Issue721Properties::Targets => reference (outer.inner[2]);
 	end Top.indexed_inner_array;
+
+	-- A feature array can be a later path element below a scalar subcomponent.
+	system implementation Top.feature_array_path
+		subcomponents
+			worker: system FeatureArrayComponent;
+		properties
+			Issue721Properties::Feature_Targets => reference (worker.ports);
+	end Top.feature_array_path;
+
+	-- Subcomponent-array and feature-array selections combine into one flat Cartesian result.
+	system implementation Top.subcomponent_and_feature_arrays
+		subcomponents
+			workers: system FeatureArrayComponent[2];
+		properties
+			Issue721Properties::Feature_Targets => reference (workers.ports);
+	end Top.subcomponent_and_feature_arrays;
 end Issue721;

--- a/core/org.osate.core.tests/models/issue721/Issue721Invalid.aadl
+++ b/core/org.osate.core.tests/models/issue721/Issue721Invalid.aadl
@@ -1,0 +1,44 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to the Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+package Issue721Invalid
+public
+	with Issue721Properties;
+
+	system Worker
+	end Worker;
+
+	system Top
+	end Top;
+
+	system implementation Top.invalid
+		subcomponents
+			workers: system Worker[3];
+		properties
+			-- A multi-element reference cannot be assigned to a scalar reference property.
+			Issue721Properties::Scalar_Target => reference (workers);
+			-- Every selected element must satisfy the list element's reference type.
+			Issue721Properties::Wrong_Targets => reference (workers);
+	end Top.invalid;
+end Issue721Invalid;

--- a/core/org.osate.core.tests/models/issue721/Issue721Properties.aadl
+++ b/core/org.osate.core.tests/models/issue721/Issue721Properties.aadl
@@ -25,6 +25,8 @@
 property set Issue721Properties is
 	Targets: list of reference (subcomponent) applies to (all);
 	Feature_Targets: list of reference (feature) applies to (all);
+	Feature_Range_Targets: list of reference (feature) applies to (all);
+	Feature_Target: reference (feature) applies to (all);
 	Target: reference (subcomponent) applies to (all);
 	Scalar_Target: reference (subcomponent) applies to (all);
 	Wrong_Targets: list of reference (feature) applies to (all);

--- a/core/org.osate.core.tests/models/issue721/Issue721Properties.aadl
+++ b/core/org.osate.core.tests/models/issue721/Issue721Properties.aadl
@@ -1,0 +1,31 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to the Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+property set Issue721Properties is
+	Targets: list of reference (subcomponent) applies to (all);
+	Feature_Targets: list of reference (feature) applies to (all);
+	Target: reference (subcomponent) applies to (all);
+	Scalar_Target: reference (subcomponent) applies to (all);
+	Wrong_Targets: list of reference (feature) applies to (all);
+end Issue721Properties;

--- a/core/org.osate.core.tests/models/issue721/Issue721Range.aadl
+++ b/core/org.osate.core.tests/models/issue721/Issue721Range.aadl
@@ -39,4 +39,12 @@ public
 		properties
 			Issue721Properties::Targets => reference (workers[2 .. 3]);
 	end Top.selected_range;
+
+	-- Ranges in more than one dimension select the Cartesian product of their bounds.
+	system implementation Top.multidimensional_range
+		subcomponents
+			grid: system Worker[3][4];
+		properties
+			Issue721Properties::Targets => reference (grid[2 .. 3][1 .. 2]);
+	end Top.multidimensional_range;
 end Issue721Range;

--- a/core/org.osate.core.tests/models/issue721/Issue721Range.aadl
+++ b/core/org.osate.core.tests/models/issue721/Issue721Range.aadl
@@ -1,0 +1,42 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+-- All Rights Reserved.
+--
+-- NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+-- KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+-- OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+-- MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+--
+-- This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+--
+-- This program includes and/or can make use of certain third party source code, object code, documentation and other
+-- files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+-- configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+-- conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+-- Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries
+-- to this license with respect to the terms applicable to the Third Party Software. Third Party Software licenses
+-- only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+-------------------------------------------------------------------------------
+
+package Issue721Range
+public
+	with Issue721Properties;
+
+	system Worker
+	end Worker;
+
+	system Top
+	end Top;
+
+	-- A range denotes every element within its bounds and is a valid reference expression.
+	system implementation Top.selected_range
+		subcomponents
+			workers: system Worker[3];
+		properties
+			Issue721Properties::Targets => reference (workers[2 .. 3]);
+	end Top.selected_range;
+end Issue721Range;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue1769Test.xtend
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue1769Test.xtend
@@ -38,7 +38,6 @@ import org.osate.testsupport.TestHelper
 
 import static extension org.junit.Assert.assertEquals
 import static extension org.osate.testsupport.AssertHelper.assertError
-import static extension org.osate.testsupport.AssertHelper.assertWarning
 
 @RunWith(XtextRunner)
 @InjectWith(Aadl2InjectorProvider)
@@ -58,11 +57,6 @@ class Issue1769Test extends XtextTest {
 				"s1.i".assertEquals(name)
 				ownedPropertyAssociations.get(2) => [
 					"def3".assertEquals(property.name)
-					(ownedValues.head.ownedValue as ReferenceValue).path.arrayRanges.head => [
-						assertWarning(testFileResult.issues, issueCollection,
-							"Array ranges in reference values are not property instantiated"
-						)
-					]
 				]
 				ownedPropertyAssociations.get(3) => [
 					"def4".assertEquals(property.name)
@@ -104,18 +98,12 @@ class Issue1769Test extends XtextTest {
 					"def10".assertEquals(property.name)
 					(ownedValues.head.ownedValue as ReferenceValue).path.arrayRanges.head => [
 						assertError(testFileResult.issues, issueCollection, "Array indices start at 1")
-						assertWarning(testFileResult.issues, issueCollection,
-							"Array ranges in reference values are not property instantiated"
-						)
 					]
 				]
 				ownedPropertyAssociations.get(10) => [
 					"def11".assertEquals(property.name)
 					(ownedValues.head.ownedValue as ReferenceValue).path.arrayRanges.head => [
 						assertError(testFileResult.issues, issueCollection, "Upper bound is greater than array size 5")
-						assertWarning(testFileResult.issues, issueCollection,
-							"Array ranges in reference values are not property instantiated"
-						)
 					]
 				]
 				ownedPropertyAssociations.get(11) => [
@@ -125,18 +113,12 @@ class Issue1769Test extends XtextTest {
 							"Array indices start at 1",
 							"Upper bound is greater than array size 5"
 						)
-						assertWarning(testFileResult.issues, issueCollection,
-							"Array ranges in reference values are not property instantiated"
-						)
 					]
 				]
 				ownedPropertyAssociations.get(12) => [
 					"def13".assertEquals(property.name)
 					(ownedValues.head.ownedValue as ReferenceValue).path.arrayRanges.head => [
 						assertError(testFileResult.issues, issueCollection, "Range lower bound is greater than upper bound")
-						assertWarning(testFileResult.issues, issueCollection,
-							"Array ranges in reference values are not property instantiated"
-						)
 					]
 				]
 				ownedPropertyAssociations.get(13) => [
@@ -149,9 +131,6 @@ class Issue1769Test extends XtextTest {
 					"def15".assertEquals(property.name)
 					(ownedValues.head.ownedValue as ReferenceValue).path.arrayRanges.head => [
 						assertError(testFileResult.issues, issueCollection, "Upper bound is greater than array size 5")
-						assertWarning(testFileResult.issues, issueCollection,
-							"Array ranges in reference values are not property instantiated"
-						)
 					]
 				]
 			]

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2159Test.xtend
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2159Test.xtend
@@ -37,7 +37,6 @@ import org.osate.testsupport.TestHelper
 
 import static extension org.junit.Assert.assertEquals
 import static extension org.osate.testsupport.AssertHelper.assertError
-import static extension org.osate.testsupport.AssertHelper.assertWarning
 
 @RunWith(XtextRunner)
 @InjectWith(Aadl2InjectorProvider)
@@ -62,13 +61,6 @@ class Issue2159Test extends XtextTest {
 				ownedPropertyAssociations.get(0) => [
 					(ownedValues.head.ownedValue as ReferenceValue).path.arrayRanges.head => [
 						assertError(testFileResult.issues, issueCollection, "'f1' does not have an array size")
-					]
-				]
-				ownedPropertyAssociations.get(1) => [
-					(ownedValues.head.ownedValue as ReferenceValue).path.arrayRanges.head => [
-						assertWarning(testFileResult.issues, issueCollection,
-							"Array ranges in reference values are not property instantiated"
-						)
 					]
 				]
 				ownedPropertyAssociations.get(2) => [

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue721Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue721Test.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to the Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.ListValue;
+import org.osate.aadl2.PropertyExpression;
+import org.osate.aadl2.ReferenceValue;
+import org.osate.aadl2.instance.InstanceObject;
+import org.osate.aadl2.instance.InstanceReferenceValue;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter.Message;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.AssertHelper;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.FluentIssueCollection;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * A reference term that selects more than one element of a subcomponent array must cache a list of
+ * instance references. Issue #721 left the declarative reference in place and reported an
+ * instantiation error because reference instantiation rejected every path with multiple matches.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue721Test extends XtextTest {
+	private static final String PROJECT = "org.osate.core.tests/models/issue721/";
+	private static final String MODEL = PROJECT + "Issue721.aadl";
+	private static final String RANGE_MODEL = PROJECT + "Issue721Range.aadl";
+	private static final String INVALID_MODEL = PROJECT + "Issue721Invalid.aadl";
+	private static final String PROPERTIES = PROJECT + "Issue721Properties.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	/** An unindexed array expands to one reference per element, in array order. */
+	@Test
+	public void wholeArrayReferenceExpandsToList() throws Exception {
+		var result = instantiate(MODEL, "Top.whole_array");
+
+		assertEquals(List.of(), result.errors());
+		assertEquals(List.of("workers[1]", "workers[2]", "workers[3]"), referencedPaths(result, "Targets"));
+	}
+
+	/** A range expands to the elements within its bounds and produces no obsolete validation warning. */
+	@Test
+	public void arrayRangeReferenceExpandsToList() throws Exception {
+		var result = instantiate(RANGE_MODEL, "Top.selected_range");
+
+		assertEquals(List.of(), result.errors());
+		assertEquals(List.of("workers[2]", "workers[3]"), referencedPaths(result, "Targets"));
+	}
+
+	/** The remainder of the path is resolved separately below every selected array element. */
+	@Test
+	public void pathContinuesThroughEveryArrayElement() throws Exception {
+		var result = instantiate(MODEL, "Top.nested_path");
+
+		assertEquals(List.of(), result.errors());
+		assertEquals(List.of("workers[1].output", "workers[2].output", "workers[3].output"),
+				referencedPaths(result, "Feature_Targets"));
+	}
+
+	/** A path that identifies one array element keeps the existing scalar reference representation. */
+	@Test
+	public void singleArrayElementRemainsOneReference() throws Exception {
+		var result = instantiate(MODEL, "Top.single_element");
+		var value = propertyValue(result.instance(), "Target");
+
+		assertEquals(List.of(), result.errors());
+		assertTrue("not an instance reference: " + value, value instanceof InstanceReferenceValue);
+		assertEquals("workers[2]",
+				relativePath(result.instance(), ((InstanceReferenceValue) value).getReferencedInstanceObject()));
+	}
+
+	/**
+	 * Validation accounts for the evaluated list type and checks the terminal element against the
+	 * reference constraints of the list element type.
+	 */
+	@Test
+	public void arrayReferenceMustMatchListAndElementTypes() throws Exception {
+		FluentIssueCollection result = issues = testHelper.testFile(INVALID_MODEL, PROPERTIES);
+		var expected = new FluentIssueCollection(result.getResource(), new ArrayList<>(), new ArrayList<>());
+		var pkg = (AadlPackage) result.getResource().getContents().getFirst();
+		var implementation = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals("Top.invalid"))
+				.findFirst()
+				.orElseThrow();
+
+		AssertHelper.assertError(referenceValue(implementation, "Scalar_Target"), result.getIssues(), expected,
+				"Assigning a list of reference values to property 'Issue721Properties::Scalar_Target' of type 'ReferenceType'");
+		AssertHelper.assertError(referenceValue(implementation, "Wrong_Targets"), result.getIssues(), expected,
+				"Assigning reference value with incorrect Named Element class to property 'Issue721Properties::Wrong_Targets' of type 'ListType'");
+		expected.sizeIs(result.getIssues().size());
+		assertConstraints(expected);
+	}
+
+	private Result instantiate(String model, String implementationName) throws Exception {
+		var pkg = testHelper.parseFile(model, PROPERTIES);
+		validationHelper.assertNoIssues(pkg);
+		var implementation = (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals(implementationName))
+				.findFirst()
+				.orElseThrow();
+		var errorManager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+		var instance = InstantiateModel.instantiate(implementation, errorManager);
+		var reporter = (QueuingAnalysisErrorReporter) errorManager.getReporter(instance.eResource());
+
+		return new Result(instance, reporter.getErrors());
+	}
+
+	private static List<String> referencedPaths(Result result, String propertyName) {
+		var value = propertyValue(result.instance(), propertyName);
+		assertTrue("not a list value: " + value, value instanceof ListValue);
+
+		return ((ListValue) value).getOwnedListElements()
+				.stream()
+				.map(element -> {
+					assertTrue("not an instance reference: " + element, element instanceof InstanceReferenceValue);
+					return relativePath(result.instance(),
+							((InstanceReferenceValue) element).getReferencedInstanceObject());
+				})
+				.toList();
+	}
+
+	private static PropertyExpression propertyValue(SystemInstance instance, String propertyName) {
+		var associations = instance.getOwnedPropertyAssociations()
+				.stream()
+				.filter(association -> association.getProperty().getName().equals(propertyName))
+				.toList();
+
+		assertEquals(1, associations.size());
+		return associations.getFirst().getOwnedValues().getFirst().getOwnedValue();
+	}
+
+	private static ReferenceValue referenceValue(ComponentImplementation implementation, String propertyName) {
+		var association = implementation.getOwnedPropertyAssociations()
+				.stream()
+				.filter(candidate -> candidate.getProperty().getName().equals(propertyName))
+				.findFirst()
+				.orElseThrow();
+		return (ReferenceValue) association.getOwnedValues().getFirst().getOwnedValue();
+	}
+
+	private static String relativePath(SystemInstance instance, InstanceObject object) {
+		var prefix = instance.getInstanceObjectPath() + ".";
+		var path = object.getInstanceObjectPath();
+
+		assertTrue(path, path.startsWith(prefix));
+		return path.substring(prefix.length());
+	}
+
+	private record Result(SystemInstance instance, List<Message> errors) {
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue721Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue721Test.java
@@ -171,6 +171,58 @@ public class Issue721Test extends XtextTest {
 				referencedPaths(innerIndexed, "Targets"));
 	}
 
+	/** A whole feature array expands to one reference per feature instance. */
+	@Test
+	public void featureArrayReferenceExpandsToList() throws Exception {
+		var result = instantiate(MODEL, "FeatureArrayComponent.i");
+
+		assertEquals(List.of(), result.errors());
+		assertEquals(List.of("ports[1]", "ports[2]", "ports[3]", "ports[4]"),
+				referencedPaths(result, "Feature_Targets"));
+	}
+
+	/** A range on a feature array expands to the feature instances within its bounds. */
+	@Test
+	public void featureArrayRangeExpandsToList() throws Exception {
+		var result = instantiate(MODEL, "FeatureArrayComponent.i");
+
+		assertEquals(List.of(), result.errors());
+		assertEquals(List.of("ports[2]", "ports[3]"), referencedPaths(result, "Feature_Range_Targets"));
+	}
+
+	/** An indexed feature-array element remains a scalar instance reference. */
+	@Test
+	public void indexedFeatureArrayElementRemainsOneReference() throws Exception {
+		var result = instantiate(MODEL, "FeatureArrayComponent.i");
+		var value = propertyValue(result.instance(), "Feature_Target");
+
+		assertEquals(List.of(), result.errors());
+		assertTrue("not an instance reference: " + value, value instanceof InstanceReferenceValue);
+		assertEquals("ports[2]",
+				relativePath(result.instance(), ((InstanceReferenceValue) value).getReferencedInstanceObject()));
+	}
+
+	/** Expansion reaches a feature array after traversing a scalar subcomponent path element. */
+	@Test
+	public void pathContinuesIntoFeatureArray() throws Exception {
+		var result = instantiate(MODEL, "Top.feature_array_path");
+
+		assertEquals(List.of(), result.errors());
+		assertEquals(List.of("worker.ports[1]", "worker.ports[2]", "worker.ports[3]", "worker.ports[4]"),
+				referencedPaths(result, "Feature_Targets"));
+	}
+
+	/** A subcomponent array followed by a feature array expands both path elements. */
+	@Test
+	public void subcomponentAndFeatureArraysExpandTogether() throws Exception {
+		var result = instantiate(MODEL, "Top.subcomponent_and_feature_arrays");
+
+		assertEquals(List.of(), result.errors());
+		assertEquals(List.of("workers[1].ports[1]", "workers[1].ports[2]", "workers[1].ports[3]",
+				"workers[1].ports[4]", "workers[2].ports[1]", "workers[2].ports[2]", "workers[2].ports[3]",
+				"workers[2].ports[4]"), referencedPaths(result, "Feature_Targets"));
+	}
+
 	/**
 	 * Validation accounts for the evaluated list type and checks the terminal element against the
 	 * reference constraints of the list element type.

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue721Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue721Test.java
@@ -114,6 +114,63 @@ public class Issue721Test extends XtextTest {
 				relativePath(result.instance(), ((InstanceReferenceValue) value).getReferencedInstanceObject()));
 	}
 
+	/** Every element of a multidimensional array is returned with the last dimension changing fastest. */
+	@Test
+	public void multidimensionalWholeArrayExpandsInIndexOrder() throws Exception {
+		var result = instantiate(MODEL, "Top.multidimensional_whole");
+
+		assertEquals(List.of(), result.errors());
+		assertEquals(List.of("grid[1][1]", "grid[1][2]", "grid[1][3]", "grid[2][1]", "grid[2][2]",
+				"grid[2][3]"), referencedPaths(result, "Targets"));
+	}
+
+	/** A range in each dimension returns the Cartesian product of the selected indices. */
+	@Test
+	public void multidimensionalRangesExpandAcrossDimensions() throws Exception {
+		var result = instantiate(RANGE_MODEL, "Top.multidimensional_range");
+
+		assertEquals(List.of(), result.errors());
+		assertEquals(List.of("grid[2][1]", "grid[2][2]", "grid[3][1]", "grid[3][2]"),
+				referencedPaths(result, "Targets"));
+	}
+
+	/** Indexing every dimension of a multidimensional array preserves a scalar reference value. */
+	@Test
+	public void multidimensionalIndexedElementRemainsOneReference() throws Exception {
+		var result = instantiate(MODEL, "Top.multidimensional_single");
+		var value = propertyValue(result.instance(), "Target");
+
+		assertEquals(List.of(), result.errors());
+		assertTrue("not an instance reference: " + value, value instanceof InstanceReferenceValue);
+		assertEquals("grid[2][3]",
+				relativePath(result.instance(), ((InstanceReferenceValue) value).getReferencedInstanceObject()));
+	}
+
+	/** Multiple array elements along one path expand to the Cartesian product in traversal order. */
+	@Test
+	public void nestedArrayPathExpandsEveryArraySegment() throws Exception {
+		var result = instantiate(MODEL, "Top.nested_arrays");
+
+		assertEquals(List.of(), result.errors());
+		assertEquals(List.of("outer[1].inner[1]", "outer[1].inner[2]", "outer[1].inner[3]",
+				"outer[2].inner[1]", "outer[2].inner[2]", "outer[2].inner[3]"),
+				referencedPaths(result, "Targets"));
+	}
+
+	/** Indexing either nested array restricts only that path segment; the other segment still expands. */
+	@Test
+	public void indexingOneNestedArrayRestrictsOnlyThatSegment() throws Exception {
+		var outerIndexed = instantiate(MODEL, "Top.indexed_outer_array");
+		var innerIndexed = instantiate(MODEL, "Top.indexed_inner_array");
+
+		assertEquals(List.of(), outerIndexed.errors());
+		assertEquals(List.of("outer[2].inner[1]", "outer[2].inner[2]", "outer[2].inner[3]"),
+				referencedPaths(outerIndexed, "Targets"));
+		assertEquals(List.of(), innerIndexed.errors());
+		assertEquals(List.of("outer[1].inner[2]", "outer[2].inner[2]"),
+				referencedPaths(innerIndexed, "Targets"));
+	}
+
 	/**
 	 * Validation accounts for the evaluated list type and checks the terminal element against the
 	 * reference constraints of the list element type.

--- a/core/org.osate.xtext.aadl2.properties/src/org/osate/xtext/aadl2/properties/validation/PropertiesValidator.java
+++ b/core/org.osate.xtext.aadl2.properties/src/org/osate/xtext/aadl2/properties/validation/PropertiesValidator.java
@@ -66,6 +66,7 @@ import org.osate.aadl2.ContainmentPathElement;
 import org.osate.aadl2.Element;
 import org.osate.aadl2.EnumerationLiteral;
 import org.osate.aadl2.EnumerationType;
+import org.osate.aadl2.Feature;
 import org.osate.aadl2.IntegerLiteral;
 import org.osate.aadl2.InternalFeature;
 import org.osate.aadl2.ListType;
@@ -221,7 +222,7 @@ public class PropertiesValidator extends AbstractPropertiesValidator {
 									ARRAY_RANGE_UPPER_LESS_THAN_LOWER);
 						}
 						if (EcoreUtil2.getContainerOfType(pathElement, ReferenceValue.class) != null
-								&& !(element instanceof Subcomponent)) {
+								&& !(element instanceof Subcomponent) && !(element instanceof Feature)) {
 							warning(providedRange, "Array ranges in reference values are not property instantiated");
 						}
 					}
@@ -919,7 +920,7 @@ public class PropertiesValidator extends AbstractPropertiesValidator {
 		} else if (pv instanceof ReferenceValue) {
 			ReferenceValue referenceValue = (ReferenceValue) pv;
 			PropertyType expectedReferenceType = pt;
-			if (selectsMultipleSubcomponentArrayElements(referenceValue)) {
+			if (selectsMultipleArrayElements(referenceValue)) {
 				if (pt instanceof ListType) {
 					expectedReferenceType = ((ListType) pt).getElementType();
 				} else {
@@ -998,13 +999,14 @@ public class PropertiesValidator extends AbstractPropertiesValidator {
 	}
 
 	/**
-	 * A reference term evaluates to a list when any subcomponent-array path element denotes the whole
-	 * array or an array range rather than an individual indexed element.
+	 * A reference term evaluates to a list when any subcomponent- or feature-array path element
+	 * denotes the whole array or an array range rather than an individual indexed element.
 	 */
-	private static boolean selectsMultipleSubcomponentArrayElements(ReferenceValue referenceValue) {
+	private static boolean selectsMultipleArrayElements(ReferenceValue referenceValue) {
 		for (ContainmentPathElement pathElement : referenceValue.getContainmentPathElements()) {
-			if (pathElement.getNamedElement() instanceof Subcomponent subcomponent
-					&& !subcomponent.getArrayDimensions().isEmpty()) {
+			NamedElement namedElement = pathElement.getNamedElement();
+			if (isExpandableArrayElement(namedElement)
+					&& !((ArrayableElement) namedElement).getArrayDimensions().isEmpty()) {
 				if (pathElement.getArrayRanges().isEmpty()
 						|| pathElement.getArrayRanges().stream().anyMatch(range -> range.getUpperBound() != 0)) {
 					return true;
@@ -1012,6 +1014,10 @@ public class PropertiesValidator extends AbstractPropertiesValidator {
 			}
 		}
 		return false;
+	}
+
+	private static boolean isExpandableArrayElement(NamedElement namedElement) {
+		return namedElement instanceof Subcomponent || namedElement instanceof Feature;
 	}
 
 	/**

--- a/core/org.osate.xtext.aadl2.properties/src/org/osate/xtext/aadl2/properties/validation/PropertiesValidator.java
+++ b/core/org.osate.xtext.aadl2.properties/src/org/osate/xtext/aadl2/properties/validation/PropertiesValidator.java
@@ -220,7 +220,8 @@ public class PropertiesValidator extends AbstractPropertiesValidator {
 							error("Range lower bound is greater than upper bound", providedRange, null,
 									ARRAY_RANGE_UPPER_LESS_THAN_LOWER);
 						}
-						if (EcoreUtil2.getContainerOfType(pathElement, ReferenceValue.class) != null) {
+						if (EcoreUtil2.getContainerOfType(pathElement, ReferenceValue.class) != null
+								&& !(element instanceof Subcomponent)) {
 							warning(providedRange, "Array ranges in reference values are not property instantiated");
 						}
 					}
@@ -916,15 +917,24 @@ public class PropertiesValidator extends AbstractPropertiesValidator {
 				typeMatchRecordFields(((RecordValue) pv).getOwnedFieldValues(), holder, defName, depth);
 			}
 		} else if (pv instanceof ReferenceValue) {
-			if (!(pt instanceof ReferenceType)) {
+			ReferenceValue referenceValue = (ReferenceValue) pv;
+			PropertyType expectedReferenceType = pt;
+			if (selectsMultipleSubcomponentArrayElements(referenceValue)) {
+				if (pt instanceof ListType) {
+					expectedReferenceType = ((ListType) pt).getElementType();
+				} else {
+					error(holder, prefix + "Assigning a list of reference values" + msg);
+					return;
+				}
+			}
+			if (!(expectedReferenceType instanceof ReferenceType)) {
 				error(holder, prefix + "Assigning incorrect reference value" + msg);
 			} else {
-				ReferenceType ptrt = (ReferenceType) pt;
+				ReferenceType ptrt = (ReferenceType) expectedReferenceType;
 				if (ptrt.getNamedElementReferences().isEmpty()) {
 					return;
 				}
-				ReferenceValue pvrv = (ReferenceValue) pv;
-				EList<ContainmentPathElement> cpes = pvrv.getContainmentPathElements();
+				EList<ContainmentPathElement> cpes = referenceValue.getContainmentPathElements();
 				if (!cpes.isEmpty()) {
 					NamedElement ne = cpes.get(cpes.size() - 1).getNamedElement();
 					for (MetaclassReference mcri : ptrt.getNamedElementReferences()) {
@@ -985,6 +995,23 @@ public class PropertiesValidator extends AbstractPropertiesValidator {
 				error(holder, "Enum/Unit literal validation should have happened before");
 			}
 		}
+	}
+
+	/**
+	 * A reference term evaluates to a list when any subcomponent-array path element denotes the whole
+	 * array or an array range rather than an individual indexed element.
+	 */
+	private static boolean selectsMultipleSubcomponentArrayElements(ReferenceValue referenceValue) {
+		for (ContainmentPathElement pathElement : referenceValue.getContainmentPathElements()) {
+			if (pathElement.getNamedElement() instanceof Subcomponent subcomponent
+					&& !subcomponent.getArrayDimensions().isEmpty()) {
+				if (pathElement.getArrayRanges().isEmpty()
+						|| pathElement.getArrayRanges().stream().anyMatch(range -> range.getUpperBound() != 0)) {
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Reference property values whose contained model element path selected a whole subcomponent or feature array, or an array range, were left declarative during instantiation. `ReferenceValueImpl` found every matching instance object but rejected the result whenever more than one object matched.

This change:

- returns an ordered `ListValue` of `InstanceReferenceValue`s for whole-array and range selections of subcomponent and feature arrays;
- continues resolving the rest of a path through every selected element, such as `workers.output`;
- preserves scalar behavior for an explicitly indexed array element and the existing error behavior for unrelated multi-match references;
- validates that an expanding reference is assigned to a `list of reference` property and that the terminal element satisfies the list element's reference type.

Fixes #721

## Regression

`Issue721Test` uses external AADL model projects to cover:

- a whole subcomponent array;
- a selected array range;
- whole and ranged multidimensional arrays;
- a fully indexed multidimensional scalar reference;
- paths containing multiple nested subcomponent arrays;
- indexing either the outer or inner nested array;
- a path that continues through every selected array element;
- a single indexed array element;
- whole, ranged, and indexed feature arrays;
- a feature array later in a path;
- combined subcomponent-array and feature-array expansion; and
- invalid scalar-property and reference-element-type assignments.

The pre-fix run reached the production path and failed because whole-array and continued-path values reported multi-match instantiation errors, while the range retained the unsupported warning.

## Validation

All Maven commands used offline mode and `-T5`.

- `Issue721Test`: 15 tests, 0 failures, 0 errors, 0 skipped
- `Issue1769Test`: 1 test, 0 failures, 0 errors, 0 skipped
- `Issue2159Test`: 1 test, 0 failures, 0 errors, 0 skipped
- `Issue3104Test`: 7 tests, 0 failures, 0 errors, 0 skipped
- Clean root reactor with `-Dtycho.localArtifacts=ignore`: 137 projects, `BUILD SUCCESS`
- Root Surefire reports: 1,463 tests, 0 failures, 0 errors, 0 skipped

## Dependencies

None.

## Residual risk

List order follows instance-model traversal order. AS5506D Section 11.4 L6 explicitly requires list-valued expansion for non-single subcomponent-array path elements; applying the same behavior to feature arrays is an intentional OSATE extension.
