### PR TITLE
Support AADL renames in language servers 🤖

### DIFF
--- a/core/org.osate.core.tests/META-INF/MANIFEST.MF
+++ b/core/org.osate.core.tests/META-INF/MANIFEST.MF
@@ -7,7 +7,10 @@ Bundle-SymbolicName: org.osate.core.tests;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.osate.aadl2;bundle-version="1.0.0",
  org.osate.xtext.aadl2,
+ org.osate.xtext.aadl2.ide,
  org.osate.xtext.aadl2.ui,
+ org.eclipse.lsp4j,
+ org.eclipse.lsp4j.jsonrpc,
  org.eclipse.core.runtime;bundle-version="3.5.0",
  org.eclipse.xtext,
  org.eclipse.ui.workbench;bundle-version="3.5.2";resolution:=optional;x-installation:=greedy,

--- a/core/org.osate.core.tests/models/issue2697/.gitignore
+++ b/core/org.osate.core.tests/models/issue2697/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/core/org.osate.core.tests/models/issue2697/.project
+++ b/core/org.osate.core.tests/models/issue2697/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue2697</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/core/org.osate.core.tests/models/issue2697/Issue2697.aadl
+++ b/core/org.osate.core.tests/models/issue2697/Issue2697.aadl
@@ -1,0 +1,11 @@
+package issue2697
+public
+	system Original
+	end Original;
+
+	system implementation Original.first
+	end Original.first;
+
+	system implementation Original.second
+	end Original.second;
+end issue2697;

--- a/core/org.osate.core.tests/models/issue2697/Issue2697References.aadl
+++ b/core/org.osate.core.tests/models/issue2697/Issue2697References.aadl
@@ -1,0 +1,13 @@
+package issue2697references
+public
+	with issue2697;
+
+	system User
+	end User;
+
+	system implementation User.impl
+		subcomponents
+			type_reference: system issue2697::Original;
+			implementation_reference: system issue2697::Original.first;
+	end User.impl;
+end issue2697references;

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2697Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2697Test.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such separate license file distributed with such Third Party Software. The parties who
+ * own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries to this license with
+ * respect to the terms applicable to such Third Party Software. Third Party Software licenses only apply to the Third
+ * Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.core.tests.issues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.xtext.formatting2.regionaccess.ITextReplacement;
+import org.eclipse.xtext.ide.refactoring.IRenameStrategy2;
+import org.eclipse.xtext.ide.refactoring.RefactoringIssueAcceptor.Severity;
+import org.eclipse.xtext.ide.refactoring.RenameChange;
+import org.eclipse.xtext.ide.refactoring.RenameContext;
+import org.eclipse.xtext.ide.serializer.IChangeSerializer;
+import org.eclipse.xtext.ide.serializer.IEmfResourceChange;
+import org.eclipse.xtext.ide.serializer.ITextDocumentChange;
+import org.eclipse.xtext.ide.server.rename.ServerRefactoringIssueAcceptor;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.eclipse.xtext.util.Modules2;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.NamedElement;
+import org.osate.aadl2.SystemImplementation;
+import org.osate.aadl2.SystemType;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+import org.osate.xtext.aadl2.Aadl2StandaloneSetup;
+import org.osate.xtext.aadl2.ide.Aadl2IdeModule;
+
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.itemis.xtext.testing.XtextTest;
+
+/**
+ * Tests serializer-based AADL renames used by language servers. Component implementations encode
+ * their realized type in the semantic name, so both implementation and type renames must preserve
+ * that coupling in the declaration and closing identifier.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Issue2697Test.IdeInjectorProvider.class)
+public class Issue2697Test extends XtextTest {
+	private static final String MODEL_PATH = "org.osate.core.tests/models/issue2697/Issue2697.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private ValidationTestHelper validationHelper;
+
+	@Test
+	public void implementationRenamePreservesTypePrefix() throws Exception {
+		var pkg = testHelper.parseFile(MODEL_PATH);
+		validationHelper.assertNoIssues(pkg);
+		var implementation = (SystemImplementation) pkg.getOwnedPublicSection().getOwnedClassifiers().get(1);
+
+		var renamedText = rename(implementation, "renamed");
+
+		assertTrue(renamedText, renamedText.contains("system implementation Original.renamed"));
+		assertTrue(renamedText, renamedText.contains("end Original.renamed;"));
+		assertFalse(renamedText, renamedText.contains("Original.first"));
+		validationHelper.assertNoIssues(testHelper.parseString(renamedText));
+	}
+
+	@Test
+	public void typeRenameUpdatesImplementationPrefixes() throws Exception {
+		var pkg = testHelper.parseFile(MODEL_PATH);
+		validationHelper.assertNoIssues(pkg);
+		var type = (SystemType) pkg.getOwnedPublicSection().getOwnedClassifiers().get(0);
+
+		var renamedText = rename(type, "Renamed");
+
+		assertTrue(renamedText, renamedText.contains("system Renamed"));
+		assertTrue(renamedText, renamedText.contains("end Renamed;"));
+		assertTrue(renamedText, renamedText.contains("system implementation Renamed.first"));
+		assertTrue(renamedText, renamedText.contains("end Renamed.first;"));
+		assertTrue(renamedText, renamedText.contains("system implementation Renamed.second"));
+		assertTrue(renamedText, renamedText.contains("end Renamed.second;"));
+		assertFalse(renamedText, renamedText.contains("Original"));
+		validationHelper.assertNoIssues(testHelper.parseString(renamedText));
+	}
+
+	private static String rename(NamedElement target, String newName) {
+		var resource = (XtextResource) target.eResource();
+		var originalText = resource.getParseResult().getRootNode().getText();
+		var services = resource.getResourceServiceProvider();
+		var changeSerializer = services.get(IChangeSerializer.class);
+		var renameStrategy = services.get(IRenameStrategy2.class);
+		var issues = new ServerRefactoringIssueAcceptor();
+		var change = new RenameChange(newName, EcoreUtil.getURI(target));
+		var context = new RenameContext(List.of(change), resource.getResourceSet(), changeSerializer, issues);
+		var changes = new ArrayList<IEmfResourceChange>();
+
+		renameStrategy.applyRename(context);
+		changeSerializer.applyModifications(changes::add);
+
+		assertEquals(Severity.OK, issues.getMaximumSeverity());
+		var documentChange = changes.stream()
+				.filter(ITextDocumentChange.class::isInstance)
+				.map(ITextDocumentChange.class::cast)
+				.filter(candidate -> resource.getURI().equals(candidate.getOldURI()))
+				.findFirst()
+				.orElseThrow();
+		return applyReplacements(originalText, documentChange.getReplacements());
+	}
+
+	private static String applyReplacements(String originalText, List<ITextReplacement> replacements) {
+		var result = new StringBuilder(originalText);
+		replacements.stream()
+				.sorted(Comparator.comparingInt(ITextReplacement::getOffset).reversed())
+				.forEach(replacement -> result.replace(replacement.getOffset(),
+						replacement.getOffset() + replacement.getLength(), replacement.getReplacementText()));
+		return result.toString();
+	}
+
+	public static class IdeInjectorProvider extends Aadl2InjectorProvider {
+		@Override
+		protected Injector internalCreateInjector() {
+			return new Aadl2StandaloneSetup() {
+				@Override
+				public Injector createInjector() {
+					return Guice.createInjector(
+							Modules2.mixin(IdeInjectorProvider.this.createRuntimeModule(), new Aadl2IdeModule()));
+				}
+			}.createInjectorAndDoEMFRegistration();
+		}
+	}
+}

--- a/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2697Test.java
+++ b/core/org.osate.core.tests/src/org/osate/core/tests/issues/Issue2697Test.java
@@ -25,12 +25,16 @@ package org.osate.core.tests.issues;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.xtext.formatting2.regionaccess.ITextReplacement;
 import org.eclipse.xtext.ide.refactoring.IRenameStrategy2;
@@ -65,12 +69,15 @@ import com.itemis.xtext.testing.XtextTest;
 /**
  * Tests serializer-based AADL renames used by language servers. Component implementations encode
  * their realized type in the semantic name, so both implementation and type renames must preserve
- * that coupling in the declaration and closing identifier.
+ * that coupling in declarations and closing identifiers while related resources receive matching
+ * cross-reference edits.
  */
 @RunWith(XtextRunner.class)
 @InjectWith(Issue2697Test.IdeInjectorProvider.class)
 public class Issue2697Test extends XtextTest {
 	private static final String MODEL_PATH = "org.osate.core.tests/models/issue2697/Issue2697.aadl";
+	private static final String REFERENCE_MODEL_PATH =
+			"org.osate.core.tests/models/issue2697/Issue2697References.aadl";
 
 	@Inject
 	private TestHelper<AadlPackage> testHelper;
@@ -110,9 +117,41 @@ public class Issue2697Test extends XtextTest {
 		validationHelper.assertNoIssues(testHelper.parseString(renamedText));
 	}
 
+	@Test
+	public void typeRenameUpdatesCrossFileReferences() throws Exception {
+		var pkg = testHelper.parseFile(MODEL_PATH, REFERENCE_MODEL_PATH);
+		validationHelper.assertNoIssues(pkg);
+		var referenceResource = pkg.eResource()
+				.getResourceSet()
+				.getResource(URI.createURI(REFERENCE_MODEL_PATH), false);
+		var referencePkg = (AadlPackage) referenceResource.getContents().getFirst();
+		validationHelper.assertNoIssues(referencePkg);
+		var type = (SystemType) pkg.getOwnedPublicSection().getOwnedClassifiers().getFirst();
+
+		var renamedTexts = renameResources(type, "Renamed");
+		var renamedSource = renamedTexts.get(URI.createURI(MODEL_PATH));
+		var renamedReferences = renamedTexts.get(URI.createURI(REFERENCE_MODEL_PATH));
+
+		assertNotNull(renamedSource);
+		assertNotNull(renamedReferences);
+		assertTrue(renamedReferences, renamedReferences.contains("system issue2697::Renamed;"));
+		assertTrue(renamedReferences, renamedReferences.contains("system issue2697::Renamed.first;"));
+		assertFalse(renamedReferences, renamedReferences.contains("issue2697::Original"));
+		validationHelper.assertNoIssues(testHelper.parseString(renamedReferences, renamedSource));
+	}
+
 	private static String rename(NamedElement target, String newName) {
+		return renameResources(target, newName).get(target.eResource().getURI());
+	}
+
+	private static Map<URI, String> renameResources(NamedElement target, String newName) {
 		var resource = (XtextResource) target.eResource();
-		var originalText = resource.getParseResult().getRootNode().getText();
+		var originalTexts = new HashMap<URI, String>();
+		for (var loadedResource : resource.getResourceSet().getResources()) {
+			if (loadedResource instanceof XtextResource xtextResource && xtextResource.getParseResult() != null) {
+				originalTexts.put(loadedResource.getURI(), xtextResource.getParseResult().getRootNode().getText());
+			}
+		}
 		var services = resource.getResourceServiceProvider();
 		var changeSerializer = services.get(IChangeSerializer.class);
 		var renameStrategy = services.get(IRenameStrategy2.class);
@@ -125,13 +164,18 @@ public class Issue2697Test extends XtextTest {
 		changeSerializer.applyModifications(changes::add);
 
 		assertEquals(Severity.OK, issues.getMaximumSeverity());
-		var documentChange = changes.stream()
+		var renamedTexts = new HashMap<URI, String>();
+		changes.stream()
 				.filter(ITextDocumentChange.class::isInstance)
 				.map(ITextDocumentChange.class::cast)
-				.filter(candidate -> resource.getURI().equals(candidate.getOldURI()))
-				.findFirst()
-				.orElseThrow();
-		return applyReplacements(originalText, documentChange.getReplacements());
+				.forEach(documentChange -> {
+					var originalText = originalTexts.get(documentChange.getOldURI());
+					if (originalText != null) {
+						renamedTexts.put(documentChange.getOldURI(),
+								applyReplacements(originalText, documentChange.getReplacements()));
+					}
+				});
+		return renamedTexts;
 	}
 
 	private static String applyReplacements(String originalText, List<ITextReplacement> replacements) {

--- a/core/org.osate.xtext.aadl2.ide/src/org/osate/xtext/aadl2/ide/Aadl2IdeModule.java
+++ b/core/org.osate.xtext.aadl2.ide/src/org/osate/xtext/aadl2/ide/Aadl2IdeModule.java
@@ -24,6 +24,8 @@
 package org.osate.xtext.aadl2.ide;
 
 import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator;
+import org.eclipse.xtext.ide.refactoring.IRenameStrategy2;
+import org.osate.xtext.aadl2.ide.refactoring.Aadl2IdeRenameStrategy;
 
 /**
  * Use this class to register ide components.
@@ -32,6 +34,11 @@ public class Aadl2IdeModule extends AbstractAadl2IdeModule {
 
 	public Class<? extends ISemanticHighlightingCalculator> bindSemanticHighlightingCalculator() {
 		return org.osate.xtext.aadl2.ide.highlighting.Aadl2SemanticHighlightingCalculator.class;
+	}
+
+	@Override
+	public Class<? extends IRenameStrategy2> bindIRenameStrategy2() {
+		return Aadl2IdeRenameStrategy.class;
 	}
 
 }

--- a/core/org.osate.xtext.aadl2.ide/src/org/osate/xtext/aadl2/ide/refactoring/Aadl2IdeRenameStrategy.java
+++ b/core/org.osate.xtext.aadl2.ide/src/org/osate/xtext/aadl2/ide/refactoring/Aadl2IdeRenameStrategy.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such separate license file distributed with such Third Party Software. The parties who
+ * own the Third Party Software ("Third Party Licensors") are intended third party beneficiaries to this license with
+ * respect to the terms applicable to such Third Party Software. Third Party Software licenses only apply to the Third
+ * Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.xtext.aadl2.ide.refactoring;
+
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.EcoreUtil2;
+import org.eclipse.xtext.formatting2.regionaccess.ISemanticRegion;
+import org.eclipse.xtext.ide.refactoring.IRenameStrategy2;
+import org.eclipse.xtext.ide.refactoring.RenameChange;
+import org.eclipse.xtext.ide.refactoring.RenameContext;
+import org.eclipse.xtext.resource.ILocationInFileProvider;
+import org.osate.aadl2.Aadl2Package;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.ComponentImplementation;
+import org.osate.aadl2.ComponentType;
+import org.osate.aadl2.NamedElement;
+import org.osate.xtext.aadl2.util.Aadl2LocationInFile;
+
+import com.google.inject.Inject;
+
+/**
+ * Applies serializer-based renames to AADL named elements. AADL uses its own string data type for
+ * names, and component implementation names also contain the realized component type name.
+ */
+public class Aadl2IdeRenameStrategy extends IRenameStrategy2.DefaultImpl {
+	@Inject
+	private ILocationInFileProvider locationInFileProvider;
+
+	@Override
+	protected EAttribute getNameEAttribute(EObject target) {
+		if (target instanceof NamedElement) {
+			return Aadl2Package.eINSTANCE.getNamedElement_Name();
+		}
+		return super.getNameEAttribute(target);
+	}
+
+	@Override
+	protected void doRename(EObject target, RenameChange change, RenameContext context) {
+		var effectiveChange = change;
+		replaceSecondaryName(context, target, !(target instanceof ComponentImplementation), change.getNewName());
+		if (target instanceof ComponentImplementation implementation && !change.getNewName().contains(".")) {
+			var type = implementation.getType();
+			if (type != null) {
+				effectiveChange = new RenameChange(type.getName() + "." + change.getNewName(), change.getTargetURI());
+			}
+		} else if (target instanceof ComponentType type) {
+			var pkg = EcoreUtil2.getContainerOfType(type, AadlPackage.class);
+			if (pkg != null) {
+				EcoreUtil2.getAllContentsOfType(pkg, ComponentImplementation.class)
+						.stream()
+						.filter(implementation -> implementation.getType() == type)
+						.forEach(implementation -> {
+							replaceSecondaryName(context, implementation, true, change.getNewName());
+							implementation.setName(change.getNewName() + "." + implementation.getImplementationName());
+						});
+			}
+		}
+		super.doRename(target, effectiveChange, context);
+	}
+
+	private void replaceSecondaryName(RenameContext context, EObject target, boolean typeName, String newName) {
+		var region = ((Aadl2LocationInFile) locationInFileProvider).getSecondaryTextRegion(target, typeName);
+		if (region == null) {
+			return;
+		}
+		var document = context.getChangeSerializer().getModifiableDocument(target.eResource());
+		if (document == null) {
+			return;
+		}
+		var objectRegion = document.getOriginalTextRegionAccess().regionForEObject(target);
+		if (objectRegion == null) {
+			return;
+		}
+		for (ISemanticRegion semanticRegion : objectRegion.getAllSemanticRegions()) {
+			if (semanticRegion.getOffset() <= region.getOffset()
+					&& semanticRegion.getEndOffset() >= region.getOffset() + region.getLength()) {
+				var relativeOffset = region.getOffset() - semanticRegion.getOffset();
+				var text = semanticRegion.getText();
+				var replacement = text.substring(0, relativeOffset) + newName
+						+ text.substring(relativeOffset + region.getLength());
+				document.replace(semanticRegion, replacement);
+				return;
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Bind an AADL-specific `IRenameStrategy2` for serializer-based IDE and language-server refactoring.
- Recognize the custom AADL name datatype, which the Xtext default strategy rejects.
- Preserve component implementation type prefixes and update implementations when their component type is renamed.
- Update unassigned AADL closing identifiers and cross-file classifier references in the generated workspace edits.

Fixes #2697

## Cause

The AADL IDE module used `IRenameStrategy2.DefaultImpl`. That implementation only recognizes name attributes typed as Ecore `EString`, while `NamedElement.name` uses the AADL metamodel string datatype. It therefore reported a warning without producing a rename. It also did not implement the coordinated component type and implementation naming behavior provided by the Eclipse UI rename strategy.

## Correction

`Aadl2IdeRenameStrategy` recognizes AADL named elements, preserves the realized type prefix when renaming component implementations, and updates every implementation name when its component type is renamed. It also records explicit serializer document edits for closing identifiers, including the type segment of implementation closing names.

The existing Eclipse LTK rename implementation remains unchanged.

## Regression coverage

`Issue2697Test` uses the IDE injector and `IChangeSerializer` directly against the models under `models/issue2697/`. It verifies that:

- renaming `Original.first` to `renamed` produces `Original.renamed` in both the declaration and closing identifier;
- renaming `Original` to `Renamed` updates the type and both realizing implementations;
- a second AADL package receives matching edits for type and implementation classifier references;
- applying all produced text replacements yields valid single-file and cross-file AADL models.

Before the fix, the original two tests failed because the default strategy reported a warning and produced no valid rename edits.

## Validation

Focused regression:

```text
mvn -o -T6 -s releng/osate.releng/settings.xml -Plocal -pl :org.osate.xtext.aadl2.ide,:org.osate.core.tests,:org.osate.core.feature -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -Dtest=Issue2697Test -DfailIfNoTests=false clean verify
```

Result: 3 tests, 0 failures, 0 errors, 0 skipped.

Clean root reactor:

```text
mvn -o -T6 -s releng/osate.releng/settings.xml -Plocal -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -DfailIfNoTests=false clean install
```

Result: all 137 projects succeeded; 1,454 tests, 0 failures, 0 errors, 0 skipped.

## Dependencies

None. PR #3135 is related but independent; it fixes EMV2 propagation-point rename in the Eclipse UI/LTK path.

## Residual risk

Embedded annex elements require annex-specific rename and reference-update services. PR #3135 does not add IDE/LSP annex dispatch, so EMV2 propagation-point rename through LSP remains separate follow-up work. Rename requests against malformed or unresolved models also retain the existing Xtext language-server behavior.