### PR TITLE
Warn for missing required feature connections 🤖

### DIFF
--- a/core/org.osate.aadl2.contrib/resources/properties/Predeclared_Property_Sets/Communication_Properties.aadl
+++ b/core/org.osate.aadl2.contrib/resources/properties/Predeclared_Property_Sets/Communication_Properties.aadl
@@ -43,8 +43,8 @@ property set Communication_Properties is
     --- The <b>Required_Connection</b> property specifies whether the port or subprogram requires a connection.  If the
     --- value of this property is false, then it is assumed that the component can function without this port or 
     --- subprogram access feature being connected.<p>
-    --- The default value is that a connection is required.
-    Required_Connection: aadlboolean applies to (feature);
+    --- OSATE defaults this property to false, which intentionally deviates from the AADL standard default of true.
+    Required_Connection: aadlboolean => false applies to (feature);
 
     --- The <b>Timing</b> property specifies the timing of port connections.  By default the interaction is <b>sampled</b>,
     --- i.e., the receiving component samples at dispatch or during execution.

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/InstantiateModel.java
@@ -559,6 +559,9 @@ public class InstantiateModel {
 		checkCanceled();
 
 		cacheProperties(root, remainingProperties);
+
+		vcs.checkRequiredConnections();
+		checkCanceled();
 	}
 
 	/**

--- a/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/ValidateConnectionsSwitch.java
+++ b/core/org.osate.aadl2.instantiation/src/org/osate/aadl2/instantiation/ValidateConnectionsSwitch.java
@@ -49,6 +49,7 @@ import org.osate.aadl2.ListValue;
 import org.osate.aadl2.PropertyConstant;
 import org.osate.aadl2.PropertyExpression;
 import org.osate.aadl2.Subcomponent;
+import org.osate.aadl2.contrib.communication.CommunicationProperties;
 import org.osate.aadl2.instance.ComponentInstance;
 import org.osate.aadl2.instance.ConnectionInstance;
 import org.osate.aadl2.instance.ConnectionInstanceEnd;
@@ -74,12 +75,16 @@ import org.osate.xtext.aadl2.properties.util.ModelingProperties;
 class ValidateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 	private final Map<InstanceObject, InstantiatedClassifier> classifierCache;
 	private final Map<FeatureInstance, Set<ConnectionInstance>> inDataPortConnectionsMap;
+	private final Map<FeatureInstance, Set<ConnectionReference>> featureConnectionsMap;
+	private final List<FeatureInstance> featureInstances;
 
 	public ValidateConnectionsSwitch(IProgressMonitor monitor, AnalysisErrorReporterManager errManager,
 			Map<InstanceObject, InstantiatedClassifier> classifierCache) {
 		super(monitor, errManager);
 		this.classifierCache = classifierCache;
 		inDataPortConnectionsMap = new HashMap<>();
+		featureConnectionsMap = new HashMap<>();
+		featureInstances = new ArrayList<>();
 	}
 
 	@Override
@@ -95,6 +100,16 @@ class ValidateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 				validateConnections(ci);
 				return DONE;
 			}
+
+			@Override
+			public String caseFeatureInstance(FeatureInstance fi) {
+				if (monitor.isCanceled()) {
+					cancelTraversal();
+					return DONE;
+				}
+				featureInstances.add(fi);
+				return DONE;
+			}
 		};
 	}
 
@@ -104,11 +119,62 @@ class ValidateConnectionsSwitch extends AadlProcessingSwitchWithProgress {
 
 	private void validateConnections(ComponentInstance ci) {
 		removeShortAccessConnections(ci);
+		recordFeatureConnections(ci);
 		recordInDataPortConnections(ci);
 		checkEndPointClassifiers(ci);
 		checkSegmentDirections(ci);
 		checkUncontinuedBoundaryEnds(ci);
 		// more
+	}
+
+	/**
+	 * Record every feature used by a declarative segment of a semantic connection.
+	 * Required connection is a consistency rule on assembled systems, so ultimate
+	 * semantic connection endpoints alone are insufficient: a boundary feature in
+	 * the middle of a complete connection is connected by one of its references.
+	 */
+	private void recordFeatureConnections(ComponentInstance ci) {
+		for (var conni : ci.getConnectionInstances()) {
+			for (var reference : conni.getConnectionReferences()) {
+				recordFeatureConnection(reference.getSource(), reference);
+				recordFeatureConnection(reference.getDestination(), reference);
+			}
+		}
+	}
+
+	private void recordFeatureConnection(ConnectionInstanceEnd end, ConnectionReference reference) {
+		for (var feature = end instanceof FeatureInstance fi ? fi : null; feature != null;) {
+			addToHashedSet(featureConnectionsMap, feature, reference);
+			feature = feature.getOwner() instanceof FeatureInstance parent ? parent : null;
+		}
+	}
+
+	/**
+	 * Warn for every active feature whose {@code Required_Connection} value is true
+	 * but which has no active connection reference. Instance property caching maps modal
+	 * values to system operation modes, allowing the generated getter to evaluate the
+	 * property directly for each SOM.
+	 */
+	void checkRequiredConnections() {
+		for (var feature : featureInstances) {
+			var systemOperationModes = feature.getSystemInstance().getSystemOperationModes();
+			var missing = systemOperationModes.stream()
+					.filter(feature::isActive)
+					.filter(som -> CommunicationProperties.getRequiredConnection(feature, som).orElse(false))
+					.filter(som -> featureConnectionsMap.getOrDefault(feature, Collections.emptySet())
+							.stream()
+							.noneMatch(reference -> reference.isActive(som)))
+					.toList();
+
+			if (!missing.isEmpty()) {
+				var message = new StringBuilder("Feature is required to be connected but is not");
+				if (missing.size() < systemOperationModes.size()) {
+					message.append(" in SOMs ");
+					message.append(missing.stream().map(SystemOperationMode::getName).collect(Collectors.joining(", ")));
+				}
+				warning(feature, message.toString());
+			}
+		}
 	}
 
 	/**

--- a/core/org.osate.core.tests/models/issue602/.gitignore
+++ b/core/org.osate.core.tests/models/issue602/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue602/.project
+++ b/core/org.osate.core.tests/models/issue602/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue602</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue602/Issue602.aadl
+++ b/core/org.osate.core.tests/models/issue602/Issue602.aadl
@@ -1,0 +1,53 @@
+package Issue602
+public
+	device Producer
+	features
+		all_missing: out data port { Required_Connection => true; };
+		default_optional_missing: out data port;
+		explicit_optional_missing: out data port;
+		partial: out data port { Required_Connection => true; };
+		full: out data port;
+	end Producer;
+
+	device Consumer
+	features
+		partial: in data port { Required_Connection => false; };
+		full: in data port { Required_Connection => false; };
+	end Consumer;
+
+	device ModalProducer
+	features
+		conditional: out data port;
+	modes
+		one: initial mode;
+		two: mode;
+	properties
+		Required_Connection => true in modes (one), false in modes (two) applies to conditional;
+	end ModalProducer;
+
+	system Top
+	end Top;
+
+	system implementation Top.impl
+	subcomponents
+		producer: device Producer;
+		consumer: device Consumer;
+	connections
+		partial: port producer.partial -> consumer.partial in modes (m1);
+		full: port producer.full -> consumer.full;
+	modes
+		m1: initial mode;
+		m2: mode;
+		m3: mode;
+	properties
+		Required_Connection => false applies to producer.explicit_optional_missing;
+	end Top.impl;
+
+	system ModalTop
+	end ModalTop;
+
+	system implementation ModalTop.impl
+	subcomponents
+		producer: device ModalProducer;
+	end ModalTop.impl;
+end Issue602;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue602Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue602Test.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to the Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.instance.FeatureInstance;
+import org.osate.aadl2.instance.SystemInstance;
+import org.osate.aadl2.instantiation.InstantiateModel;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * Regression test for issue #602. It verifies that instance connection validation honors
+ * {@code Required_Connection}, including modal values, and identifies every SOM in which a
+ * required feature has no active connection.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class Issue602Test extends XtextTest {
+	private static final String MODEL = "org.osate.core.tests/models/issue602/Issue602.aadl";
+	private static final String WARNING = "Feature is required to be connected but is not";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void requiredFeaturesAreReportedInTheSomsWhereTheyAreNotConnected() throws Exception {
+		var pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+		var manager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+		var instance = InstantiateModel.instantiate(findImplementation(pkg, "Top.impl"), manager);
+
+		assertEquals(List.of(
+				"Warning|Top_impl_Instance.producer.all_missing|" + WARNING,
+				"Warning|Top_impl_Instance.producer.partial|" + WARNING + " in SOMs som_2, som_3"),
+				requiredConnectionWarnings(instance, manager));
+	}
+
+	@Test
+	public void modalRequiredConnectionIsEvaluatedForEachSom() throws Exception {
+		var pkg = testHelper.parseFile(MODEL);
+		validationHelper.assertNoIssues(pkg);
+		var manager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
+		var instance = InstantiateModel.instantiate(findImplementation(pkg, "ModalTop.impl"), manager);
+
+		assertEquals(List.of(
+				"Warning|ModalTop_impl_Instance.producer.conditional|" + WARNING + " in SOMs som_1"),
+				requiredConnectionWarnings(instance, manager));
+	}
+
+	private static List<String> requiredConnectionWarnings(SystemInstance instance,
+			AnalysisErrorReporterManager manager) {
+		return ((QueuingAnalysisErrorReporter) manager.getReporter(instance.eResource())).getErrors()
+				.stream()
+				.filter(message -> message.message.startsWith(WARNING))
+				.map(message -> message.kind + "|" + ((FeatureInstance) message.where).getInstanceObjectPath() + "|"
+						+ message.message)
+				.sorted()
+				.toList();
+	}
+
+	private static ComponentImplementation findImplementation(AadlPackage pkg, String name) {
+		return (ComponentImplementation) pkg.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(classifier -> classifier.getName().equals(name))
+				.findFirst()
+				.orElseThrow();
+	}
+}


### PR DESCRIPTION
## Summary

- Check `Required_Connection` on assembled feature and connection instances.
- Report `Feature is required to be connected but is not` for required features without an active connection.
- When only some system operation modes are affected, append every missing SOM name.
- Default `Communication_Properties::Required_Connection` to `false` and document that this intentionally differs from the AADL standard default.

## Cause and correction

Instantiation created and validated semantic connections without a final consistency pass over feature requirements. The new pass records every feature used by a connection reference, waits until instance properties are cached, and evaluates each active feature for every SOM. This includes boundary features inside complete semantic connections and honors modal property values.

## Regression coverage

`Issue602Test` uses a separate issue model project and covers:

- a required feature missing in every SOM;
- a required feature connected in one SOM and missing in two;
- default and explicitly optional unconnected features;
- a modal `Required_Connection` value;
- exact warning severity, target, text, and SOM ordering.

## Validation

- Focused offline four-module build with `Issue602Test`: 2 tests, 0 failures.
- Clean offline root reactor with `-T5` and `-Dtycho.localArtifacts=ignore`: all 137 projects passed.
- Core test bundle in the clean reactor: 858 tests, 0 failures.

## Dependencies

None.

## Residual risk

The warning is emitted during instantiation after property caching. Features remain optional unless `Required_Connection` evaluates to `true`; this OSATE default intentionally differs from the AADL standard.

Fixes #602