### PR TITLE
Add Behavior Annex conformance tests 🤖

### DIFF
--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_ExternalConditionGrouping.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_ExternalConditionGrouping.txt
@@ -1,0 +1,1 @@
+error | syntax | 17 | 1 | 56 | no viable alternative at input 'on('

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_ExternalConditionXor.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_ExternalConditionXor.txt
@@ -1,0 +1,1 @@
+error | syntax | 17 | 1 | 55 | mismatched input 'xor' expecting {'and', 'or', '[', ']->', '.'}

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_FrozenPortParentheses.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_FrozenPortParentheses.txt
@@ -1,0 +1,1 @@
+error | syntax | 20 | 1 | 61 | extraneous input '(' expecting IDENT

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_InternalCondition.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_InternalCondition.txt
@@ -1,0 +1,1 @@
+error | syntax | 17 | 1 | 63 | extraneous input 'first_event' expecting {'and', 'or', '[', ']->', '.'}

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_InternalPortActions.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_InternalPortActions.txt
@@ -1,0 +1,2 @@
+error | semantic | 17 | 1 | 58 | 'internal_target' is not found
+error | semantic | 18 | 1 | 50 | 'internal_action' is not found

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_OptionalForClassifier.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_OptionalForClassifier.txt
@@ -1,0 +1,2 @@
+error | syntax | 16 | 1 | 23 | no viable alternative at input '{for(iin'
+warning | semantic | 5 | 7 | 10 | Base_Types in 'with' clause of public package section is not used.

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_OptionalForallClassifier.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_OptionalForallClassifier.txt
@@ -1,0 +1,2 @@
+error | syntax | 16 | 1 | 26 | no viable alternative at input '{forall(iin'
+warning | semantic | 5 | 7 | 10 | Base_Types in 'with' clause of public package section is not used.

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_PortUpdated.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_PortUpdated.txt
@@ -1,0 +1,1 @@
+error | syntax | 18 | 1 | 37 | mismatched input 'updated' expecting {'count', 'fresh'}

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_SelfPropertyReference.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_SelfPropertyReference.txt
@@ -1,0 +1,1 @@
+error | semantic | 17 | 1 | 50 | 'self' is not found

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_ShortCircuitOperators.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_ShortCircuitOperators.txt
@@ -1,0 +1,3 @@
+error | syntax | 15 | 1 | 64 | extraneous input 'right' expecting {'and', 'mod', 'or', 'rem', 'xor', '[', ']->', '?', '.', ''', '=', '!=', '<', '<=', '>', '>=', '+', '-', '*', '/', '**', '=='}
+error | syntax | 16 | 1 | 62 | no viable alternative at input 'else'
+warning | semantic | 5 | 7 | 10 | Base_Types in 'with' clause of public package section is not used.

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_TimeoutResetPorts.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_characterization_conformance_TimeoutResetPorts.txt
@@ -1,0 +1,1 @@
+error | syntax | 18 | 1 | 66 | mismatched input '(' expecting ']->'

--- a/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_ExternalConditionGrouping.txt
+++ b/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_ExternalConditionGrouping.txt
@@ -1,0 +1,1 @@
+annex[0] owner=ExternalConditionGrouping::component.i

--- a/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_ExternalConditionXor.txt
+++ b/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_ExternalConditionXor.txt
@@ -1,0 +1,1 @@
+annex[0] owner=ExternalConditionXor::component.i

--- a/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_FrozenPortParentheses.txt
+++ b/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_FrozenPortParentheses.txt
@@ -1,0 +1,1 @@
+annex[0] owner=FrozenPortParentheses::worker.i

--- a/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_InternalCondition.txt
+++ b/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_InternalCondition.txt
@@ -1,0 +1,1 @@
+annex[0] owner=InternalCondition::component.i

--- a/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_InternalPortActions.txt
+++ b/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_InternalPortActions.txt
@@ -1,0 +1,1 @@
+annex[0] owner=InternalPortActions::component.i

--- a/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_OptionalForClassifier.txt
+++ b/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_OptionalForClassifier.txt
@@ -1,0 +1,1 @@
+annex[0] owner=OptionalForClassifier::operation

--- a/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_OptionalForallClassifier.txt
+++ b/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_OptionalForallClassifier.txt
@@ -1,0 +1,1 @@
+annex[0] owner=OptionalForallClassifier::operation

--- a/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_PortUpdated.txt
+++ b/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_PortUpdated.txt
@@ -1,0 +1,1 @@
+annex[0] owner=PortUpdated::component.i

--- a/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_SelfPropertyReference.txt
+++ b/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_SelfPropertyReference.txt
@@ -1,0 +1,1 @@
+annex[0] owner=SelfPropertyReference::worker

--- a/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_ShortCircuitOperators.txt
+++ b/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_ShortCircuitOperators.txt
@@ -1,0 +1,1 @@
+annex[0] owner=ShortCircuitOperators::operation

--- a/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_TimeoutResetPorts.txt
+++ b/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_TimeoutResetPorts.txt
@@ -1,0 +1,1 @@
+annex[0] owner=TimeoutResetPorts::worker.i

--- a/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_UnaryPlus.txt
+++ b/ba/org.osate.ba.tests/expected/positions/org.osate.ba.tests_models_characterization_conformance_UnaryPlus.txt
@@ -1,0 +1,7 @@
+annex[0] owner=UnaryPlus::operation
+  (BehaviorState, finish, 333, 6)
+  (BehaviorState, start, 257, 5)
+  (BehaviorState, start, 282, 6)
+  (BehaviorState, start, 320, 5)
+  (BehaviorVariable, value, 342, 5)
+  (DataType, Integer, 224, 10)

--- a/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_ExternalConditionGrouping.txt
+++ b/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_ExternalConditionGrouping.txt
@@ -1,0 +1,2 @@
+annex[0] owner=ExternalConditionGrouping::component.i
+  parsedAnnexSubclause : BehaviorAnnex name=behavior_specification

--- a/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_ExternalConditionXor.txt
+++ b/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_ExternalConditionXor.txt
@@ -1,0 +1,2 @@
+annex[0] owner=ExternalConditionXor::component.i
+  parsedAnnexSubclause : BehaviorAnnex name=behavior_specification

--- a/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_FrozenPortParentheses.txt
+++ b/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_FrozenPortParentheses.txt
@@ -1,0 +1,2 @@
+annex[0] owner=FrozenPortParentheses::worker.i
+  parsedAnnexSubclause : BehaviorAnnex name=behavior_specification

--- a/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_InternalCondition.txt
+++ b/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_InternalCondition.txt
@@ -1,0 +1,2 @@
+annex[0] owner=InternalCondition::component.i
+  parsedAnnexSubclause : BehaviorAnnex name=behavior_specification

--- a/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_InternalPortActions.txt
+++ b/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_InternalPortActions.txt
@@ -1,0 +1,19 @@
+annex[0] owner=InternalPortActions::component.i
+  parsedAnnexSubclause : BehaviorAnnex name=behavior_specification
+    states[0] : BehaviorState name=start
+    states[1] : BehaviorState name=finish
+    transitions[0] : DeclarativeBehaviorTransition name=assign
+      srcStates[0] : Identifier
+      destState : Identifier
+    transitions[1] : DeclarativeBehaviorTransition name=send
+      srcStates[0] : Identifier
+      destState : Identifier
+    actions[0] : BehaviorActionBlock
+      content : AssignmentAction
+        target : Reference
+          ids[0] : ArrayableIdentifier
+        valueExpression : Any
+    actions[1] : BehaviorActionBlock
+      content : CommAction
+        reference : Reference
+          ids[0] : ArrayableIdentifier

--- a/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_OptionalForClassifier.txt
+++ b/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_OptionalForClassifier.txt
@@ -1,0 +1,2 @@
+annex[0] owner=OptionalForClassifier::operation
+  parsedAnnexSubclause : BehaviorAnnex name=behavior_specification

--- a/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_OptionalForallClassifier.txt
+++ b/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_OptionalForallClassifier.txt
@@ -1,0 +1,2 @@
+annex[0] owner=OptionalForallClassifier::operation
+  parsedAnnexSubclause : BehaviorAnnex name=behavior_specification

--- a/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_PortUpdated.txt
+++ b/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_PortUpdated.txt
@@ -1,0 +1,2 @@
+annex[0] owner=PortUpdated::component.i
+  parsedAnnexSubclause : BehaviorAnnex name=behavior_specification

--- a/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_SelfPropertyReference.txt
+++ b/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_SelfPropertyReference.txt
@@ -1,0 +1,24 @@
+annex[0] owner=SelfPropertyReference::worker
+  parsedAnnexSubclause : BehaviorAnnex name=behavior_specification
+    variables[0] : BehaviorVariable name=value
+    states[0] : BehaviorState name=start
+    states[1] : BehaviorState name=finish
+    transitions[0] : DeclarativeBehaviorTransition
+      srcStates[0] : Identifier
+      destState : Identifier
+    actions[0] : BehaviorActionBlock
+      content : AssignmentAction
+        target : Reference
+          ids[0] : ArrayableIdentifier
+        valueExpression : ValueExpression
+          relations[0] : Relation
+            firstExpression : SimpleExpression
+              terms[0] : Term
+                factors[0] : Factor
+                  firstValue : DeclarativePropertyReference
+                    qualifiedName : QualifiedNamedElement
+                      baName : Identifier
+                    reference : Reference
+                      ids[0] : ArrayableIdentifier
+                    propertyNames[0] : DeclarativePropertyName
+                      propertyName : Identifier

--- a/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_ShortCircuitOperators.txt
+++ b/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_ShortCircuitOperators.txt
@@ -1,0 +1,2 @@
+annex[0] owner=ShortCircuitOperators::operation
+  parsedAnnexSubclause : BehaviorAnnex name=behavior_specification

--- a/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_TimeoutResetPorts.txt
+++ b/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_TimeoutResetPorts.txt
@@ -1,0 +1,2 @@
+annex[0] owner=TimeoutResetPorts::worker.i
+  parsedAnnexSubclause : BehaviorAnnex name=behavior_specification

--- a/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_UnaryPlus.txt
+++ b/ba/org.osate.ba.tests/expected/resolved-model/org.osate.ba.tests_models_characterization_conformance_UnaryPlus.txt
@@ -1,0 +1,15 @@
+annex[0] owner=UnaryPlus::operation
+  parsedAnnexSubclause : BehaviorAnnex name=behavior_specification
+    variables[0] : BehaviorVariable name=value
+    states[0] : BehaviorState name=start
+    states[1] : BehaviorState name=finish
+    transitions[0] : BehaviorTransition
+    actions[0] : BehaviorActionBlock
+      content : AssignmentAction
+        target : BehaviorVariableHolder element=value [BehaviorVariable]
+        valueExpression : ValueExpression
+          relations[0] : Relation
+            firstExpression : SimpleExpression
+              terms[0] : Term
+                factors[0] : Factor
+                  firstValue : BehaviorIntegerLiteral

--- a/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_ExternalConditionGrouping.txt
+++ b/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_ExternalConditionGrouping.txt
@@ -1,0 +1,4 @@
+===== annex[0] owner=ExternalConditionGrouping::component.i =====
+
+----- legacy round-trip -----
+idempotent

--- a/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_ExternalConditionXor.txt
+++ b/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_ExternalConditionXor.txt
@@ -1,0 +1,4 @@
+===== annex[0] owner=ExternalConditionXor::component.i =====
+
+----- legacy round-trip -----
+idempotent

--- a/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_FrozenPortParentheses.txt
+++ b/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_FrozenPortParentheses.txt
@@ -1,0 +1,4 @@
+===== annex[0] owner=FrozenPortParentheses::worker.i =====
+
+----- legacy round-trip -----
+idempotent

--- a/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_InternalCondition.txt
+++ b/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_InternalCondition.txt
@@ -1,0 +1,4 @@
+===== annex[0] owner=InternalCondition::component.i =====
+
+----- legacy round-trip -----
+idempotent

--- a/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_InternalPortActions.txt
+++ b/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_InternalPortActions.txt
@@ -1,0 +1,14 @@
+===== annex[0] owner=InternalPortActions::component.i =====
+
+states
+  start : initial state;
+  finish : final state;
+transitions
+  assign : start -[]-> finish {
+    internal_target := any
+  };
+  send : start -[]-> finish {
+    internal_action !
+  };
+----- legacy round-trip -----
+idempotent

--- a/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_OptionalForClassifier.txt
+++ b/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_OptionalForClassifier.txt
@@ -1,0 +1,4 @@
+===== annex[0] owner=OptionalForClassifier::operation =====
+
+----- legacy round-trip -----
+idempotent

--- a/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_OptionalForallClassifier.txt
+++ b/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_OptionalForallClassifier.txt
@@ -1,0 +1,4 @@
+===== annex[0] owner=OptionalForallClassifier::operation =====
+
+----- legacy round-trip -----
+idempotent

--- a/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_PortUpdated.txt
+++ b/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_PortUpdated.txt
@@ -1,0 +1,4 @@
+===== annex[0] owner=PortUpdated::component.i =====
+
+----- legacy round-trip -----
+idempotent

--- a/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_SelfPropertyReference.txt
+++ b/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_SelfPropertyReference.txt
@@ -1,0 +1,2 @@
+===== annex[0] owner=SelfPropertyReference::worker =====
+<legacy-unparse-exception> java.lang.NullPointerException: Cannot invoke "org.osate.ba.declarative.Identifier.getId()" because the return value of "org.osate.ba.declarative.QualifiedNamedElement.getBaNamespace()" is null

--- a/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_ShortCircuitOperators.txt
+++ b/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_ShortCircuitOperators.txt
@@ -1,0 +1,4 @@
+===== annex[0] owner=ShortCircuitOperators::operation =====
+
+----- legacy round-trip -----
+idempotent

--- a/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_TimeoutResetPorts.txt
+++ b/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_TimeoutResetPorts.txt
@@ -1,0 +1,4 @@
+===== annex[0] owner=TimeoutResetPorts::worker.i =====
+
+----- legacy round-trip -----
+idempotent

--- a/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_UnaryPlus.txt
+++ b/ba/org.osate.ba.tests/expected/unparse/org.osate.ba.tests_models_characterization_conformance_UnaryPlus.txt
@@ -1,0 +1,13 @@
+===== annex[0] owner=UnaryPlus::operation =====
+
+variables
+  value : Base_Types::Integer;
+states
+  start : initial state;
+  finish : final state;
+transitions
+  start -[]-> finish {
+    value := +1
+  };
+----- legacy round-trip -----
+idempotent

--- a/ba/org.osate.ba.tests/models/characterization/conformance/ExternalConditionGrouping.aadl
+++ b/ba/org.osate.ba.tests/models/characterization/conformance/ExternalConditionGrouping.aadl
@@ -1,0 +1,20 @@
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others.
+-- SPDX-License-Identifier: EPL-2.0
+package ExternalConditionGrouping
+public
+	abstract component
+	features
+		first_event: in event port;
+		second_event: in event port;
+	end component;
+
+	abstract implementation component.i
+	annex behavior_specification {**
+		states
+			start: initial state;
+			finish: final state;
+		transitions
+			start -[ on (first_event or second_event) ]-> finish;
+	**};
+	end component.i;
+end ExternalConditionGrouping;

--- a/ba/org.osate.ba.tests/models/characterization/conformance/ExternalConditionXor.aadl
+++ b/ba/org.osate.ba.tests/models/characterization/conformance/ExternalConditionXor.aadl
@@ -1,0 +1,20 @@
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others.
+-- SPDX-License-Identifier: EPL-2.0
+package ExternalConditionXor
+public
+	abstract component
+	features
+		first_event: in event port;
+		second_event: in event port;
+	end component;
+
+	abstract implementation component.i
+	annex behavior_specification {**
+		states
+			start: initial state;
+			finish: final state;
+		transitions
+			start -[ on first_event xor second_event ]-> finish;
+	**};
+	end component.i;
+end ExternalConditionXor;

--- a/ba/org.osate.ba.tests/models/characterization/conformance/FrozenPortParentheses.aadl
+++ b/ba/org.osate.ba.tests/models/characterization/conformance/FrozenPortParentheses.aadl
@@ -1,0 +1,23 @@
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others.
+-- SPDX-License-Identifier: EPL-2.0
+package FrozenPortParentheses
+public
+	with Base_Types;
+
+	thread worker
+	features
+		sampled_input: in data port Base_Types::Integer;
+	properties
+		Dispatch_Protocol => Periodic;
+		Period => 10 ms;
+	end worker;
+
+	thread implementation worker.i
+	annex behavior_specification {**
+		states
+			waiting: initial complete final state;
+		transitions
+			waiting -[ on dispatch frozen (sampled_input) ]-> waiting;
+	**};
+	end worker.i;
+end FrozenPortParentheses;

--- a/ba/org.osate.ba.tests/models/characterization/conformance/InternalCondition.aadl
+++ b/ba/org.osate.ba.tests/models/characterization/conformance/InternalCondition.aadl
@@ -1,0 +1,20 @@
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others.
+-- SPDX-License-Identifier: EPL-2.0
+package InternalCondition
+public
+	abstract component
+	end component;
+
+	abstract implementation component.i
+	internal features
+		first_event: event;
+		second_event: event;
+	annex behavior_specification {**
+		states
+			start: initial state;
+			finish: final state;
+		transitions
+			start -[ on internal first_event or second_event ]-> finish;
+	**};
+	end component.i;
+end InternalCondition;

--- a/ba/org.osate.ba.tests/models/characterization/conformance/InternalPortActions.aadl
+++ b/ba/org.osate.ba.tests/models/characterization/conformance/InternalPortActions.aadl
@@ -1,0 +1,21 @@
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others.
+-- SPDX-License-Identifier: EPL-2.0
+package InternalPortActions
+public
+	abstract component
+	end component;
+
+	abstract implementation component.i
+	internal features
+		internal_target: event data;
+		internal_action: event;
+	annex behavior_specification {**
+		states
+			start: initial state;
+			finish: final state;
+		transitions
+			assign: start -[ ]-> finish { internal_target := any };
+			send: start -[ ]-> finish { internal_action! };
+	**};
+	end component.i;
+end InternalPortActions;

--- a/ba/org.osate.ba.tests/models/characterization/conformance/OptionalForClassifier.aadl
+++ b/ba/org.osate.ba.tests/models/characterization/conformance/OptionalForClassifier.aadl
@@ -1,0 +1,22 @@
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others.
+-- SPDX-License-Identifier: EPL-2.0
+package OptionalForClassifier
+public
+	with Base_Types;
+
+	subprogram operation
+	annex behavior_specification {**
+		variables
+			value: Base_Types::Integer;
+		states
+			start: initial state;
+			finish: final state;
+		transitions
+			start -[ ]-> finish {
+				for (i in 0 .. 1) {
+					value := i
+				}
+			};
+	**};
+	end operation;
+end OptionalForClassifier;

--- a/ba/org.osate.ba.tests/models/characterization/conformance/OptionalForallClassifier.aadl
+++ b/ba/org.osate.ba.tests/models/characterization/conformance/OptionalForallClassifier.aadl
@@ -1,0 +1,22 @@
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others.
+-- SPDX-License-Identifier: EPL-2.0
+package OptionalForallClassifier
+public
+	with Base_Types;
+
+	subprogram operation
+	annex behavior_specification {**
+		variables
+			value: Base_Types::Integer;
+		states
+			start: initial state;
+			finish: final state;
+		transitions
+			start -[ ]-> finish {
+				forall (i in 0 .. 1) {
+					value := i
+				}
+			};
+	**};
+	end operation;
+end OptionalForallClassifier;

--- a/ba/org.osate.ba.tests/models/characterization/conformance/PortUpdated.aadl
+++ b/ba/org.osate.ba.tests/models/characterization/conformance/PortUpdated.aadl
@@ -1,0 +1,21 @@
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others.
+-- SPDX-License-Identifier: EPL-2.0
+package PortUpdated
+public
+	with Base_Types;
+
+	abstract component
+	features
+		input: in data port Base_Types::Integer;
+	end component;
+
+	abstract implementation component.i
+	annex behavior_specification {**
+		states
+			start: initial state;
+			finish: final state;
+		transitions
+			start -[ input'updated ]-> finish;
+	**};
+	end component.i;
+end PortUpdated;

--- a/ba/org.osate.ba.tests/models/characterization/conformance/SelfPropertyReference.aadl
+++ b/ba/org.osate.ba.tests/models/characterization/conformance/SelfPropertyReference.aadl
@@ -1,0 +1,20 @@
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others.
+-- SPDX-License-Identifier: EPL-2.0
+package SelfPropertyReference
+public
+	with Base_Types;
+
+	thread worker
+	properties
+		Priority => 1;
+	annex behavior_specification {**
+		variables
+			value: Base_Types::Integer;
+		states
+			start: initial state;
+			finish: final state;
+		transitions
+			start -[ ]-> finish { value := self#Priority };
+	**};
+	end worker;
+end SelfPropertyReference;

--- a/ba/org.osate.ba.tests/models/characterization/conformance/ShortCircuitOperators.aadl
+++ b/ba/org.osate.ba.tests/models/characterization/conformance/ShortCircuitOperators.aadl
@@ -1,0 +1,19 @@
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others.
+-- SPDX-License-Identifier: EPL-2.0
+package ShortCircuitOperators
+public
+	with Base_Types;
+
+	subprogram operation
+	annex behavior_specification {**
+		variables
+			left, right: Base_Types::Boolean;
+		states
+			start: initial state;
+			finish: final state;
+		transitions
+			and_then_transition: start -[ left and then right ]-> finish;
+			or_else_transition: start -[ left or else right ]-> finish;
+	**};
+	end operation;
+end ShortCircuitOperators;

--- a/ba/org.osate.ba.tests/models/characterization/conformance/TimeoutResetPorts.aadl
+++ b/ba/org.osate.ba.tests/models/characterization/conformance/TimeoutResetPorts.aadl
@@ -1,0 +1,21 @@
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others.
+-- SPDX-License-Identifier: EPL-2.0
+package TimeoutResetPorts
+public
+	thread worker
+	features
+		reset_event: in event port;
+	properties
+		Dispatch_Protocol => Timed;
+		Period => 10 ms;
+	end worker;
+
+	thread implementation worker.i
+	annex behavior_specification {**
+		states
+			waiting: initial complete final state;
+		transitions
+			waiting -[ on dispatch timeout (reset_event) 10 ms ]-> waiting;
+	**};
+	end worker.i;
+end TimeoutResetPorts;

--- a/ba/org.osate.ba.tests/models/characterization/conformance/UnaryPlus.aadl
+++ b/ba/org.osate.ba.tests/models/characterization/conformance/UnaryPlus.aadl
@@ -1,0 +1,18 @@
+-- Copyright (c) 2004-2026 Carnegie Mellon University and others.
+-- SPDX-License-Identifier: EPL-2.0
+package UnaryPlus
+public
+	with Base_Types;
+
+	subprogram operation
+	annex behavior_specification {**
+		variables
+			value: Base_Types::Integer;
+		states
+			start: initial state;
+			finish: final state;
+		transitions
+			start -[ ]-> finish { value := +1 };
+	**};
+	end operation;
+end UnaryPlus;

--- a/ba/org.osate.ba.tests/src/org/osate/ba/tests/characterization/BehaviorAnnexConformanceTest.java
+++ b/ba/org.osate.ba.tests/src/org/osate/ba/tests/characterization/BehaviorAnnexConformanceTest.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.ba.tests.characterization;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.validation.Issue;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AnnexSubclause;
+import org.osate.aadl2.DefaultAnnexSubclause;
+import org.osate.aadl2.Element;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisToParseErrorReporterAdapter;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingParseErrorReporter;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingParseErrorReporter.Message;
+import org.osate.annexsupport.AnnexUtil;
+import org.osate.ba.AadlBaParserAction;
+import org.osate.ba.AadlBaResolver;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.FluentIssueCollection;
+
+/**
+ * Records the Behavior Annex constructs required by AS5506/3 Rev A but not implemented by the current parser,
+ * resolver, or type checker. Each active test pins today's legacy-front-end behavior, while the paired ignored test
+ * states the standard-conforming outcome that the Xtext implementation may satisfy as part of issue #2445. The Xtext
+ * parser is not required to reproduce the legacy rejection.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class BehaviorAnnexConformanceTest {
+	private static final String MODEL_DIRECTORY = "org.osate.ba.tests/models/characterization/conformance/";
+
+	@Inject
+	private TestHelper<?> testHelper;
+
+	@Test
+	public void internalConditionCurrentFailure() throws Exception {
+		assertDiagnostics("InternalCondition.aadl",
+				List.of("syntax | extraneous input 'first_event' expecting {'and', 'or', '[', ']->', '.'}"));
+	}
+
+	@Ignore("Issue #2445: implement internal conditions")
+	@Test
+	public void internalConditionIsAcceptedByTheStandard() throws Exception {
+		assertNoIssues("InternalCondition.aadl");
+	}
+
+	@Test
+	public void externalConditionOperatorsCurrentFailure() throws Exception {
+		assertDiagnostics("ExternalConditionXor.aadl",
+				List.of("syntax | mismatched input 'xor' expecting {'and', 'or', '[', ']->', '.'}"));
+		assertDiagnostics("ExternalConditionGrouping.aadl",
+				List.of("syntax | extraneous input 'or' expecting {<EOF>, IDENT}",
+						"syntax | no viable alternative at input 'on('",
+						"syntax | unterminated behavior transition (missing ending ';')"));
+	}
+
+	@Ignore("Issue #2445: implement all external-condition logical operators and grouping")
+	@Test
+	public void externalConditionOperatorsAreAcceptedByTheStandard() throws Exception {
+		assertNoIssues("ExternalConditionXor.aadl");
+		assertNoIssues("ExternalConditionGrouping.aadl");
+	}
+
+	@Test
+	public void frozenPortParenthesesCurrentFailure() throws Exception {
+		assertDiagnostics("FrozenPortParentheses.aadl",
+				List.of("syntax | extraneous input '(' expecting IDENT",
+						"syntax | extraneous input ')' expecting {'[', ',', ']->', '.', IDENT}"));
+	}
+
+	@Ignore("Issue #2445: conform frozen-port syntax to AS5506/3 Rev A")
+	@Test
+	public void frozenPortParenthesesAreAcceptedByTheStandard() throws Exception {
+		assertNoIssues("FrozenPortParentheses.aadl");
+	}
+
+	@Test
+	public void timeoutResetPortsCurrentFailure() throws Exception {
+		assertDiagnostics("TimeoutResetPorts.aadl", List.of("syntax | mismatched input '(' expecting ']->'"));
+	}
+
+	@Ignore("Issue #2445: implement completion-relative timeout reset ports")
+	@Test
+	public void timeoutResetPortsAreAcceptedByTheStandard() throws Exception {
+		assertNoIssues("TimeoutResetPorts.aadl");
+	}
+
+	@Test
+	public void shortCircuitOperatorsCurrentFailure() throws Exception {
+		assertDiagnostics("ShortCircuitOperators.aadl",
+				List.of("syntax | extraneous input 'right' expecting {'and', 'mod', 'or', 'rem', 'xor', '[', "
+						+ "']->', '?', '.', ''', '=', '!=', '<', '<=', '>', '>=', '+', '-', '*', '/', '**', '=='}",
+						"syntax | no viable alternative at input 'else'"));
+	}
+
+	@Ignore("Issue #2445: implement and then and or else")
+	@Test
+	public void shortCircuitOperatorsAreAcceptedByTheStandard() throws Exception {
+		assertNoIssues("ShortCircuitOperators.aadl");
+	}
+
+	@Test
+	public void unaryPlusCurrentOverAcceptance() throws Exception {
+		assertNoIssues("UnaryPlus.aadl");
+	}
+
+	@Ignore("Issue #2445: reject unary plus as required by AS5506/3 Rev A")
+	@Test
+	public void unaryPlusIsRejectedByTheStandard() throws Exception {
+		assertHasSyntaxError("UnaryPlus.aadl");
+	}
+
+	@Test
+	public void portUpdatedCurrentFailure() throws Exception {
+		assertDiagnostics("PortUpdated.aadl",
+				List.of("syntax | mismatched input 'updated' expecting {'count', 'fresh'}"));
+	}
+
+	@Ignore("Issue #2445: implement the port updated value")
+	@Test
+	public void portUpdatedIsAcceptedByTheStandard() throws Exception {
+		assertNoIssues("PortUpdated.aadl");
+	}
+
+	@Test
+	public void selfPropertyReferenceCurrentFailure() throws Exception {
+		assertDiagnostics("SelfPropertyReference.aadl", List.of("semantic | 'self' is not found"));
+	}
+
+	@Ignore("Issue #2445: implement self as a component element reference")
+	@Test
+	public void selfPropertyReferenceIsAcceptedByTheStandard() throws Exception {
+		assertNoIssues("SelfPropertyReference.aadl");
+	}
+
+	@Test
+	public void optionalLoopClassifierCurrentFailure() throws Exception {
+		assertDiagnostics("OptionalForClassifier.aadl",
+				List.of("syntax | no viable alternative at input '{for(iin'",
+						"syntax | unterminated behavior transition (missing ending ';')"));
+		assertDiagnostics("OptionalForallClassifier.aadl",
+				List.of("syntax | no viable alternative at input '{forall(iin'",
+						"syntax | unterminated behavior transition (missing ending ';')"));
+	}
+
+	@Ignore("Issue #2445: make for and forall classifiers optional")
+	@Test
+	public void optionalLoopClassifierIsAcceptedByTheStandard() throws Exception {
+		assertNoIssues("OptionalForClassifier.aadl");
+		assertNoIssues("OptionalForallClassifier.aadl");
+	}
+
+	@Test
+	public void internalPortActionsCurrentFailure() throws Exception {
+		assertDiagnostics("InternalPortActions.aadl",
+				List.of("semantic | 'internal_action' is not found", "semantic | 'internal_target' is not found"));
+	}
+
+	@Ignore("Issue #2445: support internal ports as targets and communication actions")
+	@Test
+	public void internalPortActionsAreAcceptedByTheStandard() throws Exception {
+		assertNoIssues("InternalPortActions.aadl");
+	}
+
+	private void assertNoIssues(final String model) throws Exception {
+		final FluentIssueCollection result = testHelper.testFile(MODEL_DIRECTORY + model);
+		assertTrue(result.getSummary(), result.getIssues().isEmpty());
+	}
+
+	private void assertHasSyntaxError(final String model) throws Exception {
+		final FluentIssueCollection result = testHelper.testFile(MODEL_DIRECTORY + model);
+		assertTrue(result.getSummary(), result.getIssues().stream().anyMatch(Issue::isSyntaxError));
+	}
+
+	private void assertDiagnostics(final String model, final List<String> expected) throws Exception {
+		final Element root = (Element) testHelper.parseFile(MODEL_DIRECTORY + model);
+		final DefaultAnnexSubclause defaultAnnex = AnnexUtil.getAllDefaultAnnexSubclauses(root).get(0);
+		final String sourceText = defaultAnnex.getSourceText();
+		final String annexText = sourceText.startsWith("{**")
+				? sourceText.substring(3, sourceText.length() - 3)
+				: sourceText;
+		final QueuingParseErrorReporter parseReporter = new QueuingParseErrorReporter();
+		parseReporter.setContextResource(defaultAnnex.eResource());
+		AnnexUtil.setCurrentAnnexSubclause(defaultAnnex);
+		final AnnexSubclause parsed;
+		try {
+			parsed = new AadlBaParserAction().parseAnnexSubclause(AadlBaParserAction.ANNEX_NAME, annexText, model, 1,
+					AnnexUtil.getAnnexOffset(defaultAnnex), parseReporter);
+		} finally {
+			AnnexUtil.setCurrentAnnexSubclause(null);
+		}
+
+		final List<String> actual;
+		if (parseReporter.getNumErrors() > 0) {
+			actual = describe("syntax", parseReporter.getErrors());
+		} else {
+			parsed.setName(AadlBaParserAction.ANNEX_NAME);
+			defaultAnnex.setParsedAnnexSubclause(parsed);
+			parsed.getInModes().addAll(defaultAnnex.getInModes());
+			final QueuingParseErrorReporter resolverReporter = new QueuingParseErrorReporter();
+			resolverReporter.setContextResource(defaultAnnex.eResource());
+			final AnalysisErrorReporterManager errorManager = new AnalysisErrorReporterManager(
+					new AnalysisToParseErrorReporterAdapter.Factory(resource -> resolverReporter));
+			new AadlBaResolver().resolveAnnex(AadlBaParserAction.ANNEX_NAME, Collections.singletonList(parsed),
+					errorManager);
+			actual = describe("semantic", resolverReporter.getErrors());
+		}
+		assertEquals(expected, actual);
+	}
+
+	private static List<String> describe(final String origin, final List<Message> messages) {
+		return messages.stream()
+				.map(message -> origin + " | " + message.message)
+				.sorted()
+				.collect(Collectors.toList());
+	}
+}


### PR DESCRIPTION
## Summary

- Add phase 2a conformance fixtures for the AS5506/3 Rev A constructs documented in the Behavior Annex Xtext plan.
- Pin the current ANTLR parser and resolver behavior with active tests.
- Pair each legacy expectation with an ignored issue #2445 acceptance test; the Xtext parser may accept the standard syntax without reproducing the legacy rejection.
- Add diagnostic, resolved-model, position, and unparse goldens for all 12 fixtures.

## Validation

- Focused BA reactor with Maven `-T5`: 60 tests, 0 failures, 0 errors, 12 intentionally skipped.
- Clean offline root reactor with Maven `-T5` and `-Dtycho.localArtifacts=ignore`: 138 projects, 1,477 tests, 0 failures, 0 errors, 12 skipped.

## Dependency and merge order

- Depends on #3138, which adds the characterization infrastructure used here.
- Merge #3138 first, then this PR.
- This PR is intentionally based on `2445_characterize_behavior_annex`.

## Residual risk

This is test-only. The standards-acceptance tests remain ignored until the Xtext implementation provides the corresponding behavior.

Part of #2445