### PR TITLE
Decouple Behavior Annex checkers from resolution 🤖

### DIFF
--- a/ba/org.osate.ba.tests/src/org/osate/ba/tests/characterization/CheckerDecouplingTest.java
+++ b/ba/org.osate.ba.tests/src/org/osate/ba/tests/characterization/CheckerDecouplingTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to the Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.ba.tests.characterization;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.ComponentClassifier;
+import org.osate.aadl2.DefaultAnnexSubclause;
+import org.osate.aadl2.Element;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.modelsupport.errorreporting.QueuingAnalysisErrorReporter;
+import org.osate.annexsupport.AnnexUtil;
+import org.osate.ba.aadlba.BehaviorAnnex;
+import org.osate.ba.analyzers.AadlBaNameResolver;
+import org.osate.ba.analyzers.AadlBaRulesCheckersDriver;
+import org.osate.ba.analyzers.AadlBaTypeChecker;
+import org.osate.ba.analyzers.AdaLikeDataTypeChecker;
+import org.osate.ba.analyzers.DataTypeChecker;
+import org.osate.ba.utils.AadlBaVisitors;
+import org.osate.testsupport.Aadl2InjectorProvider;
+import org.osate.testsupport.TestHelper;
+
+import com.google.inject.Inject;
+import com.itemis.xtext.testing.FluentIssueCollection;
+
+/**
+ * Verifies the phase 2b checker boundary required by the future declarative-to-strict translator: classifier context
+ * must be supplied without relying on annex containment, and checking an already resolved detached strict model must
+ * not mutate it.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Aadl2InjectorProvider.class)
+public class CheckerDecouplingTest {
+	private static final String MODEL = "org.osate.ba.tests/models/characterization/GrammarHazards.aadl";
+
+	@Inject
+	private TestHelper<Element> testHelper;
+
+	@Test
+	public void detachedResolvedModelUsesExplicitContextAndRemainsUnchanged() throws Exception {
+		final Element root = testHelper.parseFile(MODEL);
+		final FluentIssueCollection issues = testHelper.testResource(root.eResource());
+		assertTrue(issues.getSummary(), issues.getIssues().isEmpty());
+
+		final DefaultAnnexSubclause defaultAnnex = AnnexUtil.getAllDefaultAnnexSubclauses(root).get(0);
+		final ComponentClassifier classifier = (ComponentClassifier) defaultAnnex.getContainingClassifier();
+		final BehaviorAnnex detached = EcoreUtil.copy((BehaviorAnnex) defaultAnnex.getParsedAnnexSubclause());
+		assertNull(detached.eContainer());
+
+		final Method getParentComponent = AadlBaVisitors.class.getMethod("getParentComponent", BehaviorAnnex.class,
+				ComponentClassifier.class);
+		assertSame(classifier, getParentComponent.invoke(null, detached, classifier));
+
+		final AnalysisErrorReporterManager errorManager = new AnalysisErrorReporterManager(
+				QueuingAnalysisErrorReporter.factory);
+		final Constructor<AadlBaNameResolver> nameResolverConstructor = AadlBaNameResolver.class
+				.getConstructor(BehaviorAnnex.class, ComponentClassifier.class, AnalysisErrorReporterManager.class);
+		nameResolverConstructor.newInstance(detached, classifier, errorManager);
+
+		final DataTypeChecker dataTypeChecker = new AdaLikeDataTypeChecker(errorManager);
+		final Constructor<AadlBaTypeChecker> typeCheckerConstructor = AadlBaTypeChecker.class.getConstructor(
+				BehaviorAnnex.class, ComponentClassifier.class, DataTypeChecker.class,
+				AnalysisErrorReporterManager.class);
+		final AadlBaTypeChecker typeChecker = typeCheckerConstructor.newInstance(detached, classifier, dataTypeChecker,
+				errorManager);
+		final BehaviorAnnex beforeChecking = EcoreUtil.copy(detached);
+		assertTrue(typeChecker.checkTypes());
+		assertTrue("Type checking changed the detached strict model", EcoreUtil.equals(beforeChecking, detached));
+
+		final Constructor<AadlBaRulesCheckersDriver> rulesConstructor = AadlBaRulesCheckersDriver.class
+				.getConstructor(BehaviorAnnex.class, ComponentClassifier.class, AnalysisErrorReporterManager.class);
+		final AadlBaRulesCheckersDriver rules = rulesConstructor.newInstance(detached, classifier, errorManager);
+		assertTrue(rules.process(detached));
+		assertTrue("Rules checking changed the detached strict model", EcoreUtil.equals(beforeChecking, detached));
+	}
+}

--- a/ba/org.osate.ba/src/org/osate/ba/AadlBaResolver.java
+++ b/ba/org.osate.ba/src/org/osate/ba/AadlBaResolver.java
@@ -25,10 +25,12 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.core.runtime.Platform;
+import org.osate.aadl2.ComponentClassifier;
 import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
 import org.osate.annexsupport.AnnexResolver;
 import org.osate.ba.aadlba.BehaviorAnnex;
 import org.osate.ba.aadlba.BehaviorTransition;
+import org.osate.ba.analyzers.AadlBaModelResolver;
 import org.osate.ba.analyzers.AadlBaNameResolver;
 import org.osate.ba.analyzers.AadlBaRulesCheckersDriver;
 import org.osate.ba.analyzers.AadlBaTypeChecker;
@@ -38,6 +40,7 @@ import org.osate.ba.analyzers.DeclarativeUtils;
 import org.osate.ba.texteditor.AadlBaHyperlink;
 import org.osate.ba.texteditor.DefaultAadlBaHyperlink;
 import org.osate.ba.texteditor.XtextAadlBaHyperlink;
+import org.osate.ba.utils.AadlBaVisitors;
 
 public class AadlBaResolver implements AnnexResolver {
 	public static final String ANNEX_NAME = "behavior_specification";
@@ -49,19 +52,20 @@ public class AadlBaResolver implements AnnexResolver {
 		BehaviorAnnex ba;
 		AadlBaNameResolver nameResolver;
 		AadlBaRulesCheckersDriver semanticAnalysis;
+		AadlBaModelResolver modelResolver;
 		AadlBaTypeChecker typeChecker;
 		DataTypeChecker dataTypeChecker = new AdaLikeDataTypeChecker(errManager);
 		while (it.hasNext()) {
 			boolean result = false;
 			ba = (BehaviorAnnex) it.next();
-			nameResolver = new AadlBaNameResolver(ba, errManager);
+			ComponentClassifier parentContainer = AadlBaVisitors.getParentComponent(ba);
+			nameResolver = new AadlBaNameResolver(ba, parentContainer, errManager);
 
 			result = nameResolver.resolveNames();
 
 			// It doesnt't perform semantic tests if the name resolution has
 			// failed.
 			if (result) {
-				typeChecker = new AadlBaTypeChecker(ba, dataTypeChecker, errManager);
 				AadlBaHyperlink hyperlinker;
 
 				// Set a Xtext hyperlink builder if AADLBA Front End is running
@@ -72,12 +76,17 @@ public class AadlBaResolver implements AnnexResolver {
 				{
 					hyperlinker = new DefaultAadlBaHyperlink();
 				}
-				typeChecker.setAadlBaHyperlink(hyperlinker);
-				result = typeChecker.checkTypes();
+				modelResolver = new AadlBaModelResolver(ba, parentContainer, dataTypeChecker, errManager);
+				modelResolver.setAadlBaHyperlink(hyperlinker);
+				result = modelResolver.resolveModel();
 
 				if (result) {
+					typeChecker = new AadlBaTypeChecker(ba, parentContainer, dataTypeChecker, errManager);
+					result = typeChecker.checkTypes();
+				}
 
-					semanticAnalysis = new AadlBaRulesCheckersDriver(ba, errManager);
+				if (result) {
+					semanticAnalysis = new AadlBaRulesCheckersDriver(ba, parentContainer, errManager);
 					result = semanticAnalysis.process(ba);
 				}
 

--- a/ba/org.osate.ba/src/org/osate/ba/analyzers/AadlBaConsistencyRulesChecker.java
+++ b/ba/org.osate.ba/src/org/osate/ba/analyzers/AadlBaConsistencyRulesChecker.java
@@ -52,10 +52,15 @@ public class AadlBaConsistencyRulesChecker {
 	private AnalysisErrorReporterManager _errManager;
 
 	public AadlBaConsistencyRulesChecker(BehaviorAnnex ba, AnalysisErrorReporterManager errManager) {
+		this(ba, AadlBaVisitors.getParentComponent(ba), errManager);
+	}
+
+	public AadlBaConsistencyRulesChecker(BehaviorAnnex ba, ComponentClassifier parentContainer,
+			AnalysisErrorReporterManager errManager) {
 		_ba = ba;
 		_errManager = errManager;
-		_baParentContainer = AadlBaVisitors.getParentComponent(ba);
-		_contextsTab = AadlBaVisitors.getBaPackageSections(_ba);
+		_baParentContainer = AadlBaVisitors.getParentComponent(ba, parentContainer);
+		_contextsTab = AadlBaVisitors.getBaPackageSections(_ba, _baParentContainer);
 	}
 
 	/**

--- a/ba/org.osate.ba/src/org/osate/ba/analyzers/AadlBaLegalityRulesChecker.java
+++ b/ba/org.osate.ba/src/org/osate/ba/analyzers/AadlBaLegalityRulesChecker.java
@@ -65,7 +65,6 @@ import org.osate.ba.aadlba.IntegerValue;
 import org.osate.ba.aadlba.LoopStatement;
 import org.osate.ba.aadlba.Target;
 import org.osate.ba.aadlba.TimedAction;
-import org.osate.ba.declarative.DeclarativeBehaviorTransition;
 import org.osate.ba.declarative.Identifier;
 import org.osate.ba.utils.AadlBaUtils;
 import org.osate.ba.utils.AadlBaVisitors;
@@ -88,9 +87,14 @@ public class AadlBaLegalityRulesChecker {
 	private List<BehaviorTransition> _alreadyReportedErroneousTransition = new ArrayList<BehaviorTransition>();
 
 	public AadlBaLegalityRulesChecker(BehaviorAnnex ba, AnalysisErrorReporterManager errManager) {
+		this(ba, AadlBaVisitors.getParentComponent(ba), errManager);
+	}
+
+	public AadlBaLegalityRulesChecker(BehaviorAnnex ba, ComponentClassifier parentContainer,
+			AnalysisErrorReporterManager errManager) {
 		_ba = ba;
 		_errManager = errManager;
-		_baParentContainer = AadlBaVisitors.getParentComponent(ba);
+		_baParentContainer = AadlBaVisitors.getParentComponent(ba, parentContainer);
 	}
 
 	/**
@@ -356,7 +360,7 @@ public class AadlBaLegalityRulesChecker {
 	public boolean D_3_L5_Check(DispatchCondition dc) {
 		boolean canBeDispatched = false;
 		// Only accept dispatch conditions on components for which a Dispatch_Protocl can be associated
-		PackageSection[] contextsTab = AadlBaVisitors.getBaPackageSections(_ba);
+		PackageSection[] contextsTab = AadlBaVisitors.getBaPackageSections(_ba, _baParentContainer);
 		PropertiesLinkingService pls = Aadl2Visitors.getPropertiesLinkingService(contextsTab[0]);
 
 		Property dispatchProtocolProperty = pls.findPropertyDefinition(_baParentContainer,
@@ -465,11 +469,11 @@ public class AadlBaLegalityRulesChecker {
 	 * Keys : dispatch relative timeout condition catch timed thread complete
 	 * state period property
 	 */
-	public boolean D_4_L1_Check(DispatchRelativeTimeout tc, DeclarativeBehaviorTransition bt) {
-		List<Identifier> sourceState = bt.getSrcStates();
+	public boolean D_4_L1_Check(DispatchRelativeTimeout tc, BehaviorTransition bt) {
+		List<BehaviorState> sourceState = BehaviorTransitionContext.getSourceStates(bt);
 
 		if (sourceState.size() == 1) {
-			BehaviorState bs = (BehaviorState) (sourceState.get(0)).getBaRef();
+			BehaviorState bs = sourceState.get(0);
 			if (false == _alreadyFoundDispatchRelativeTimeoutTransition.containsKey(bs) && bs.isComplete()) {
 				// If the ba's parent container is not a Thread, the return value
 				// list will be empty.
@@ -546,12 +550,12 @@ public class AadlBaLegalityRulesChecker {
 	 * Keys : dispatch completion relative timeout condition catch complete
 	 * state
 	 */
-	public Boolean D_4_L2_Check(CompletionRelativeTimeout crtcac, DeclarativeBehaviorTransition bt) {
-		List<Identifier> sourceState = bt.getSrcStates();
+	public Boolean D_4_L2_Check(CompletionRelativeTimeout crtcac, BehaviorTransition bt) {
+		List<BehaviorState> sourceState = BehaviorTransitionContext.getSourceStates(bt);
 
 		if (!_alreadyFoundCompletionRelativeTimeoutConditionCatchTransition.containsKey(sourceState)
 				&& sourceState.size() == 1) {
-			BehaviorState bs = (BehaviorState) (sourceState.get(0)).getBaRef();
+			BehaviorState bs = sourceState.get(0);
 			// Positive case.
 			if (bs.isComplete()) {
 				_alreadyFoundCompletionRelativeTimeoutConditionCatchTransition.put(bs, bt);

--- a/ba/org.osate.ba/src/org/osate/ba/analyzers/AadlBaModelResolver.java
+++ b/ba/org.osate.ba/src/org/osate/ba/analyzers/AadlBaModelResolver.java
@@ -1,0 +1,2992 @@
+/**
+ * AADL-BA-FrontEnd
+ *
+ * Copyright (c) 2011-2021 TELECOM ParisTech and CNRS
+ *
+ * TELECOM ParisTech/LTCI
+ *
+ * Authors: see AUTHORS
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Eclipse Public License as published by Eclipse,
+ * either version 2.0 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Eclipse Public License for more details.
+ * You should have received a copy of the Eclipse Public License
+ * along with this program.  If not, see
+ * https://www.eclipse.org/legal/epl-2.0/
+ */
+
+package org.osate.ba.analyzers;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.ListIterator;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.osate.aadl2.Aadl2Factory;
+import org.osate.aadl2.ArrayDimension;
+import org.osate.aadl2.ArraySize;
+import org.osate.aadl2.BasicProperty;
+import org.osate.aadl2.CalledSubprogram;
+import org.osate.aadl2.Classifier;
+import org.osate.aadl2.ClassifierValue;
+import org.osate.aadl2.ComponentClassifier;
+import org.osate.aadl2.ComponentPrototype;
+import org.osate.aadl2.ComponentPrototypeActual;
+import org.osate.aadl2.ComponentPrototypeBinding;
+import org.osate.aadl2.DataAccess;
+import org.osate.aadl2.DataClassifier;
+import org.osate.aadl2.DataPort;
+import org.osate.aadl2.DataSubcomponent;
+import org.osate.aadl2.DirectionType;
+import org.osate.aadl2.Element;
+import org.osate.aadl2.EnumerationLiteral;
+import org.osate.aadl2.EventDataPort;
+import org.osate.aadl2.EventPort;
+import org.osate.aadl2.Feature;
+import org.osate.aadl2.FeaturePrototypeBinding;
+import org.osate.aadl2.NamedElement;
+import org.osate.aadl2.NumberValue;
+import org.osate.aadl2.Parameter;
+import org.osate.aadl2.Port;
+import org.osate.aadl2.ProcessorClassifier;
+import org.osate.aadl2.Property;
+import org.osate.aadl2.PropertyAssociation;
+import org.osate.aadl2.PropertyConstant;
+import org.osate.aadl2.PropertyExpression;
+import org.osate.aadl2.PropertySet;
+import org.osate.aadl2.PropertyType;
+import org.osate.aadl2.Prototype;
+import org.osate.aadl2.PrototypeBinding;
+import org.osate.aadl2.Subprogram;
+import org.osate.aadl2.SubprogramAccess;
+import org.osate.aadl2.SubprogramImplementation;
+import org.osate.aadl2.SubprogramPrototype;
+import org.osate.aadl2.SubprogramSubcomponent;
+import org.osate.aadl2.SubprogramType;
+import org.osate.aadl2.UnitLiteral;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.aadl2.parsesupport.LocationReference;
+import org.osate.ba.aadlba.*;
+import org.osate.ba.declarative.ArrayableIdentifier;
+import org.osate.ba.declarative.CommAction;
+import org.osate.ba.declarative.DeclarativeArrayDimension;
+import org.osate.ba.declarative.DeclarativeBehaviorElement;
+import org.osate.ba.declarative.DeclarativePropertyName;
+import org.osate.ba.declarative.DeclarativePropertyReference;
+import org.osate.ba.declarative.DeclarativeTime;
+import org.osate.ba.declarative.Identifier;
+import org.osate.ba.declarative.NamedValue;
+import org.osate.ba.declarative.QualifiedNamedElement;
+import org.osate.ba.declarative.Reference;
+import org.osate.ba.texteditor.AadlBaHyperlink;
+import org.osate.ba.texteditor.DefaultAadlBaHyperlink;
+import org.osate.ba.unparser.AadlBaUnparser;
+import org.osate.ba.utils.AadlBaUtils;
+import org.osate.ba.utils.AadlBaVisitors;
+import org.osate.ba.utils.DimensionException;
+import org.osate.utils.internal.Aadl2Utils;
+
+/**
+ * Resolves declarative Behavior Annex elements into the strict model while preserving the legacy diagnostics.
+ *
+ * Data type checking is delegated to the given DataTypeChecker implementation
+ * (Dependency Injection).
+ *
+ */
+public class AadlBaModelResolver {
+
+	private BehaviorAnnex _ba;
+
+	private ComponentClassifier _baParentContainer;
+
+	private AnalysisErrorReporterManager _errManager;
+
+	private static final String STRING_TYPE_SEPARATOR = " or ";
+
+	private static final String STRING_PARAMETER_SEPARATOR = ", ";
+
+	private final DataTypeChecker _dataChecker;
+
+	private final static AadlBaFactory _fact = AadlBaFactory.eINSTANCE;
+
+	private AadlBaHyperlink _hl = new DefaultAadlBaHyperlink();
+
+	/**
+	 * Constructs an AADL behavior annex type checker.
+	 * Reports any errors with the given error reporter manager.
+	 *
+	 * @param ba the given behavior annex
+	 * @param dataChecker the given data type checker implementation
+	 * @param errManager the given error reporter manager
+	 */
+	public AadlBaModelResolver(BehaviorAnnex ba, DataTypeChecker dataChecker, AnalysisErrorReporterManager errManager) {
+		this(ba, AadlBaVisitors.getParentComponent(ba), dataChecker, errManager);
+	}
+
+	/**
+	 * Constructs an AADL behavior annex type checker with explicit component context.
+	 *
+	 * @param ba the behavior annex
+	 * @param parentContainer the component which owns the behavior annex
+	 * @param dataChecker the data type checker
+	 * @param errManager the error reporter manager
+	 */
+	public AadlBaModelResolver(BehaviorAnnex ba, ComponentClassifier parentContainer, DataTypeChecker dataChecker,
+			AnalysisErrorReporterManager errManager) {
+		_ba = ba;
+		_baParentContainer = AadlBaVisitors.getParentComponent(ba, parentContainer);
+		_dataChecker = dataChecker;
+		_errManager = errManager;
+	}
+
+	public void setAadlBaHyperlink(AadlBaHyperlink hl) {
+		_hl = hl;
+	}
+
+	/**
+	 * Checks the type of the objects referenced during the name resolution phase.
+	 * Reports any error.
+	 *
+	 * @return {@code true} if all the objects have the excepted types.
+	 * {@code false} otherwise.
+	 */
+	public boolean resolveModel() {
+		return behaviorVariableCheck() & behaviorTransitionCheck();
+	}
+
+	/**
+	 * Document: AADL Behavior Annex draft
+	 * Version : 0.94
+	 * Type : Semantic rule
+	 * Section : D.3 Behavior Specification
+	 * Object : Check semantic rule D.3.(28)
+	 * Keys : local variables explicitly typed valid data component classifier
+	 */
+	private boolean behaviorVariableCheck() {
+		boolean result = true;
+		IntegerValueConstant ivc = null;
+		QualifiedNamedElement uccr;
+
+		for (BehaviorVariable bv : _ba.getVariables()) {
+			uccr = (QualifiedNamedElement) bv.getDataClassifier();
+
+			DataClassifier dc = (DataClassifier) uniqueNamedElementReferenceResolver(uccr, TypeCheckRule.DATA_UCCR);
+
+			_hl.addToHyperlinking(uccr.getAadlBaLocationReference(), dc);
+
+			result &= dc != null;
+			bv.setDataClassifier(dc);
+
+			for (PropertyAssociation pa : bv.getOwnedPropertyAssociations()) {
+				Property p = (Property) uniqueNamedElementReferenceResolver((QualifiedNamedElement) pa.getProperty(),
+						TypeCheckRule.PROPERTY);
+				pa.setProperty(p);
+			}
+
+			ListIterator<ArrayDimension> it = bv.getArrayDimensions().listIterator();
+
+			while (it.hasNext()) {
+				ArrayDimension tmp = it.next();
+				DeclarativeArrayDimension dad = (DeclarativeArrayDimension) tmp;
+
+				ivc = dad.getDimension();
+				ivc = integerValueConstantCheck(ivc);
+				result &= ivc != null;
+
+				// The returned value may be different from the tested value
+				// because of semantic ambiguity resolution in
+				// integervalueConstantCheck method. So replace if needed.
+				if (ivc != null) {
+					it.set(integerValueConstantToArrayDimension(ivc));
+				}
+			}
+		}
+
+		return result;
+	}
+
+	private String unparseQualifiedNamedElement(QualifiedNamedElement qne) {
+		StringBuilder sb = new StringBuilder();
+		if (qne.getBaNamespace() != null) {
+			sb.append(qne.getBaNamespace().getId());
+			sb.append("::");
+		}
+
+		sb.append(qne.getBaName().getId());
+
+		return sb.toString();
+	}
+
+	private Element uniqueNamedElementReferenceResolver(QualifiedNamedElement qne, TypeCheckRule rule) {
+		String unparsed = unparseQualifiedNamedElement(qne);
+
+		boolean succeed = typeCheck(qne, unparsed, rule, true) != null;
+
+		if (succeed) {
+			return qne.getOsateRef();
+		} else {
+			return null;
+		}
+	}
+
+	private ArrayDimension integerValueConstantToArrayDimension(IntegerValueConstant ivc) {
+		ArrayDimension result = Aadl2Factory.eINSTANCE.createArrayDimension();
+		ArraySize size = result.createSize();
+		result.setSize(size);
+		result.setLocationReference(ivc.getLocationReference());
+		size.setLocationReference(ivc.getLocationReference());
+
+		if (ivc instanceof BehaviorIntegerLiteral) {
+			size.setSize(((BehaviorIntegerLiteral) ivc).getValue());
+		} else if (ivc instanceof BehaviorPropertyConstant) {
+			PropertyExpression pe = null;
+			PropertyConstant pc = ((BehaviorPropertyConstant) ivc).getProperty();
+			pe = pc.getConstantValue();
+
+			if (pe instanceof NumberValue) {
+				double value = ((NumberValue) pe).getScaledValue();
+				size.setSize((long) value);
+			} else {
+				String msg = "cannot evaluate the property constant";
+				_errManager.warning(ivc, msg);
+			}
+		} else if (ivc instanceof PropertyReference) {
+			PropertyReference pr = (PropertyReference) ivc;
+			PropertyNameHolder last = pr.getProperties().get(pr.getProperties().size() - 1);
+			Element el = last.getProperty().getElement();
+
+			if (el instanceof NumberValue) {
+				double value = ((NumberValue) el).getScaledValue();
+				size.setSize((long) value);
+			} else {
+				String msg = "cannot evaluate the property value";
+				_errManager.warning(ivc, msg);
+			}
+		} else {
+			String errorMsg = "integerValueConstantToArrayDimension : " + ivc.getClass().getSimpleName()
+					+ " is not supported yet.";
+			System.err.println(errorMsg);
+			throw new UnsupportedOperationException(errorMsg);
+		}
+
+		return result;
+	}
+
+	// This method checks the given object and returns an object resolved from
+	// semantic ambiguities. On error, reports error and returns null.
+	private IntegerValueConstant integerValueConstantCheck(IntegerValueConstant ivc) {
+		ValueAndTypeHolder holder = valueConstantCheck(ivc);
+
+		if (typeCheck(ivc, null, holder, DataRepresentation.INTEGER)) {
+			return (IntegerValueConstant) holder.value;
+		} else {
+			return null;
+		}
+	}
+
+	// This method checks the given object and returns an object resolved from
+	// semantic ambiguities. On error, reports error and returns null.
+	private IntegerValue integerValueCheck(IntegerValue iv) {
+		// Ambiguity between property constant and name without array index
+		// has already been resolved in the name resolution phase.
+
+		if (iv instanceof IntegerValueConstant) {
+			return integerValueConstantCheck((IntegerValueConstant) iv);
+		} else {
+			return integerValueVariableCheck((IntegerValueVariable) iv);
+		}
+	}
+
+	// This method checks the given object and returns an object resolved from
+	// semantic ambiguities. On error, reports error and returns null.
+	private IntegerValueVariable integerValueVariableCheck(IntegerValueVariable ivv) {
+		ValueAndTypeHolder holder = valueVariableCheck(ivv);
+
+		if (typeCheck(ivv, null, holder, DataRepresentation.INTEGER)) {
+			return (IntegerValueVariable) holder.value;
+		} else {
+			return null;
+		}
+	}
+
+	private boolean behaviorTransitionCheck() {
+		boolean result = true;
+
+		for (BehaviorTransition trans : _ba.getTransitions()) {
+			BehaviorCondition cond = trans.getCondition();
+
+			if (cond instanceof DispatchCondition) {
+				result &= dispatchConditionCheck((DispatchCondition) cond);
+			} else if (cond instanceof ModeSwitchTriggerLogicalExpression) {
+				result &= modeSwitchTriggerLogicalExpressionCheck((ModeSwitchTriggerLogicalExpression) cond);
+			} else {
+				result &= executeConditionCheck((ExecuteCondition) cond);
+			}
+
+			if (trans.getActionBlock() != null) {
+				result &= behaviorActionBlockCheck(trans.getActionBlock());
+			}
+		}
+
+		return result;
+	}
+
+	private boolean modeSwitchTriggerLogicalExpressionCheck(ModeSwitchTriggerLogicalExpression dtle) {
+		boolean result = true;
+
+		ElementHolder elHolder = null;
+
+		for (ModeSwitchConjunction msc : dtle.getModeSwitchConjunctions()) {
+			ListIterator<ModeSwitchTrigger> it = msc.getModeSwitchTriggers().listIterator();
+
+			while (it.hasNext()) {
+				Reference e = (Reference) it.next();
+
+				elHolder = dispatchTriggerResolver(e, TypeCheckRule.MODE_SWITCH_TRIGGER);
+
+				if (elHolder != null) {
+					it.set((ModeSwitchTrigger) elHolder);
+				} else {
+					result = false;
+				}
+			}
+		}
+
+		return result;
+	}
+
+	/**
+	 * Document: AADL Behavior Annex draft
+	 * Version : 0.94
+	 * Type : Naming rule
+	 * Section : D.4 Thread Dispatch Behavior Specification
+	 * Object : Check naming rules D.4.(N1), D.4.(N2)
+	 * Keys : frozen port, subprogram access feature, dispatch trigger condition
+	 */
+	private boolean dispatchConditionCheck(DispatchCondition cond) {
+		boolean result = false;
+
+		DispatchTriggerCondition dtc = cond.getDispatchTriggerCondition();
+
+		if (dtc != null) {
+			DispatchTriggerCondition tmp = dispatchTriggerConditionCheck(dtc);
+			result = tmp != null;
+
+			// The returned DispatchTriggerCondition may be different from the
+			// tested one because of semantic ambiguity resolution in
+			// dispatchTriggerConditionCheck method. So replace if needed.
+			if (tmp != dtc && result) {
+				cond.setDispatchTriggerCondition(tmp);
+			}
+		} else {
+			result = true;
+		}
+
+		if (cond.isSetFrozenPorts()) {
+			PortHolder portHolder = null;
+
+			ListIterator<ActualPortHolder> it = cond.getFrozenPorts().listIterator();
+
+			while (it.hasNext()) {
+				Reference ref = (Reference) it.next();
+
+				portHolder = frozenPortCheck(ref);
+
+				if (portHolder != null) {
+					it.set((ActualPortHolder) portHolder);
+				} else {
+					result = false;
+				}
+			}
+		}
+
+		return result;
+	}
+
+	private PortHolder frozenPortCheck(Reference ref) {
+		PortHolder result = null;
+
+		TypeCheckRule stopOnThisRule = TypeCheckRule.FROZEN_PORT;
+		TypeCheckRule checkRules = stopOnThisRule;
+
+		List<ElementHolder> resolvedRef = refResolver(ref, null, stopOnThisRule, checkRules);
+
+		if (resolvedRef != null) {
+			result = (PortHolder) resolvedRef.get(0);
+		}
+
+		return result;
+	}
+
+	private void reportError(BehaviorElement el, String msg) {
+		_errManager.error(el, msg);
+	}
+
+	private void reportTypeError(BehaviorElement el, String name, String expectedTypes, String typeFound) {
+		String message = "type error for \'" + name + "\', \'" + expectedTypes + "\' expected, found \'" + typeFound
+				+ "\'.";
+
+		reportError(el, message);
+	}
+
+	private String unparseNameElement(BehaviorElement e) {
+		if (e instanceof Reference) {
+			return unparseReference((Reference) e);
+		} else {
+			AadlBaUnparser unparser = new AadlBaUnparser();
+			unparser.process(e);
+			return unparser.getOutput();
+		}
+	}
+
+	private String unparseReference(Reference ref) {
+		return ref.getIds().get(ref.getIds().size() - 1).getId();
+	}
+
+	// This method checks the given object and returns an object resolved from
+	// semantic ambiguities. On error, reports error and returns null.
+	private DispatchTriggerCondition dispatchTriggerConditionCheck(DispatchTriggerCondition dtc) {
+		if (dtc instanceof DispatchTriggerLogicalExpression) {
+			DispatchTriggerLogicalExpression dtle = (DispatchTriggerLogicalExpression) dtc;
+
+			// dispatch trigger logical expression.
+			// Resolves ambiguity between a single dispatch trigger and subprogram
+			// access.
+			if (dtle.getDispatchConjunctions().size() == 1) {
+				DispatchConjunction dc = dtle.getDispatchConjunctions().get(0);
+
+				List<DispatchTrigger> dispatchTriggers = dc.getDispatchTriggers();
+
+				if (dispatchTriggers.size() == 1) {
+					Reference ref = (Reference) dispatchTriggers.get(0);
+
+					ElementHolder el = dispatchTriggerResolver(ref, TypeCheckRule.DISPATCH_TRIGGER_CONDITION);
+					if (el != null) {
+						if (el instanceof DispatchTrigger) {
+							dispatchTriggers.set(0, (DispatchTrigger) el);
+							return dtc;
+						} else // Subprogram access case.
+						{
+							return (DispatchTriggerCondition) el;
+						}
+					} else {
+						return null;
+					}
+				} else {
+					return dispatchTriggerLogicalExpressionCheck(dtle) ? dtc : null;
+				}
+			} else {
+				return dispatchTriggerLogicalExpressionCheck(dtle) ? dtc : null;
+			}
+		} else {
+			// CompletionRelativeTimeout case.
+			if (dtc instanceof CompletionRelativeTimeout) {
+				CompletionRelativeTimeout tmp = _fact.createCompletionRelativeTimeout();
+
+				if (behaviorTimeCheck((DeclarativeTime) dtc, tmp)) {
+					return tmp;
+				} else {
+					return null;
+				}
+			} else // Cases of DispatchTriggerConditionStop and TimeoutCatch:
+					// There isn't any type to check.
+			{
+				return dtc;
+			}
+		}
+	}
+
+	private ElementHolder dispatchTriggerResolver(Reference ref, TypeCheckRule rule) {
+		TypeCheckRule stopOnThisRule = rule;
+		TypeCheckRule checkRules = stopOnThisRule;
+		List<ElementHolder> resolvedRef = refResolver(ref, null, stopOnThisRule, checkRules);
+		if (resolvedRef != null) {
+			return resolvedRef.get(0);
+		} else {
+			return null;
+		}
+	}
+
+	private boolean behaviorTimeCheck(DeclarativeTime dbt, BehaviorTime result) {
+		IntegerValue tmp = integerValueCheck(dbt.getIntegerValue());
+
+		// The returned value may be different from the tested value
+		// because of semantic ambiguity resolution in integerValueCheck
+		// method. So replace if needed.
+		if (tmp != null) {
+			result.setIntegerValue(tmp);
+			Identifier unitId = dbt.getUnitId();
+			result.setUnit((UnitLiteral) unitId.getOsateRef());
+			result.setLocationReference(dbt.getLocationReference());
+		}
+
+		return tmp != null;
+	}
+
+	private boolean dispatchTriggerLogicalExpressionCheck(DispatchTriggerLogicalExpression dtle) {
+		boolean result = true;
+
+		ElementHolder elHolder = null;
+
+		for (DispatchConjunction dc : dtle.getDispatchConjunctions()) {
+			ListIterator<DispatchTrigger> it = dc.getDispatchTriggers().listIterator();
+
+			while (it.hasNext()) {
+				Reference e = (Reference) it.next();
+
+				elHolder = dispatchTriggerResolver(e, TypeCheckRule.DISPATCH_TRIGGER);
+
+				if (elHolder != null) {
+					it.set((DispatchTrigger) elHolder);
+				} else {
+					result = false;
+				}
+			}
+		}
+
+		return result;
+	}
+
+	private boolean executeConditionCheck(ExecuteCondition cond) {
+		if (cond instanceof ValueExpression) {
+			ValueAndTypeHolder holder = valueExpressionCheck((ValueExpression) cond);
+
+			// Execute condition is only defined for logical value expression.
+			return typeCheck(cond, "the execute condition", holder, DataRepresentation.BOOLEAN);
+		} else // Timeout catch and Otherwise cases : no type to check.
+		{
+			return true;
+		}
+	}
+
+	// This method checks the given object and returns a value expression
+	// resolved from semantic ambiguities and its data representation. On error,
+	// reports error and returns null.
+	/**
+	 * Document: AADL Behavior Annex draft
+	 * Version : 0.94
+	 * Type : Legality rule
+	 * Section : D.7 Behavior Expression Language
+	 * Object : Check legality rules D.7.(L3), partially D.7.(L6)
+	 * Keys : operand logical operators boolean
+	 */
+	private ValueAndTypeHolder valueExpressionCheck(ValueExpression ve) {
+		EList<Relation> rl = ve.getRelations();
+
+		TypeHolder[] typea = new TypeHolder[rl.size()];
+		EList<LogicalOperator> opl = ve.getLogicalOperators();
+		boolean isTopLevelTypePossible = true;
+
+		// Checks all relations.
+		for (int i = 0; i < rl.size(); i++) {
+			typea[i] = relationCheck(rl.get(i));
+
+			// Current checking has failed but continues because all relations have
+			// to be checked.
+			if (typea[i] == null) {
+				isTopLevelTypePossible = false;
+			}
+		}
+
+		// If the relation checking are successful, checks operators definition
+		// and evaluates top level value variable type representation.
+		if (isTopLevelTypePossible) {
+			if (rl.size() > 1) {
+				for (int i = 1; i < rl.size(); i++) {
+					typea[i] = _dataChecker.checkDefinition(ve, opl.get(i - 1), typea[i - 1], typea[i]);
+					// Error case : the current operator is not defined.
+					if (typea[i] == null) {
+						return null;
+					}
+				}
+
+				return new ValueAndTypeHolder(ve, typea[typea.length - 1]);
+			} else // As there isn't any operator set, top level type is the unique
+					// relation's one.
+			{
+				return new ValueAndTypeHolder(ve, typea[0]);
+			}
+		} else // Relation checking has failed.
+		{
+			return null;
+		}
+	}
+
+	// Returns the top-level relation data representation or null on error.
+	// Reports any error.
+	/**
+	 * Document: AADL Behavior Annex draft
+	 * Version : 0.94
+	 * Type : Legality rule
+	 * Section : D.7 Behavior Expression Language
+	 * Object : Check legality rule D.7.(L4)
+	 * Keys : operand relational operators supports comparison
+	 */
+	private TypeHolder relationCheck(Relation r) {
+		TypeHolder th1 = simpleExpressionCheck(r.getFirstExpression());
+		TypeHolder th2 = null;
+
+		if (r.isSetRelationalOperator()) {
+			th2 = simpleExpressionCheck(r.getSecondExpression());
+		} else {
+			return th1;
+		}
+
+		if (th1 != null && th2 != null) {
+			return _dataChecker.checkDefinition(r, r.getRelationalOperator(), th1, th2);
+		} else {
+			return null;
+		}
+	}
+
+	// Returns the top-level simple expression type representation or null on
+	// error. Reports any error.
+	/**
+	 * Document: AADL Behavior Annex draft
+	 * Version : 0.94
+	 * Type : Legality rule
+	 * Section : D.7 Behavior Expression Language
+	 * Object : Check legality rule D.7.(L5)
+	 * Keys : adding other numeric operators support numeric operations
+	 */
+	private TypeHolder simpleExpressionCheck(SimpleExpression se) {
+		EList<Term> tl = se.getTerms();
+		TypeHolder[] typea = new TypeHolder[tl.size()];
+		EList<BinaryAddingOperator> opl = se.getBinaryAddingOperators();
+		boolean isTopLevelTypePossible = true;
+
+		// Checks all terms.
+		for (int i = 0; i < tl.size(); i++) {
+			typea[i] = termCheck(tl.get(i));
+
+			// Current checking has failed but continues because all terms have to
+			// be checked.
+			if (typea[i] == null) {
+				isTopLevelTypePossible = false;
+			}
+		}
+
+		// If the term checking are successful, checks operators definition and
+		// evaluates top level simple expression type representation.
+		if (isTopLevelTypePossible) {
+			if (se.isSetUnaryAddingOperator()) {
+				typea[0] = _dataChecker.checkDefinition(se, se.getUnaryAddingOperator(), typea[0]);
+				// Error case : the unary adding operator is not defined.
+				if (typea[0] == null) {
+					return null;
+				}
+			}
+
+			if (tl.size() > 1) {
+				for (int i = 1; i < tl.size(); i++) {
+					typea[i] = _dataChecker.checkDefinition(se, opl.get(i - 1), typea[i - 1], typea[i]);
+
+					// Error case : the current operator is not defined.
+					if (typea[i] == null) {
+						return null;
+					}
+				}
+
+				return typea[typea.length - 1];
+			} else // As there isn't any operator set, top level type is the unique
+					// term's one.
+			{
+				return typea[0];
+			}
+		} else // Term checking has failed.
+		{
+			return null;
+		}
+	}
+
+	// Returns the top-level term type representation or null on error.
+	// Reports any error.
+	/**
+	 * Document: AADL Behavior Annex draft
+	 * Version : 0.94
+	 * Type : Legality rule
+	 * Section : D.7 Behavior Expression Language
+	 * Object : Check legality rule D.7.(L5)
+	 * Keys : multiplying other numeric operators support numeric operations
+	 */
+	private TypeHolder termCheck(Term t) {
+		EList<Factor> fl = t.getFactors();
+		TypeHolder[] typea = new TypeHolder[fl.size()];
+		EList<MultiplyingOperator> opl = t.getMultiplyingOperators();
+		boolean isTopLevelTypePossible = true;
+
+		// Checks all the factors.
+		for (int i = 0; i < fl.size(); i++) {
+			typea[i] = factorCheck(fl.get(i));
+
+			// Current checking has failed but continues because all factors have to
+			// be checked.
+			if (typea[i] == null) {
+				isTopLevelTypePossible = false;
+			}
+		}
+
+		// If the factor checking are successful, checks operators definition
+		// and evaluates top level term type representation.
+		if (isTopLevelTypePossible) {
+			if (fl.size() > 1) {
+				for (int i = 1; i < fl.size(); i++) {
+					typea[i] = _dataChecker.checkDefinition(t, opl.get(i - 1), typea[i - 1], typea[i]);
+					// Error case : the current operator is not defined.
+					if (typea[i] == null) {
+						return null;
+					}
+				}
+
+				return typea[typea.length - 1];
+			} else // As there isn't any operator set, top level type is the unique
+					// factor's one.
+			{
+				return typea[0];
+			}
+		} else {
+			return null;
+		}
+	}
+
+	// Returns the top-level factor type representation or null on error.
+	// Reports any error.
+	/**
+	 * Document: AADL Behavior Annex draft
+	 * Version : 0.94
+	 * Type : Legality rule
+	 * Section : D.7 Behavior Expression Language
+	 * Object : Check legality rule D.7.(L5)
+	 * Keys : other numeric operators support numeric operations
+	 */
+	private TypeHolder factorCheck(Factor f) {
+		Value fValue = f.getFirstValue();
+		Value sdValue = f.getSecondValue();
+		ValueAndTypeHolder vth1 = valueCheck(fValue);
+		ValueAndTypeHolder vth2 = null;
+
+		if (sdValue != null) {
+			// Checks second value even if the first value checking has failed.
+			vth2 = valueCheck(sdValue);
+		}
+
+		if (vth1 != null) // Don't check operator definition on value checking error.
+		{
+			// The returned value may be different from the tested value
+			// because of semantic ambiguity resolution in valueCheck
+			// method. So replace if needed.
+			f.setFirstValue(vth1.value);
+			fValue = vth1.value;
+
+			// Checks Unary operators.
+			if (f.isSetUnaryNumericOperator() || f.isSetUnaryBooleanOperator()) {
+				Enumerator op;
+
+				op = ((f.isSetUnaryBooleanOperator()) ? f.getUnaryBooleanOperator() : f.getUnaryNumericOperator());
+
+				return _dataChecker.checkDefinition(f, op, vth1.typeHolder);
+			} else {
+				if (f.isSetBinaryNumericOperator()) {
+					if (vth2 != null) {
+						// The returned value may be different from the tested value
+						// because of semantic ambiguity resolution in valueCheck
+						// method. So replace if needed.
+						f.setSecondValue(vth2.value);
+						sdValue = vth2.value;
+
+						return _dataChecker.checkDefinition(f, f.getBinaryNumericOperator(), vth1.typeHolder,
+								vth2.typeHolder);
+					} else // Second value error case.
+					{
+						return null;
+					}
+				} else // As there isn's any operator, the top level type is the unique
+						// value' one.
+				{
+					return vth1.typeHolder;
+				}
+			}
+		} else // First value error case.
+		{
+			return null;
+		}
+	}
+
+	// This method checks the given object and returns a value
+	// resolved from semantic ambiguities and its data representation. On error,
+	// reports error and returns null.
+	private ValueAndTypeHolder valueCheck(Value v) {
+		if (v instanceof ValueConstant) {
+			return valueConstantCheck((ValueConstant) v);
+		} else {
+			if (v instanceof ValueVariable) {
+				return valueVariableCheck((ValueVariable) v);
+			} else // Value expression case.
+			{
+				return valueExpressionCheck((ValueExpression) v);
+			}
+		}
+	}
+
+	// This method checks the given object and returns a value variable
+	// resolved from semantic ambiguities and its data representation. On error,
+	// reports error and returns null.
+	private ValueAndTypeHolder valueVariableCheck(ValueVariable v) {
+		List<ElementHolder> ehl = null;
+		ValueVariable tmpResult = null;
+		ActualPortHolder port;
+		TypeCheckRule stopRule;
+		TypeCheckRule[] checkRules;
+
+		if (v instanceof Reference) {
+			port = null;
+			stopRule = TypeCheckRule.VV_STOP_RULE;
+
+			checkRules = new TypeCheckRule[] { TypeCheckRule.VV_COMPONENT_REFERENCE_FIRST_NAME,
+					TypeCheckRule.DATA_COMPONENT_REFERENCE_OTHER_NAMES };
+		} else // NamedValue case.
+		{
+			NamedValue nv = (NamedValue) v;
+			v = nv.getReference();
+
+			if (nv.isCount()) {
+				port = _fact.createPortCountValue();
+				stopRule = TypeCheckRule.PORT_COUNT_VALUE;
+			} else if (nv.isDequeue()) {
+				port = _fact.createPortDequeueValue();
+				stopRule = TypeCheckRule.PORT_DEQUEUE_VALUE;
+			} else {
+				port = _fact.createPortFreshValue();
+				stopRule = TypeCheckRule.PORT_FRESH_VALUE;
+			}
+
+			port.setLocationReference(v.getLocationReference());
+			checkRules = new TypeCheckRule[] { stopRule };
+		}
+
+		ehl = refResolver((Reference) v, port, stopRule, checkRules);
+		if (ehl != null) {
+			tmpResult = referenceToValueVariable(ehl);
+
+			if (tmpResult instanceof PortFreshValue) {
+				PortFreshValue pfv = (PortFreshValue) tmpResult;
+				AadlBaVisitors.putFreshPort(_ba, pfv.getPort());
+			}
+
+			return this.getValueAndTypeHolder(tmpResult, v);
+		} else {
+			return null;
+		}
+	}
+
+	// Null proof.
+	@SuppressWarnings("all")
+	private ValueVariable referenceToValueVariable(List<ElementHolder> resolvedRef) {
+		ValueVariable result = null;
+
+		if (resolvedRef != null) {
+			if (resolvedRef.size() > 1) {
+				DataComponentReference dcr = _fact.createDataComponentReference();
+				dcr.setLocationReference(resolvedRef.get(0).getLocationReference());
+				dcr.getData().addAll((Collection<? extends DataHolder>) resolvedRef);
+				result = dcr;
+			} else {
+				result = (ValueVariable) resolvedRef.get(0);
+			}
+		}
+
+		return result;
+	}
+
+	private ValueAndTypeHolder getValueAndTypeHolder(Value v, Element errorRef) {
+		try {
+			return new ValueAndTypeHolder(v, AadlBaUtils.getTypeHolder(v, _baParentContainer));
+		} catch (DimensionException e) {
+			e.setElement(errorRef);
+			reportDimensionException(e);
+			return null;
+		}
+	}
+
+	// Checks group rules by default.
+	// Special attention is provided for Value or Target that are not
+	// data component references (ex: PortHolder): if stopOnThisRule is found
+	// and extra information exists (ex: port.port which syntactically correct but
+	// semantically wrong), it will report extraneous information error.
+	// If given port is not null, elementHolderResolver will try to set it
+	// (optimize reinstanciation when using design pattern decoration, for
+	// PortActions and PortValues).
+	// Also, IterativeVariable and BehaviorVariable instances can't have any
+	// group information. It will report extraneous information error if
+	// groups are provided.
+	// This method can't detect if there is not enought information (currently
+	// just for required_data_access_name.provided_subprogram_access_name case).
+	private List<ElementHolder> refResolver(Reference ref, ActualPortHolder port, TypeCheckRule stopOnThisRule,
+			TypeCheckRule... checkRules) {
+		List<ElementHolder> result = new ArrayList<ElementHolder>(ref.getIds().size());
+		Enum<?> currentResult = null;
+
+		ElementHolder currentElementholder = null;
+		int currentIndexRule = 0;
+		TypeCheckRule currentRule = checkRules[currentIndexRule];
+		TypeCheckRule lastRule = checkRules[checkRules.length - 1];
+		boolean hasToContinue = true;
+
+		ArrayList<GroupHolder> grpl = new ArrayList<GroupHolder>(ref.getIds().size());
+
+		ListIterator<ArrayableIdentifier> it = ref.getIds().listIterator();
+
+		while (it.hasNext()) {
+			ArrayableIdentifier id = it.next();
+
+			currentResult = typeCheck(id, id.getId(), TypeCheckRule.GROUPS, false);
+
+			// The current id represents a group, so store it in the groups stack.
+			if (currentResult != null) {
+				currentElementholder = elementHolderResolver(id, currentResult, port);
+				grpl.add((GroupHolder) currentElementholder);
+			} else // Checks given rules: if ref.getIds().size > rules.length then
+					// use the last given rule for the extra ids.
+			{
+				currentResult = typeCheck(id, id.getId(), currentRule, true);
+
+				if (currentResult != null) {
+					currentElementholder = elementHolderResolver(id, currentResult, port);
+					result.add(currentElementholder);
+
+					if (currentElementholder instanceof GroupableElement) {
+						if (false == grpl.isEmpty()) {
+							GroupableElement ge = (GroupableElement) currentElementholder;
+
+							// Flush GroupHolder List.
+							if (false == grpl.isEmpty()) {
+								ge.getGroupHolders().addAll(grpl);
+								grpl.clear();
+							}
+						}
+					} else if (false == grpl.isEmpty()) {
+						// Reports error of a not GroupableHolder that have group information.
+						String msg = id.getId() + " can't have group information.";
+						reportError(id, msg);
+						return null;
+					}
+
+					// Tests if a type that stop the checking is found.
+					hasToContinue = stopOnThisRule.testTypeCheckRule(currentResult) == null;
+					if (it.hasNext()) {
+						currentIndexRule++;
+
+						// Extra information (it passes the name resolved),
+						// has been given whereas the stop type is reached.
+						// So report error.
+						if (hasToContinue == false) {
+							// To much information.
+							String msg = id.getId() + " can't have any more tokens.";
+							reportError(id, msg);
+							return null;
+						} else // Stop type is not reached or is null that means there is
+								// not id number limit.
+						{
+							// If the number of ids is greater than the number of given
+							// rules: use the last rule for the extra ids. Only for data
+							// component reference.
+							currentRule = (currentIndexRule < checkRules.length) ? checkRules[currentIndexRule]
+									: lastRule;
+						}
+					}
+				} else {
+					// Error reporting has already been done.
+					return null;
+				}
+			}
+
+			// Checks array indexes.
+			if (id.isSetArrayIndexes()) {
+				if (currentElementholder instanceof IndexableElement) {
+					IndexableElement currentIndexableElement = (IndexableElement) currentElementholder;
+
+					boolean isConsistent = true;
+
+					List<IntegerValue> resolvedValues = new ArrayList<IntegerValue>(id.getArrayIndexes().size());
+
+					for (IntegerValue iv : id.getArrayIndexes()) {
+						// Reports any error.
+						IntegerValue resolvedValue = integerValueCheck(iv);
+						if (resolvedValue != null) {
+							resolvedValues.add(resolvedValue);
+						} else {
+							isConsistent = false;
+						}
+					}
+
+					// Avoid collection concurrency modification between id's integer values
+					// and currentIndexableElement's one.
+					if (isConsistent) {
+						currentIndexableElement.getArrayIndexes().addAll(resolvedValues);
+					}
+				} else {
+					// Not an arrayable element.
+					String msg = currentElementholder.getElement().getName() + " can't have array index.";
+					reportError(currentElementholder, msg);
+					return null;
+				}
+			}
+		} // End of for.
+		if (result.isEmpty()) {
+			String expectedTypes = currentRule.getExpectedTypes(STRING_TYPE_SEPARATOR);
+			String errMsg = "Wrong type in " + stopOnThisRule.getLiteral() + "; expected types are: " + expectedTypes;
+			this.reportError(ref, errMsg);
+			return null;
+		}
+		return result;
+	}
+
+	// It doesn't perform any check.
+	// It just builds an element holder according to the given type.
+	// If port is not null, it will set the given port.
+	private ElementHolder elementHolderResolver(ArrayableIdentifier id, Enum<?> type, ActualPortHolder port) {
+		ElementHolder result = null;
+
+		if (type instanceof FeatureType) {
+			FeatureType t = (FeatureType) type;
+
+			switch (t) {
+			case IN_DATA_PORT:
+			case OUT_DATA_PORT:
+			case IN_OUT_DATA_PORT: {
+				if (port == null) {
+					DataPortHolder tmp = _fact.createDataPortHolder();
+					tmp.setDataPort((DataPort) id.getOsateRef());
+					result = tmp;
+				} else {
+					port.setPort((Port) id.getOsateRef());
+					result = port;
+				}
+
+				break;
+			}
+
+			case IN_EVENT_DATA_PORT:
+			case OUT_EVENT_DATA_PORT:
+			case IN_OUT_EVENT_DATA_PORT: {
+				if (port == null) {
+					EventDataPortHolder tmp = _fact.createEventDataPortHolder();
+					tmp.setEventDataPort((EventDataPort) id.getOsateRef());
+					result = tmp;
+				} else {
+					port.setPort((Port) id.getOsateRef());
+					result = port;
+				}
+
+				break;
+			}
+
+			case IN_EVENT_PORT:
+			case OUT_EVENT_PORT:
+			case IN_OUT_EVENT_PORT: {
+				if (port == null) {
+					EventPortHolder tmp = _fact.createEventPortHolder();
+					tmp.setEventPort((EventPort) id.getOsateRef());
+					result = tmp;
+				} else {
+					port.setPort((Port) id.getOsateRef());
+					result = port;
+				}
+
+				break;
+			}
+
+			case REQUIRES_DATA_ACCESS:
+			case PROVIDES_DATA_ACCESS: {
+				DataAccessHolder tmp = _fact.createDataAccessHolder();
+				tmp.setDataAccess((DataAccess) id.getOsateRef());
+				result = tmp;
+				break;
+			}
+
+			case DATA_SUBCOMPONENT: {
+				DataSubcomponentHolder tmp = _fact.createDataSubcomponentHolder();
+				tmp.setDataSubcomponent((DataSubcomponent) id.getOsateRef());
+				result = tmp;
+				break;
+			}
+
+			case CLASSIFIER_VALUE: {
+				ClassifierValue cv = (ClassifierValue) id.getOsateRef();
+				DataClassifier dc = (DataClassifier) cv.getClassifier();
+
+				StructUnionElement sue = _fact.createStructUnionElement();
+				sue.setLocationReference(Aadl2Utils.getLocationReference(dc));
+				sue.setDataClassifier(dc);
+				sue.setName(id.getId());
+
+				StructUnionElementHolder sueHolder = _fact.createStructUnionElementHolder();
+				sueHolder.setStructUnionElement(sue);
+
+				// Set econtainer as ElementHolder::element is not containment.
+				InternalEObject parent = (InternalEObject) sueHolder;
+				InternalEObject child = (InternalEObject) sue;
+
+				child.eBasicSetContainer(parent, AadlBaPackage.STRUCT_UNION_ELEMENT_HOLDER__STRUCT_UNION_ELEMENT, null);
+				result = sueHolder;
+				break;
+			}
+
+			case IN_PARAMETER:
+			case OUT_PARAMETER:
+			case IN_OUT_PARAMETER: {
+				ParameterHolder tmp = _fact.createParameterHolder();
+				tmp.setParameter((Parameter) id.getOsateRef());
+				result = tmp;
+				break;
+			}
+
+			case SUBPROGRAM_CLASSIFIER:
+			case SUBPROGRAM_SUBCOMPONENT: {
+				SubprogramHolder tmp = _fact.createSubprogramHolder();
+				tmp.setSubprogram((Subprogram) id.getOsateRef());
+				result = tmp;
+				break;
+			}
+
+			case REQUIRES_SUBPROGRAM_ACCESS:
+			case PROVIDES_SUBPROGRAM_ACCESS: {
+				SubprogramAccessHolder tmp = _fact.createSubprogramAccessHolder();
+				tmp.setSubprogramAccess((SubprogramAccess) id.getOsateRef());
+				result = tmp;
+				break;
+			}
+
+			case FEATURE_GROUP:
+			case SUBPROGRAM_GROUP:
+			case THREAD_GROUP:
+			case REQUIRES_SUBPROGRAM_GROUP_ACCESS:
+			case PROVIDES_SUBPROGRAM_GROUP_ACCESS: {
+				GroupHolder tmp = _fact.createGroupHolder();
+				tmp.setGroup((NamedElement) id.getOsateRef());
+				result = tmp;
+				break;
+			}
+
+			case SUBPROGRAM_PROTOTYPE: {
+				Element el = id.getOsateRef();
+				SubprogramPrototypeHolder tmp = _fact.createSubprogramPrototypeHolder();
+				if (el instanceof PrototypeBinding) {
+					PrototypeBinding pb = (PrototypeBinding) el;
+					tmp.setPrototype(pb.getFormal());
+					tmp.setPrototypeBinding(pb);
+				} else {
+					Prototype p = (Prototype) el;
+					tmp.setPrototype(p);
+				}
+
+				result = tmp;
+				break;
+			}
+
+			case IN_DATA_PORT_PROTOTYPE:
+			case OUT_DATA_PORT_PROTOTYPE:
+			case IN_OUT_DATA_PORT_PROTOTYPE:
+			case IN_EVENT_DATA_PORT_PROTOTYPE:
+			case OUT_EVENT_DATA_PORT_PROTOTYPE:
+			case IN_OUT_EVENT_DATA_PORT_PROTOTYPE:
+			case IN_EVENT_PORT_PROTOTYPE:
+			case OUT_EVENT_PORT_PROTOTYPE:
+			case IN_OUT_EVENT_PORT_PROTOTYPE: {
+				Element el = id.getOsateRef();
+				PortPrototypeHolder tmp = _fact.createPortPrototypeHolder();
+				if (el instanceof PrototypeBinding) {
+					PrototypeBinding pb = (PrototypeBinding) el;
+					tmp.setPrototype(pb.getFormal());
+					tmp.setPrototypeBinding(pb);
+				} else {
+					Prototype p = (Prototype) el;
+					tmp.setPrototype(p);
+				}
+
+				result = tmp;
+				break;
+			}
+
+			case REQUIRES_DATA_ACCESS_PROTOTYPE:
+			case PROVIDES_DATA_ACCESS_PROTOTYPE: {
+				Element el = id.getOsateRef();
+				DataAccessPrototypeHolder tmp = _fact.createDataAccessPrototypeHolder();
+				if (el instanceof PrototypeBinding) {
+					PrototypeBinding pb = (PrototypeBinding) el;
+					tmp.setPrototype(pb.getFormal());
+					tmp.setPrototypeBinding(pb);
+				} else {
+					Prototype p = (Prototype) el;
+					tmp.setPrototype(p);
+				}
+
+				result = tmp;
+				break;
+			}
+
+			case FEATURE_GROUP_PROTOTYPE:
+			case FEATURE_GROUP_PROTOTYPE_BINDING:
+			case SUBPROGRAM_GROUP_PROTOTYPE:
+			case THREAD_GROUP_PROTOTYPE:
+			case REQUIRES_SUBPROGRAM_GROUP_ACCESS_PROTOTYPE:
+			case PROVIDES_SUBPROGRAM_GROUP_ACCESS_PROTOTYPE: {
+				Element el = id.getOsateRef();
+				GroupPrototypeHolder tmp = _fact.createGroupPrototypeHolder();
+				if (el instanceof PrototypeBinding) {
+					PrototypeBinding pb = (PrototypeBinding) el;
+					tmp.setPrototype(pb.getFormal());
+					tmp.setPrototypeBinding(pb);
+				} else {
+					Prototype p = (Prototype) el;
+					tmp.setPrototype(p);
+				}
+				result = tmp;
+				break;
+			}
+
+			case IN_FEATURE_PROTOTYPE:
+			case OUT_FEATURE_PROTOTYPE:
+			case IN_OUT_FEATURE_PROTOTYPE: {
+				Element el = id.getOsateRef();
+				FeaturePrototypeHolder tmp = _fact.createFeaturePrototypeHolder();
+				if (el instanceof PrototypeBinding) {
+					PrototypeBinding pb = (PrototypeBinding) el;
+					tmp.setPrototype(pb.getFormal());
+					tmp.setPrototypeBinding(pb);
+				} else {
+					Prototype p = (Prototype) el;
+					tmp.setPrototype(p);
+				}
+
+				result = tmp;
+				break;
+			}
+
+			default: {
+				String errorMsg = "type: " + type.toString() + " is not supported yet.";
+				System.err.println(errorMsg);
+				throw new UnsupportedOperationException(errorMsg);
+			}
+			}
+		} else {
+			BehaviorFeatureType t = (BehaviorFeatureType) type;
+
+			switch (t) {
+			case BEHAVIOR_VARIABLE: {
+				BehaviorVariableHolder tmp = _fact.createBehaviorVariableHolder();
+				tmp.setVariable((BehaviorVariable) id.getBaRef());
+				result = tmp;
+				break;
+			}
+
+			case ITERATIVE_VARIABLE: {
+				IterativeVariableHolder ivh = _fact.createIterativeVariableHolder();
+				ivh.setIterativeVariable((IterativeVariable) id.getBaRef());
+				result = ivh;
+				break;
+			}
+
+			default: {
+				String errorMsg = "type: " + type.toString() + " is not supported yet.";
+				System.err.println(errorMsg);
+				throw new UnsupportedOperationException(errorMsg);
+			}
+			}
+		}
+
+		result.setLocationReference(id.getLocationReference());
+
+		_hl.addToHyperlinking(id.getAadlBaLocationReference(), result);
+
+		return result;
+	}
+
+	private void reportDimensionException(DimensionException de) {
+		StringBuilder msg = new StringBuilder();
+
+		if (de.getElement() instanceof BehaviorElement) {
+			msg.append('"');
+			msg.append(this.unparseNameElement((BehaviorElement) de.getElement()));
+			msg.append("\" ");
+		}
+
+		msg.append(de.getMessage());
+
+		_errManager.error(de.getElement(), msg.toString());
+	}
+
+	// This method checks the given object and returns a value constant
+	// resolved from semantic ambiguities and its data representation. On error,
+	// reports error and returns null.
+	private ValueAndTypeHolder valueConstantCheck(ValueConstant v) {
+		ValueAndTypeHolder result = null;
+		ValueConstant tmpResult = null;
+
+		if (v instanceof DeclarativePropertyReference) {
+			tmpResult = propertyReferenceResolver((DeclarativePropertyReference) v);
+		} else // Literal cases. Nothing to do.
+		{
+			tmpResult = v;
+		}
+
+		if (tmpResult != null) {
+			result = getValueAndTypeHolder(tmpResult, v);
+		}
+
+		return result;
+	}
+
+	private ValueConstant propertyReferenceResolver(DeclarativePropertyReference ref) {
+		ValueConstant result = null;
+
+		if (ref.isPropertySet()) {
+			DeclarativePropertyName firstName = ref.getPropertyNames().get(0);
+
+			// Property constant from a property set.
+			if (firstName.getOsateRef() instanceof PropertyConstant) {
+				BehaviorPropertyConstant tmp = _fact.createBehaviorPropertyConstant();
+				tmp.setProperty((PropertyConstant) firstName.getOsateRef());
+				if (ref.getQualifiedName() != null) {
+					tmp.setPropertySet((PropertySet) ref.getQualifiedName().getOsateRef());
+				}
+				result = tmp;
+			} else // Property value case.
+			{
+				PropertySetPropertyReference tmp = _fact.createPropertySetPropertyReference();
+				propertyNameListResolver(ref.getPropertyNames(), tmp.getProperties());
+
+				if (ref.getQualifiedName() != null) {
+					tmp.setPropertySet((PropertySet) ref.getQualifiedName().getOsateRef());
+				}
+				result = tmp;
+			}
+		} else if (ref.getQualifiedName() != null) // [qualified] classifier case.
+		{
+			ClassifierPropertyReference tmp = _fact.createClassifierPropertyReference();
+			tmp.setClassifier((Classifier) ref.getQualifiedName().getOsateRef());
+			propertyNameListResolver(ref.getPropertyNames(), tmp.getProperties());
+			result = tmp;
+		} else // Classifier feature case.
+		{
+			ClassifierFeaturePropertyReference tmp = _fact.createClassifierFeaturePropertyReference();
+
+			classifierFeatureResolver(tmp, ref.getReference());
+			propertyNameListResolver(ref.getPropertyNames(), tmp.getProperties());
+			result = tmp;
+		}
+
+		result.setLocationReference(ref.getLocationReference());
+		return result;
+	}
+
+	private void propertyNameListResolver(EList<DeclarativePropertyName> dpns, EList<PropertyNameHolder> result) {
+		PropertyNameHolder pnh = null;
+		PropertyElementHolder peh = null;
+		EList<IntegerValue> indexes = null;
+		LocationReference loc = null;
+		Element global, primary;
+
+		for (DeclarativePropertyName dpn : dpns) {
+			pnh = _fact.createPropertyNameHolder();
+			pnh.setLocationReference(dpn.getLocationReference());
+
+			global = dpn.getOsateRef();
+			primary = dpn.getPropertyName().getOsateRef();
+
+			if (primary != global) // Item list case.
+			{
+				loc = dpn.getPropertyName().getLocationReference();
+				peh = propertyElementHolderResolver(primary, loc);
+			} else {
+				loc = dpn.getLocationReference();
+				peh = propertyElementHolderResolver(global, loc);
+
+			}
+
+			indexes = peh.getArrayIndexes();
+
+			if (dpn.getField() != null) {
+				pnh.setField(dpn.getField());
+			} else {
+				for (IntegerValue iv : dpn.getIndexes()) {
+					IntegerValue tmp = integerValueCheck(iv); // Report any error.
+					if (tmp != null) {
+						indexes.add(tmp);
+					}
+				}
+			}
+
+			pnh.setProperty(peh);
+			result.add(pnh);
+		}
+	}
+
+	private PropertyElementHolder propertyElementHolderResolver(Element el, LocationReference loc) {
+		PropertyElementHolder result = null;
+
+		if (el instanceof BasicProperty) {
+			BasicProperty bp = (BasicProperty) el;
+			BasicPropertyHolder tmp = _fact.createBasicPropertyHolder();
+			tmp.setBasicProperty(bp);
+			result = tmp;
+		} else if (el instanceof PropertyAssociation) {
+			PropertyAssociation pa = (PropertyAssociation) el;
+			PropertyAssociationHolder tmp = _fact.createPropertyAssociationHolder();
+			tmp.setPropertyAssociation(pa);
+			result = tmp;
+		} else if (el instanceof PropertyExpression) {
+			PropertyExpression pe = (PropertyExpression) el;
+			PropertyExpressionHolder tmp = _fact.createPropertyExpressionHolder();
+			tmp.setPropertyExpression(pe);
+			result = tmp;
+		} else if (el instanceof PropertyType) {
+			PropertyType pt = (PropertyType) el;
+			PropertyTypeHolder tmp = _fact.createPropertyTypeHolder();
+			tmp.setPropertyType(pt);
+			result = tmp;
+		} else if (el instanceof EnumerationLiteral) {
+			EnumerationLiteral enumLit = (EnumerationLiteral) el;
+			EnumLiteralHolder tmp = _fact.createEnumLiteralHolder();
+			tmp.setEnumLiteral(enumLit);
+			result = tmp;
+		} else {
+			String errorMsg = "type: " + el.getClass().getSimpleName() + " is not supported yet.";
+			System.err.println(errorMsg);
+			throw new UnsupportedOperationException(errorMsg);
+		}
+
+		result.setLocationReference(loc);
+		return result;
+	}
+
+	private void classifierFeatureResolver(ClassifierFeaturePropertyReference result, Reference ref) {
+		List<ElementHolder> holders = refResolver(ref, null, TypeCheckRule.NOTHING, TypeCheckRule.ALL);
+		result.setComponent((ClassifierFeatureHolder) holders.get(0));
+	}
+
+	private boolean behaviorActionBlockCheck(BehaviorActionBlock bab) {
+		boolean result = true;
+
+		if (bab.getTimeout() != null) {
+			BehaviorTime resolvedTime = _fact.createBehaviorTime();
+			result = behaviorTimeCheck((DeclarativeTime) bab.getTimeout(), resolvedTime);
+			bab.setTimeout(resolvedTime);
+		}
+
+		result &= behaviorActionsCheck(bab.getContent(), bab);
+
+		return result;
+	}
+
+	private boolean behaviorActionsCheck(BehaviorActions bActs, Object parentContainer) {
+		if (bActs instanceof BehaviorAction) {
+			return behaviorActionCheck((BehaviorAction) bActs, parentContainer);
+		} else // BehaviorCollection case.
+		{
+			boolean result = true;
+
+			ListIterator<BehaviorAction> it = ((BehaviorActionCollection) bActs).getActions().listIterator();
+			while (it.hasNext()) {
+				BehaviorAction bAct = it.next();
+				result &= behaviorActionCheck(bAct, it);
+			}
+
+			return result;
+		}
+	}
+
+	private boolean behaviorActionCheck(BehaviorAction bAct, Object parentContainer) {
+		if (bAct instanceof BehaviorActionBlock) {
+			return behaviorActionBlockCheck((BehaviorActionBlock) bAct);
+		} else {
+			if (bAct instanceof BasicAction) {
+				return basicActionCheck((BasicAction) bAct, parentContainer);
+			} else // Conditional statements cases.
+			{
+				return condStatementCheck((CondStatement) bAct);
+			}
+		}
+	}
+
+	private boolean condStatementCheck(CondStatement stat) {
+		if (stat instanceof IfStatement) {
+			return ifStatementCheck((IfStatement) stat);
+		} else {
+			if (stat instanceof ForOrForAllStatement) {
+				return forOrForAllStatementCheck((ForOrForAllStatement) stat);
+			} else // While or do until statement cases.
+			{
+				return whileOrDoUntilStatementCheck((WhileOrDoUntilStatement) stat);
+			}
+		}
+	}
+
+	private boolean whileOrDoUntilStatementCheck(WhileOrDoUntilStatement stat) {
+		boolean result = behaviorActionsCheck(stat.getBehaviorActions(), stat);
+
+		ValueExpression ve = stat.getLogicalValueExpression();
+
+		ValueAndTypeHolder holder = valueExpressionCheck(ve);
+
+		result &= typeCheck(ve, null, holder, DataRepresentation.BOOLEAN);
+
+		return result;
+	}
+
+	/**
+	 * Document: AADL Behavior Annex draft
+	 * Version : 0.94
+	 * Type : Legality rule
+	 * Section : D.6 Behavior Action Language
+	 * Object : Check legality rule D.6.(L2)
+	 * Keys : for forall iterative variable not valid assignment target
+	 *
+	*/
+	private boolean forOrForAllStatementCheck(ForOrForAllStatement stat) {
+		IterativeVariable itVar = stat.getIterativeVariable();
+		boolean result = iterativeVariableCheck(itVar);
+
+		result &= behaviorActionsCheck(stat.getBehaviorActions(), stat);
+
+		ElementValues tmp = elementValuesCheck(stat.getIteratedValues());
+		result &= tmp != null;
+
+		// The returned element values may be different from the tested one
+		// because of semantic ambiguity resolution in elementValuesCheck
+		// method. So replace if needed.
+		if (tmp != stat.getIteratedValues() && tmp != null) {
+			stat.setIteratedValues(tmp);
+		}
+
+		// Matches the element values data type and the uccr's one.
+		if (result) {
+			TypeHolder eleType;
+			TypeHolder uccrType;
+
+			if (tmp instanceof IntegerRange) {
+				IntegerRange ir = (IntegerRange) tmp;
+				TypeHolder t1, t2;
+				try {
+					t1 = AadlBaUtils.getTypeHolder(ir.getLowerIntegerValue(), _baParentContainer);
+					t2 = AadlBaUtils.getTypeHolder(ir.getUpperIntegerValue(), _baParentContainer);
+				} catch (DimensionException de) {
+					reportDimensionException(de);
+					return false;
+				}
+
+				eleType = _dataChecker.getTopLevelType(t1, t2);
+				// Integer Ranges are one dimension kind of integer collection.
+				// => pass the arrayness checking.
+				eleType.setDimension(1);
+			} else // Name or DataComponentReference cases.
+			{
+				try {
+					eleType = AadlBaUtils.getTypeHolder(tmp);
+				} catch (DimensionException de) {
+					reportDimensionException(de);
+					return false;
+				}
+
+				if (tmp instanceof EventDataPortHolder) {
+					// Event ports are one dimension events queue.
+					// => pass the arrayness checking.
+					eleType.setDimension(1);
+				}
+			}
+
+			try {
+				uccrType = AadlBaUtils.getTypeHolder(itVar);
+			} catch (DimensionException de) {
+				reportDimensionException(de);
+				return false;
+			}
+
+			// iterative variable's UCCR syntax cannot express array
+			// ([] are not allowed). Also, this implementation of AADL behavior
+			// annex, doesn't allow the use of iterative variable's types which are
+			// declared as array (data model annex).
+			if (uccrType.getDimension() > 0) {
+				StringBuilder message = new StringBuilder(
+						"the for/forall iterative variable's type cannot be an array.");
+
+				message.append(" Found \'");
+				message.append(uccrType.toString());
+				message.append("\'.");
+				reportError(tmp, message.toString());
+				result = false;
+			}
+
+			if (_dataChecker.conformsTo(eleType, uccrType, false)) {
+				result = true;
+			} else {
+				StringBuilder sb = new StringBuilder("\'iterative variable\' type error:");
+				sb.append(" an array of \"");
+				sb.append(uccrType.toString());
+				sb.append("\" expected, found \"");
+				sb.append(eleType.toString());
+				sb.append("\".");
+				reportError(stat, sb.toString());
+			}
+
+			// Checks data component reference arrayness and reports any error.
+			if (eleType.getDimension() == 0) {
+				String message = "\'" + unparseNameElement(tmp) + "\' is not an array";
+				reportError(tmp, message);
+				result = false;
+			}
+		}
+		return result;
+	}
+
+	private boolean iterativeVariableCheck(IterativeVariable itVar) {
+		QualifiedNamedElement qne = (QualifiedNamedElement) itVar.getDataClassifier();
+
+		// The statement's unique component reference reference has to be
+		// data classifier.
+		Classifier dataClassifier = (Classifier) uniqueNamedElementReferenceResolver(qne, TypeCheckRule.DATA_UCCR);
+
+		itVar.setDataClassifier((DataClassifier) dataClassifier);
+
+		return dataClassifier != null;
+	}
+
+	// This method checks the given object and returns a element values
+	// resolved from semantic ambiguities. On error, reports error and returns
+	// null.
+	private ElementValues elementValuesCheck(ElementValues ev) {
+		if (ev instanceof IntegerRange) {
+			if (integerRangeCheck((IntegerRange) ev)) {
+				return ev;
+			} else // Integer range error case.
+			{
+				return null;
+			}
+		} else {
+			TypeCheckRule stopRule = TypeCheckRule.EVENT_DATA_PORT;
+			TypeCheckRule[] checkRules = new TypeCheckRule[] { TypeCheckRule.ELEMENT_VALUES,
+					TypeCheckRule.DATA_COMPONENT_REFERENCE_OTHER_NAMES };
+
+			List<ElementHolder> ehl = refResolver((Reference) ev, null, stopRule, checkRules);
+
+			// Can reuse this method as PortHolder and DataComponentVariable are also
+			// ElementValues.
+			return (ElementValues) referenceToValueVariable(ehl);
+		}
+	}
+
+	// Checks the given integer range and checks the consistency between
+	// the integer values.
+	private boolean integerRangeCheck(IntegerRange ir) {
+		boolean result = false;
+
+		IntegerValue original = ir.getLowerIntegerValue();
+		IntegerValue tmp = integerValueCheck(original);
+
+		result = tmp != null;
+
+		if (result && tmp != original) {
+			ir.setLowerIntegerValue(tmp);
+		}
+
+		original = ir.getUpperIntegerValue();
+		tmp = integerValueCheck(original);
+		result &= tmp != null;
+
+		if (tmp != null && tmp != original) {
+			ir.setUpperIntegerValue(tmp);
+		}
+
+		// Matches the two integer value data types.
+		if (result) {
+			TypeHolder t1, t2;
+
+			try {
+				t1 = AadlBaUtils.getTypeHolder(ir.getLowerIntegerValue(), _baParentContainer);
+				t2 = AadlBaUtils.getTypeHolder(ir.getUpperIntegerValue(), _baParentContainer);
+			} catch (DimensionException de) {
+				reportDimensionException(de);
+				return false;
+			}
+
+			if (!_dataChecker.conformsTo(t1, t2, true)) {
+				result = false;
+				reportError(ir, "\'integer range\' error type : its integer values" + " are not consistent");
+			}
+		}
+
+		return result;
+	}
+
+	private boolean ifStatementCheck(IfStatement stat) {
+		boolean result;
+		ValueAndTypeHolder holder = null;
+
+		ValueExpression ve = stat.getLogicalValueExpression();
+		holder = valueExpressionCheck(ve);
+		result = typeCheck(ve, null, holder, DataRepresentation.BOOLEAN);
+
+		result &= behaviorActionsCheck(stat.getBehaviorActions(), stat);
+
+		ElseStatement elseStat = stat.getElseStatement();
+
+		if (elseStat != null) {
+			// Elif case.
+			if (elseStat instanceof IfStatement) {
+				result &= ifStatementCheck((IfStatement) elseStat);
+			} else {
+				result &= behaviorActionsCheck(elseStat.getBehaviorActions(), elseStat);
+			}
+		}
+
+		return result;
+	}
+
+	@SuppressWarnings("all")
+	private boolean basicActionCheck(BasicAction ba, Object parentContainer) {
+		if (ba instanceof AssignmentAction) {
+			return assignmentActionCheck((AssignmentAction) ba);
+		} else {
+			if (ba instanceof CommunicationAction) {
+				CommunicationAction resolvedCommAct = communicationActionCheck((CommunicationAction) ba);
+				boolean result = resolvedCommAct != null;
+
+				// The returned communication action may be different from the
+				// tested one because of semantic ambiguity resolution in
+				// communicationActionCheck method. So replace if needed.
+				if (resolvedCommAct != ba && result) {
+					// [DEBUG]
+					boolean hasBeenReplaced = false;
+
+					if (parentContainer instanceof ListIterator<?>) {
+						((ListIterator) parentContainer).set(resolvedCommAct);
+						hasBeenReplaced = true;
+					} else if (parentContainer instanceof ElseStatement) {
+						// And also IfStatement.
+						((ElseStatement) parentContainer).setBehaviorActions(resolvedCommAct);
+						hasBeenReplaced = true;
+					} else if (parentContainer instanceof LoopStatement) {
+						((LoopStatement) parentContainer).setBehaviorActions(resolvedCommAct);
+						hasBeenReplaced = true;
+					} else if (parentContainer instanceof BehaviorActionBlock) {
+						((BehaviorActionBlock) parentContainer).setContent(resolvedCommAct);
+						hasBeenReplaced = true;
+					}
+
+					if (!hasBeenReplaced) {
+						String msg = "The resolved communication action: " + unparseNameElement(resolvedCommAct)
+								+ " hasn't been set";
+
+						System.err.println(msg);
+						throw new RuntimeException(msg);
+					}
+				}
+
+				return result;
+			} else // Timed action case.
+			{
+				return timedActionCheck((TimedAction) ba);
+			}
+		}
+	}
+
+	private boolean timedActionCheck(TimedAction ta) {
+		BehaviorTime resolvedTime = _fact.createBehaviorTime();
+
+		boolean result = behaviorTimeCheck((DeclarativeTime) ta.getLowerTime(), resolvedTime);
+		ta.setLowerTime(resolvedTime);
+
+		if (ta.getUpperTime() != null) {
+			resolvedTime = _fact.createBehaviorTime();
+			result &= behaviorTimeCheck((DeclarativeTime) ta.getUpperTime(), resolvedTime);
+			ta.setUpperTime(resolvedTime);
+		}
+
+		if (ta.isSetProcessorClassifier()) {
+			List<ProcessorClassifier> qnes = new ArrayList<ProcessorClassifier>(ta.getProcessorClassifier().size());
+			qnes.addAll(ta.getProcessorClassifier());
+			ta.unsetProcessorClassifier();
+
+			QualifiedNamedElement qne;
+			Classifier tmp;
+
+			for (int i = 0; i < qnes.size(); i++) {
+				qne = (QualifiedNamedElement) qnes.get(i);
+				tmp = (Classifier) uniqueNamedElementReferenceResolver(qne, TypeCheckRule.PROCESSOR_RULE);
+				if (tmp != null) {
+					try {
+						ta.getProcessorClassifier().add((ProcessorClassifier) tmp);
+					} catch (IllegalArgumentException e) {
+						// if the user set the same more than once.
+						System.out.println("catch IllegalArgumentException AadlTypeChecker");
+					}
+				} else {
+					result = false;
+				}
+			}
+		}
+
+		return result;
+	}
+
+	private PortDequeueAction portDequeueActionResolver(CommAction comAct) {
+		// if already resolved, check port ref is event or event data port
+		QualifiedNamedElement qne = comAct.getQualifiedName();
+
+		if (qne != null) {
+			boolean isOfExpectedType = qne.getOsateRef() instanceof EventPort
+					|| qne.getOsateRef() instanceof EventDataPort;
+			if (!isOfExpectedType) {
+				String name = "referenced object";
+				if (qne.getOsateRef() instanceof NamedElement) {
+					NamedElement ne = (NamedElement) qne.getOsateRef();
+					name = ne.getName();
+				} else if (qne.getBaRef() instanceof BehaviorNamedElement) {
+					BehaviorNamedElement bne = (BehaviorNamedElement) qne.getBaRef();
+					name = bne.getName();
+				} else if (qne.getBaName().getId() != null) {
+					name = qne.getBaName().getId();
+				} else if (qne.getName() != null) {
+					name = qne.getName();
+				}
+				reportError(comAct, "incorrect port dequeue action, " + name + " is not an event [data] port");
+				return null;
+			}
+		} else if (comAct.getReference() == null) {
+			return null;
+		}
+
+		Target tarTmp = null;
+		boolean tarCheckResult = true;
+
+		TypeCheckRule stopOnThisRule = TypeCheckRule.IN_PORT;
+		TypeCheckRule checkRule = TypeCheckRule.PORT_DEQUEUE_VALUE;
+		List<ElementHolder> resolvedRef = refResolver(comAct.getReference(), null, stopOnThisRule, checkRule);
+		if (resolvedRef != null) {
+			PortHolder portHolder = (PortHolder) resolvedRef.get(0);
+			return portDequeueActionResolver(portHolder, comAct);
+		} else {
+			return null;
+		}
+	}
+
+	private CommunicationAction qualifiedSubprogramClassifierCallOrPortCommunicationActionResolver(CommAction comAct) {
+		QualifiedNamedElement qne = comAct.getQualifiedName();
+
+		if (qne.getOsateRef() instanceof EventPort) {
+			EventPortHolder tmp = _fact.createEventPortHolder();
+			tmp.setEventPort((EventPort) qne.getOsateRef());
+			if (comAct.isPortDequeue()) {
+				return portDequeueActionResolver(tmp, comAct);
+			}
+			return portSendActionResolver(tmp, comAct);
+		} else if (qne.getOsateRef() instanceof EventDataPort) {
+			EventDataPortHolder tmp = _fact.createEventDataPortHolder();
+			tmp.setEventDataPort((EventDataPort) qne.getOsateRef());
+			if (comAct.isPortDequeue()) {
+				return portDequeueActionResolver(tmp, comAct);
+			}
+			return portSendActionResolver(tmp, comAct);
+		} else if (qne.getOsateRef() instanceof SubprogramAccess) {
+			SubprogramAccessHolder sah = _fact.createSubprogramAccessHolder();
+			sah.setSubprogramAccess((SubprogramAccess) qne.getOsateRef());
+			List<ElementHolder> refs = new ArrayList<ElementHolder>();
+			refs.add(sah);
+			return subprogramCallActionResolver(refs, comAct);
+		} else if (qne.getOsateRef() instanceof SubprogramSubcomponent) {
+			SubprogramSubcomponentHolder ssh = _fact.createSubprogramSubcomponentHolder();
+			ssh.setSubprogramSubcomponent((SubprogramSubcomponent) qne.getOsateRef());
+			List<ElementHolder> refs = new ArrayList<ElementHolder>();
+			refs.add(ssh);
+			return subprogramCallActionResolver(refs, comAct);
+		}
+		return null;
+	}
+
+	private PortDequeueAction portDequeueActionResolver(PortHolder portHolder, CommAction comAct) {
+		PortDequeueAction portDequeueAction = _fact.createPortDequeueAction();
+
+		TypeCheckRule stopOnThisRule = TypeCheckRule.IN_PORT;
+
+		if (comAct.getTarget() != null) {
+			final Target tarTmp = targetCheck(comAct.getTarget(), stopOnThisRule);
+			if (tarTmp == null) {
+				return null;
+			}
+
+			portDequeueAction.setTarget(tarTmp);
+
+			// Matches the target's data type with the input port's one
+			// when port dequeue action.
+			TypeHolder tarType, portType;
+
+			try {
+				portType = AadlBaUtils.getTypeHolder(portHolder, _baParentContainer);
+				tarType = AadlBaUtils.getTypeHolder(tarTmp, _baParentContainer);
+			} catch (DimensionException de) {
+				de.setElement(comAct);
+				reportDimensionException(de);
+				return null;
+			}
+
+			if (false == _dataChecker.conformsTo(portType, tarType, true)) {
+				reportTypeError(comAct, "port dequeue action", portType.toString(), tarType.toString());
+				return null;
+			}
+		}
+		portDequeueAction.setPort((ActualPortHolder) portHolder);
+		portDequeueAction.setLocationReference(comAct.getLocationReference());
+		return portDequeueAction;
+	}
+
+	// This method checks the given object and returns a communication action
+	// resolved from semantic ambiguities. On error, reports error and returns
+	// null.
+	/**
+	 * Document: AADL Behavior Annex draft
+	 * Version : 0.94
+	 * Type : Legality rule
+	 * Section : D.6 Behavior Action Language
+	 * Object : Check legality rule D.6.(L6)
+	 * Keys : dequeue value port target
+	 */
+	private CommunicationAction communicationActionCheck(CommunicationAction ca) {
+		CommAction comAct = (CommAction) ca;
+
+		// Subprogram qualified classifier call.
+		if (isSubprogramClassifierCallOrPortCommunicationAction(comAct)) {
+			return qualifiedSubprogramClassifierCallOrPortCommunicationActionResolver(comAct);
+		}
+		// Port dequeue call.
+		else if (comAct.isPortDequeue()) {
+			return portDequeueActionResolver(comAct);
+		}
+		// Port freeze call.
+		else if (comAct.isPortFreeze()) {
+			return portFreezeActionResolver(comAct);
+		}
+		// Shared action call.
+		else if (comAct.isLock() || comAct.isUnlock()) {
+			return sharedActionResolver(comAct);
+		} else // Ambiguous cases.
+		{
+			return subprogramCallActionAndPortSendActionResolver(comAct);
+		}
+	}
+
+	private boolean isSubprogramClassifierCallOrPortCommunicationAction(CommAction comAct) {
+		QualifiedNamedElement qne = comAct.getQualifiedName();
+
+		if (qne == null) {
+			return false;
+		}
+
+		if (qne.getOsateRef() instanceof EventPort || qne.getOsateRef() instanceof EventDataPort
+				|| qne.getOsateRef() instanceof SubprogramAccess
+				|| qne.getOsateRef() instanceof SubprogramSubcomponent) {
+			return true;
+		}
+		return false;
+	}
+
+	// Resolves semantic ambiguities (subprogram call and port send action).
+	// On error, reports error and returns null.
+	private CommunicationAction subprogramCallActionAndPortSendActionResolver(CommAction comAct) {
+		if (comAct.getQualifiedName() != null) {
+			TypeCheckRule rule = TypeCheckRule.SUBPROGRAM_UCCR;
+			Subprogram sub = (Subprogram) uniqueNamedElementReferenceResolver(comAct.getQualifiedName(), rule);
+			if (sub != null) {
+				// Gets subprogram type.
+				Classifier subprogType = subprogramTypeCheck(comAct);
+
+				// Checks and resolves parameter labels.
+				// Event if the subprogram call action doesn't have any parameter labels,
+				// the subprogram type may have and vice versa:
+				// subprogramParameterListCheck is also design for these cases.
+				// It also binds the subprogram type found to the subprogram call action.
+				if (subprogType != null) {
+					if (subprogramParameterListCheck(comAct, comAct.getParameters(), subprogType)) {
+						SubprogramCallAction result = _fact.createSubprogramCallAction();
+						SubprogramHolder sh = _fact.createSubprogramHolder();
+						sh.setLocationReference(comAct.getLocationReference());
+						sh.setSubprogram(sub);
+						result.setSubprogram(sh);
+						result.setLocationReference(comAct.getLocationReference());
+						result.getParameterLabels().addAll(comAct.getParameters());
+						return result;
+					}
+				}
+			}
+		} else if (comAct.getReference() != null) {
+			TypeCheckRule stopOnThisRule = TypeCheckRule.OUT_PORT;
+			TypeCheckRule[] checkRules = new TypeCheckRule[] { TypeCheckRule.SUBPROGRAM_CALL_ACTION_FIRST_NAME,
+					TypeCheckRule.SUBPROGRAM_CALL_ACTION_SD_NAME };
+
+			List<ElementHolder> resolvedRef = refResolver(comAct.getReference(), null, stopOnThisRule, checkRules);
+
+			if (resolvedRef != null) {
+				// Port send action case.
+				if (resolvedRef.get(0) instanceof PortHolder) {
+					ActualPortHolder portHolder = (ActualPortHolder) resolvedRef.get(0);
+					return portSendActionResolver(portHolder, comAct);
+				} else // Subprogram call action case.
+				{
+					return subprogramCallActionResolver(resolvedRef, comAct);
+				}
+			}
+		}
+		return null;
+	}
+
+	private SubprogramCallAction subprogramCallActionResolver(List<ElementHolder> resolvedRef, CommAction comAct) {
+		// Gets subprogram type.
+		Classifier subprogType = subprogramTypeCheck(comAct);
+
+		// Checks and resolves parameter labels.
+		// Event if the subprogram call action doesn't have any parameter labels,
+		// the subprogram type may have and vice versa :
+		// subprogramParameterListCheck is also design for these cases.
+		// It also binds the subprogram type found to the subprogram call action.
+		if (subprogType != null) {
+			if (subprogramParameterListCheck(comAct, comAct.getParameters(), subprogType)) {
+				SubprogramCallAction result = _fact.createSubprogramCallAction();
+				result.getParameterLabels().addAll(comAct.getParameters());
+
+				ElementHolder firstHolder = resolvedRef.get(0);
+				ElementHolder secondHolder = null;
+
+				if (resolvedRef.size() == 2) {
+					secondHolder = resolvedRef.get(1);
+				}
+
+				if (firstHolder instanceof SubprogramHolderProxy) {
+					// RefResolver can't detect that error. So do it.
+					if (resolvedRef.size() != 2) {
+						String msg = "missing subprogram access for : " + firstHolder.getElement().getName();
+
+						reportError(firstHolder, msg);
+
+						return null;
+					} else {
+						result.setProxy((SubprogramHolderProxy) firstHolder);
+						result.setSubprogram((CalledSubprogramHolder) secondHolder);
+					}
+				} else {
+					result.setSubprogram((CalledSubprogramHolder) firstHolder);
+				}
+
+				result.setLocationReference(comAct.getLocationReference());
+
+				return result;
+			} else {
+				return null;
+			}
+		} else {
+			return null;
+		}
+	}
+
+	private CommunicationAction portSendActionResolver(ActualPortHolder portHolder, CommAction comAct) {
+		PortSendAction portSendActionResult = _fact.createPortSendAction();
+
+		if (comAct.isSetParameters()) {
+			List<ParameterLabel> pll = comAct.getParameters();
+
+			if (pll.size() == 1) {
+				ValueExpression ve = (ValueExpression) pll.get(0);
+
+				ValueAndTypeHolder tmp = valueExpressionCheck(ve);
+
+				if (tmp != null) {
+					portSendActionResult.setPort(portHolder);
+
+					// Matches the value expression top level data type
+					// with the port data type.
+					TypeHolder portType;
+
+					try {
+						portType = AadlBaUtils.getTypeHolder(portHolder, _baParentContainer);
+					} catch (DimensionException de) {
+						reportDimensionException(de);
+						return null;
+					}
+
+					if (!_dataChecker.conformsTo(portType, tmp.typeHolder, true)) {
+						reportTypeError(comAct, "port send action", portType.toString(), tmp.typeHolder.toString());
+						return null;
+					} else {
+						ValueExpression veTmp = (ValueExpression) tmp.value;
+						portSendActionResult.setValueExpression(veTmp);
+					}
+				} else // Value expression checking has failed.
+				{
+					return null;
+				}
+			} else // Error case : Port send action has only one value expression.
+			{
+				return null;
+			}
+		} else {
+			portSendActionResult.setPort(portHolder);
+		}
+
+		portSendActionResult.setLocationReference(comAct.getLocationReference());
+
+		return portSendActionResult;
+	}
+
+	private SharedDataAction sharedActionResolver(CommAction comAct) {
+		DataAccessHolder dah = null;
+		SharedDataAction result = null;
+
+		if (comAct.getReference() != null) {
+			TypeCheckRule checkRules = TypeCheckRule.SHARED_DATA_ACTION;
+			TypeCheckRule stopOnThisRule = checkRules;
+			List<ElementHolder> resolvedRef = refResolver(comAct.getReference(), null, stopOnThisRule, checkRules);
+			if (resolvedRef != null) {
+				dah = (DataAccessHolder) resolvedRef.get(0);
+			} else {
+				return null;
+			}
+		}
+
+		if (comAct.isLock()) {
+			result = _fact.createLockAction();
+			if (comAct.getQualifiedName() != null && comAct.getQualifiedName().getOsateRef() != null
+					&& comAct.getQualifiedName().getOsateRef() instanceof DataAccess) {
+				dah = _fact.createDataAccessHolder();
+				dah.setElement((DataAccess) comAct.getQualifiedName().getOsateRef());
+			}
+
+		} else {
+			result = _fact.createUnlockAction();
+			if (comAct.getQualifiedName() != null && comAct.getQualifiedName().getOsateRef() != null
+					&& comAct.getQualifiedName().getOsateRef() instanceof DataAccess) {
+				dah = _fact.createDataAccessHolder();
+				dah.setElement((DataAccess) comAct.getQualifiedName().getOsateRef());
+			}
+		}
+
+		result.setDataAccess(dah);
+		result.setLocationReference(comAct.getLocationReference());
+
+		return result;
+	}
+
+	private PortFreezeAction portFreezeActionResolver(CommAction comAct) {
+		TypeCheckRule checkRules = TypeCheckRule.IN_PORT;
+		TypeCheckRule stopOnThisRule = TypeCheckRule.PORT_FREEZE_ACTION;
+
+		PortFreezeAction pfa = _fact.createPortFreezeAction();
+
+		List<ElementHolder> resolvedRef = refResolver(comAct.getReference(), pfa, stopOnThisRule, checkRules);
+		if (resolvedRef != null) {
+			return (PortFreezeAction) resolvedRef.get(0);
+		} else {
+			return null;
+		}
+	}
+
+	// Recursive method.
+	private Classifier getSubprogramType(CalledSubprogram sc) {
+		Classifier result = null;
+
+		if (sc instanceof SubprogramImplementation) {
+			result = ((SubprogramImplementation) sc).getType();
+		} else if (sc instanceof SubprogramType) {
+			result = (SubprogramType) sc;
+		} else if (sc instanceof SubprogramAccess) {
+			SubprogramAccess sa = (SubprogramAccess) sc;
+			result = sa.getClassifier();
+		} else if (sc instanceof SubprogramSubcomponent) {
+			SubprogramSubcomponent ss = (SubprogramSubcomponent) sc;
+			result = ss.getClassifier();
+		}
+
+		return result;
+	}
+
+	// Gets subprogram type binded to the given subprogram call action.
+	// On error, reports error and returns null.
+	private Classifier subprogramTypeCheck(CommAction comAct) {
+		Element el = null;
+
+		if (comAct.getReference() != null) {
+			el = comAct.getReference().getOsateRef();
+		} else {
+			el = comAct.getQualifiedName().getOsateRef();
+		}
+
+		Classifier result = null;
+		String errorMsg = null;
+
+		if (el instanceof ComponentPrototype) {
+			ComponentPrototype cp = (ComponentPrototype) el;
+
+			if (cp instanceof SubprogramPrototype) {
+				ComponentClassifier cc = cp.getConstrainingClassifier();
+
+				if (cc != null && cc instanceof SubprogramType) {
+					result = cc;
+				} else {
+					errorMsg = " is not a defined subprogram prototype";
+					result = null;
+				}
+			} else {
+				errorMsg = " is not an subprogram prototype";
+				result = null;
+			}
+		} else if (el instanceof CalledSubprogram) // Always after ComponentPrototype
+		{ // case.
+			result = getSubprogramType((CalledSubprogram) el);
+		} else if (el instanceof ComponentPrototypeBinding) {
+			ComponentPrototypeBinding cpb = (ComponentPrototypeBinding) el;
+
+			// Takes the last binding.
+			ComponentPrototypeActual cpa = cpb.getActuals().get(cpb.getActuals().size() - 1);
+
+			if (cpa.getSubcomponentType() instanceof SubprogramType) {
+				result = (SubprogramType) cpa.getSubcomponentType();
+			} else {
+				errorMsg = " is not an subprogram prototype";
+				result = null;
+			}
+		} else // Error case : the binded object is not an subprogram.
+		{
+			errorMsg = "is not subprogram";
+			result = null;
+		}
+
+		// Error reporting.
+		if (result == null && errorMsg != null) {
+			String subprogramName = unparseReference(comAct.getReference());
+			reportError(comAct, '\'' + subprogramName + '\'' + errorMsg);
+		}
+
+		return result;
+	}
+
+	// This method checks the given parameter labels and matches them against the
+	// subprogram parameters. It resolves target/value expression semantic
+	// ambiguities. On error, reports error and returns false.
+	// Event if the subprogram call action doesn't have any parameter labels,
+	// the subprogram type may have and vice versa : subprogramParameterListCheck
+	/// is also design for these cases.
+	/**
+	 * Document: AADL Behavior Annex draft
+	 * Version : 0.94
+	 * Type : Legality rule
+	 * Section : D.6 Behavior Action Language
+	 * Object : Check legality rule D.6.(L5)
+	 * Keys : parameter list match signature subprogram call
+	 */
+	private boolean subprogramParameterListCheck(CommAction comAct, EList<ParameterLabel> callParams,
+			Classifier subprogType) {
+		// Fetches sorted subprogram feature list.
+
+		List<Feature> tmp = Aadl2Utils.orderFeatures(subprogType);
+		List<Feature> subprogFeat = new ArrayList<Feature>(tmp.size());
+
+		for (Feature feat : tmp) {
+			if (feat instanceof DataAccess || feat instanceof Parameter) {
+				subprogFeat.add(feat);
+			}
+		}
+
+		// Matching the parameter labels with the subprogram signature.
+		// Resolves ambiguity between target and value expression:
+		// value expression are for in parameter, target are for out parameter.
+
+		// Preliminary checking : on error, reports error and exit early.
+		if (callParams.size() != subprogFeat.size()) {
+			String subprogramName = null;
+
+			if (comAct.getReference() != null) {
+				subprogramName = unparseReference(comAct.getReference());
+			} else {
+				subprogramName = unparseQualifiedNamedElement(comAct.getQualifiedName());
+			}
+
+			reportError(comAct, "Invalid number of argument(s) for the subprogram " + subprogramName);
+			return false;
+		}
+
+		boolean isconsistent = true;
+		boolean hasCheckingPassed = true;
+
+		Enum<?> currentDirRight;
+		ValueExpression valueExp;
+		ListIterator<ParameterLabel> it = callParams.listIterator();
+		Value v;
+		Target tar;
+		TypeHolder t1, t2;
+		ValueAndTypeHolder vth;
+
+		List<TypeHolder> typesFound = new ArrayList<TypeHolder>(callParams.size());
+		List<Enum<?>> dirRightsFound = new ArrayList<Enum<?>>(callParams.size());
+
+		List<TypeHolder> expectedTypes = new ArrayList<TypeHolder>(subprogFeat.size());
+		List<Enum<?>> expectedDirRight = new ArrayList<Enum<?>>(subprogFeat.size());
+
+		// As AADL standard doesn't allow subprogram overloading (two subprogram
+		// classifier names can't be the same), parameter labels checking is
+		// driven by the subprogram signature.
+		for (Feature feat : subprogFeat) {
+			if (feat instanceof Parameter) {
+				Parameter param = (Parameter) feat;
+				currentDirRight = param.getDirection();
+				expectedDirRight.add(currentDirRight);
+			} else // DataAccess case.
+			{
+				DataAccess data = (DataAccess) feat;
+				currentDirRight = Aadl2Utils.getDataAccessRight(data);
+				expectedDirRight.add(currentDirRight);
+			}
+
+			valueExp = (ValueExpression) it.next();
+
+			Classifier klass = AadlBaUtils.getClassifier(feat, _baParentContainer);
+
+			// ValueExpression case.
+			if (currentDirRight == DirectionType.IN || currentDirRight == Aadl2Utils.DataAccessRight.read_only) {
+				vth = valueExpressionCheck(valueExp);
+
+				if (vth != null) {
+					try {
+						t1 = AadlBaUtils.getTypeHolder(klass);
+					} catch (DimensionException de) {
+						reportDimensionException(de);
+						return false;
+					}
+
+					t2 = vth.typeHolder;
+					expectedTypes.add(t1);
+					typesFound.add(t2);
+					dirRightsFound.add(DirectionType.IN);
+
+					if (!_dataChecker.conformsTo(t1, t2, true)) {
+						isconsistent = false;
+					}
+				} else // Value expression checking error case.
+				{
+					// Error reporting has already been done.
+					hasCheckingPassed = false;
+				}
+			} else if (currentDirRight != Aadl2Utils.DataAccessRight.unknown) {
+				v = AadlBaUtils.isOnlyOneValue(valueExp);
+
+				boolean isOnlyOneReference = false;
+				if (v instanceof Reference) {
+					Reference r = (Reference) v;
+					if (r.getIds().size() == 1) {
+						isOnlyOneReference = true;
+					}
+				}
+				if (v instanceof Target && isOnlyOneReference) // Target but not reference case.
+				{
+					TypeCheckRule stopOnThisRule = TypeCheckRule.DATA_ACCESS;
+					tar = targetCheck((Target) v, stopOnThisRule);
+
+					if (tar != null) {
+						try {
+							t1 = AadlBaUtils.getTypeHolder(klass);
+							t2 = AadlBaUtils.getTypeHolder(tar, _baParentContainer);
+						} catch (DimensionException de) {
+							reportDimensionException(de);
+							return false;
+						}
+
+						expectedTypes.add(t1);
+						typesFound.add(t2);
+
+						Enum<?> dirRightFound = AadlBaUtils.getDirectionType(tar);
+
+						if (dirRightFound == null) {
+							dirRightFound = AadlBaUtils.getDataAccessRight(tar);
+						}
+
+						dirRightsFound.add(dirRightFound);
+
+						if (!_dataChecker.conformsTo(t1, t2, true)) {
+							isconsistent = false;
+						} else {
+							// As checking passed and ambiguity between
+							// ValueExpression and Target has been resolved, it replaces
+							// the value expression by the target as parameter label.
+							it.set(tar);
+						}
+					} else // Target checking error case.
+					{
+						// Error reporting has already been done.
+						hasCheckingPassed = false;
+					}
+				} else // Value expression taken as a target -> warning arithmetic pointer operation.
+				{
+					// Due to target/value expression semantic ambiguity, the parsing
+					// phase may have introduced a semantic errors :
+
+					// If v == null :
+					// The parameter label has
+					// to be a value expression with a single value when the expected
+					// subprogram parameter is IN_OUT or OUT.
+
+					// If v is not instanceof Target but ValueExpression or Value
+					// like :
+					// _ IntegerConstant or ValueConstant
+					// _ PortFreshValue
+					// _ PortCountValue
+					// _ PortDequeueValue
+					// It resolves the type in order to format the warning message:
+
+					vth = valueExpressionCheck(valueExp);
+
+					if (vth != null) {
+						try {
+							t1 = AadlBaUtils.getTypeHolder(klass);
+						} catch (DimensionException de) {
+							reportDimensionException(de);
+							return false;
+						}
+
+						t2 = vth.typeHolder;
+						expectedTypes.add(t1);
+						typesFound.add(t2);
+
+						boolean inconsistentDir = false;
+						if (v instanceof Reference) {
+							Reference ref = (Reference) v;
+							ArrayableIdentifier refRootId = ref.getIds().get(0);
+							Enum<?> dirRightFound = null;
+							if (refRootId.getOsateRef() != null) {
+								dirRightFound = AadlBaUtils.getDirectionType(refRootId.getOsateRef());
+							}
+							if (dirRightFound == null && refRootId.getOsateRef() instanceof DataAccess) {
+								dirRightFound = Aadl2Utils.getDataAccessRight((DataAccess) refRootId.getOsateRef());
+							}
+							if (dirRightFound == DirectionType.IN
+									|| dirRightFound == Aadl2Utils.DataAccessRight.read_only) {
+								inconsistentDir = true;
+							}
+						} else {
+							inconsistentDir = true;
+							dirRightsFound.add(DirectionType.IN);
+						}
+
+						if (inconsistentDir) {
+							StringBuilder msg = new StringBuilder();
+							msg.append('\'');
+							msg.append(unparseNameElement(valueExp));
+							msg.append("\': is a read only value and it is used as a writable value");
+
+							// Reports a warning.
+							reportWarning(valueExp, msg.toString());
+						}
+					} else {
+						// Error reporting has already been done.
+						hasCheckingPassed = false;
+					}
+				}
+			} else {
+				reportError(valueExp,
+						"can't fetch data access right. Set the default " + "right in memory_properties.aadl");
+			}
+		}
+
+		// Reports consistency error.
+		if (!isconsistent && hasCheckingPassed) {
+			String subprogramName = null;
+
+			if (comAct.getReference() != null) {
+				subprogramName = unparseReference(comAct.getReference());
+			} else {
+				subprogramName = unparseQualifiedNamedElement(comAct.getQualifiedName());
+			}
+
+			reportSubprogParamMatchingError(comAct, subprogramName, expectedTypes, expectedDirRight, typesFound,
+					dirRightsFound);
+		}
+
+		return isconsistent && hasCheckingPassed;
+	}
+
+	private void reportWarning(Element el, String msg) {
+		_errManager.warning(el, msg);
+	}
+
+	private void reportSubprogParamMatchingError(BehaviorElement e, String subprogramName,
+			List<TypeHolder> expectedTypes, List<Enum<?>> expectedDirections, List<TypeHolder> typesFound,
+			List<Enum<?>> directionsFound) {
+		StringBuilder msg = new StringBuilder("The subprogram ");
+		msg.append(subprogramName);
+		msg.append('(');
+
+		if (!expectedTypes.isEmpty()) {
+			int index = 0;
+
+			for (TypeHolder th : expectedTypes) {
+				msg.append(expectedDirections.get(index++));
+				msg.append(' ');
+				msg.append(th.toString());
+				msg.append(STRING_PARAMETER_SEPARATOR);
+			}
+
+			// Remove the last separator.
+			msg.delete(msg.length() - STRING_PARAMETER_SEPARATOR.length(), msg.length());
+		}
+
+		msg.append(") is not applicable for the arguments (");
+
+		if (!typesFound.isEmpty()) {
+			int index = 0;
+
+			for (TypeHolder th : typesFound) {
+				msg.append(directionsFound.get(index++));
+				msg.append(' ');
+				msg.append(th.toString());
+				msg.append(STRING_PARAMETER_SEPARATOR);
+			}
+
+			// Remove the last separator.
+			msg.delete(msg.length() - STRING_PARAMETER_SEPARATOR.length(), msg.length());
+
+		}
+
+		msg.append(')');
+
+		reportError(e, msg.toString());
+	}
+
+	/**
+	 * Document: AADL Behavior Annex draft
+	 * Version : 0.94
+	 * Type : Legality rule
+	 * Section : D.6 Behavior Action Language
+	 * Object : Check legality rule D.6.(L1)
+	 * Keys : assignment action value expression target match type consistency
+	 */
+	private boolean assignmentActionCheck(AssignmentAction aa) {
+		TypeCheckRule stopOnThisRule = TypeCheckRule.ASSIGNMENT_TARGET;
+		Target tmp = targetCheck(aa.getTarget(), stopOnThisRule);
+
+		boolean result = tmp != null;
+
+		TypeHolder tarType, expType;
+		tarType = expType = null;
+
+		// The returned target may be different from the tested target
+		// because of semantic ambiguity resolution in targetCheck
+		// method. So replace if needed.
+		if (tmp != aa.getTarget() && result) {
+			aa.setTarget(tmp);
+		}
+
+		ValueExpression ve = aa.getValueExpression();
+
+		if (ve != null && (false == ve instanceof Any)) {
+			ValueAndTypeHolder vth = valueExpressionCheck(aa.getValueExpression());
+			if (vth != null) {
+				expType = vth.typeHolder;
+			} else {
+				result = false;
+			}
+
+			if (result) {
+				// Performs data type consistency checking.
+				try {
+					tarType = AadlBaUtils.getTypeHolder(tmp, _baParentContainer);
+				} catch (DimensionException de) {
+					reportDimensionException(de);
+					return false;
+				}
+
+				result = _dataChecker.conformsTo(tarType, expType, true);
+
+				if (!result) {
+					reportTypeError(vth.value, "assignment", tarType.toString(), expType.toString());
+				}
+			}
+		}
+
+		return result;
+	}
+
+	// Semantic rule about iterative variable assignment is checked.
+	// This method checks the given object and returns an object resolved from
+	// semantic ambiguities. On error, reports error and returns null.
+	private Target targetCheck(Target tar, TypeCheckRule stopOnThisRule) {
+		TypeCheckRule[] checkRules = new TypeCheckRule[] { TypeCheckRule.TARGET_COMPONENT_REFERENCE_FIRST_NAME,
+				TypeCheckRule.DATA_COMPONENT_REFERENCE_OTHER_NAMES };
+
+		List<ElementHolder> resolvedRef = refResolver((Reference) tar, null, stopOnThisRule, checkRules);
+
+		return (Target) referenceToValueVariable(resolvedRef);
+	}
+
+	// Compares the given expected data representation to the ValueAndTypeHolder
+	// one. Returns true is the data representation are the same.
+	// Otherwise returns false and reports error.
+	// If the given ValueAndTypeHolder object is null, it returns false without
+	// reporting any error (error reporting has already been done ?).
+	// If the given name is null, the method will unparse the given element.
+	private boolean typeCheck(BehaviorElement e, String name, ValueAndTypeHolder holder,
+			DataRepresentation expectedDataRepresentation) {
+		boolean result = false;
+
+		if (holder != null) {
+			result = expectedDataRepresentation == holder.typeHolder.getDataRep();
+
+			if (!result) {
+				if (name == null) {
+					name = unparseNameElement(e);
+				}
+				reportTypeError(e, name, expectedDataRepresentation.getName(), holder.typeHolder.toString());
+			}
+		}
+
+		return result;
+	}
+
+	/**
+	 * Return the element binded to the given declarative behavior element.
+	 *
+	 * @param el the given declarative behavior element
+	 * @return the binded element
+	 */
+	static Element getBindedElement(DeclarativeBehaviorElement el) {
+		org.osate.aadl2.Element result = el.getOsateRef();
+
+		if (result == null) {
+			result = el.getBaRef();
+		}
+
+		return result;
+	}
+
+	/**
+	 * Returns the feature type of the element binded to the given behavior
+	 * annex element.
+	 *
+	 * @param el the given behavior annex element
+	 * @return the feature type of the binded element
+	 */
+	static Enum<?> getType(DeclarativeBehaviorElement el) {
+		org.osate.aadl2.Element testedEl = AadlBaModelResolver.getBindedElement(el);
+
+		Enum<?> result;
+
+		if (testedEl instanceof BehaviorElement) {
+			result = AadlBaUtils.getBehaviorAnnexFeatureType((BehaviorElement) testedEl);
+		} else {
+			result = AadlBaUtils.getFeatureType(testedEl);
+		}
+
+		return result;
+	}
+
+	/**
+	 * Checks the type of the reference binded to the given declarative behavior
+	 * element within the given rule's expected types. Returns the
+	 * matching feature type or {@code null} otherwise. Reports any error if
+	 * hasToReport is {@code true}.
+	 *
+	 * @param dbe the declarative behavior element to be checked
+	 * @param name the behavior element's name
+	 * @param rule the checking rule that contains the expected types
+	 * @param hasToReport flag for report error
+	 * @return the matching feature type or {@code null}
+	 */
+	private Enum<?> typeCheck(DeclarativeBehaviorElement dbe, String name, TypeCheckRule rule, boolean hasToReport) {
+		Enum<?> result = rule.test(dbe, _baParentContainer);
+
+		if (result == null && hasToReport) {
+
+			Enum<?> testedEnum = AadlBaModelResolver.getType(dbe);
+
+			// Resolves feature prototype binding.
+			if (testedEnum == FeatureType.FEATURE_PROTOTYPE_BINDING) {
+				Element el = AadlBaModelResolver.getBindedElement(dbe);
+				testedEnum = AadlBaUtils.getFeatPrototypeType((FeaturePrototypeBinding) el);
+			}
+
+			String expectedTypes = rule.getExpectedTypes(STRING_TYPE_SEPARATOR);
+			String typeFound = ((Enumerator) testedEnum).getLiteral();
+			reportTypeError(dbe, name, expectedTypes, typeFound);
+		}
+
+		return result;
+	}
+
+	// Convenient class that holds a value and its type representation.
+	private class ValueAndTypeHolder {
+		Value value;
+		TypeHolder typeHolder;
+
+		public ValueAndTypeHolder(Value v, TypeHolder typeHolder) {
+			this.value = v;
+			this.typeHolder = typeHolder;
+		}
+	}
+
+	// Behavior annex type checking rules.
+	// Based on a design pattern command.
+	private enum TypeCheckRule implements Enumerator {
+		ALL("any type", new Enum[] {}) {
+			@Override
+			public Enum<?> testTypeCheckRule(Enum<?> other) {
+				return other;
+			}
+		},
+
+		NOTHING("no type", new Enum[] {}) {
+			@Override
+			public Enum<?> test(DeclarativeBehaviorElement dbe, ComponentClassifier baParentContainer) {
+				return null;
+			}
+		},
+
+		IN_EVENT_PORT("in event port", new Enum[] { FeatureType.IN_EVENT_PORT, FeatureType.IN_OUT_EVENT_PORT }),
+
+		IN_EVENT_DATA_PORT("in event data port",
+				new Enum[] { FeatureType.IN_EVENT_DATA_PORT, FeatureType.IN_OUT_EVENT_DATA_PORT }),
+
+		EVENT_DATA_PORT("event data port", new Enum[] { FeatureType.IN_EVENT_DATA_PORT, FeatureType.OUT_EVENT_DATA_PORT,
+				FeatureType.IN_OUT_EVENT_DATA_PORT }),
+
+		IN_PORT("in port",
+				new Enum[] { FeatureType.IN_DATA_PORT, FeatureType.IN_OUT_DATA_PORT, FeatureType.IN_EVENT_PORT,
+						FeatureType.IN_OUT_EVENT_PORT, FeatureType.IN_EVENT_DATA_PORT,
+						FeatureType.IN_OUT_EVENT_DATA_PORT }),
+
+		OUT_PORT("out port",
+				new Enum[] { FeatureType.OUT_DATA_PORT, FeatureType.IN_OUT_DATA_PORT, FeatureType.OUT_EVENT_PORT,
+						FeatureType.IN_OUT_EVENT_PORT, FeatureType.OUT_EVENT_DATA_PORT,
+						FeatureType.IN_OUT_EVENT_DATA_PORT }),
+
+		PORT("port", new Enum[] { FeatureType.IN_DATA_PORT, FeatureType.IN_OUT_DATA_PORT, FeatureType.OUT_DATA_PORT,
+				FeatureType.IN_EVENT_PORT, FeatureType.IN_OUT_EVENT_PORT, FeatureType.OUT_EVENT_PORT,
+				FeatureType.IN_EVENT_DATA_PORT, FeatureType.IN_OUT_EVENT_DATA_PORT, FeatureType.OUT_EVENT_DATA_PORT }),
+
+		IN_PORT_PROTOTYPE("in port prototype",
+				new Enum[] { FeatureType.IN_DATA_PORT_PROTOTYPE, FeatureType.IN_OUT_DATA_PORT_PROTOTYPE,
+						FeatureType.IN_EVENT_PORT_PROTOTYPE, FeatureType.IN_OUT_EVENT_PORT_PROTOTYPE,
+						FeatureType.IN_EVENT_DATA_PORT_PROTOTYPE, FeatureType.IN_OUT_EVENT_DATA_PORT_PROTOTYPE }),
+
+		OUT_PORT_PROTOTYPE("out port prototype",
+				new Enum[] { FeatureType.OUT_DATA_PORT_PROTOTYPE, FeatureType.IN_OUT_DATA_PORT_PROTOTYPE,
+						FeatureType.OUT_EVENT_PORT_PROTOTYPE, FeatureType.IN_OUT_EVENT_PORT_PROTOTYPE,
+						FeatureType.OUT_EVENT_DATA_PORT_PROTOTYPE, FeatureType.IN_OUT_EVENT_DATA_PORT_PROTOTYPE }),
+
+		FEATURE_PROTOTYPE("feature prototype", new Enum[] { FeatureType.IN_FEATURE_PROTOTYPE,
+				FeatureType.OUT_FEATURE_PROTOTYPE, FeatureType.IN_OUT_FEATURE_PROTOTYPE }),
+
+		IN_PARAMETER("in parameter", new Enum[] { FeatureType.IN_PARAMETER, FeatureType.IN_OUT_PARAMETER }),
+
+		OUT_PARAMETER("out parameter", new Enum[] { FeatureType.OUT_PARAMETER, FeatureType.IN_OUT_PARAMETER }),
+
+		PARAMETER("parameter",
+				new Enum[] { FeatureType.IN_PARAMETER, FeatureType.OUT_PARAMETER, FeatureType.IN_OUT_PARAMETER }),
+
+		DATA_ACCESS("data access", new Enum[] { FeatureType.REQUIRES_DATA_ACCESS, FeatureType.PROVIDES_DATA_ACCESS }),
+
+		DATA_ACCESS_PROTOTYPE("data access prototype",
+				new Enum[] { FeatureType.REQUIRES_DATA_ACCESS_PROTOTYPE, FeatureType.PROVIDES_DATA_ACCESS_PROTOTYPE }),
+
+		FROZEN_PORT("frozen port", new Enum[] { TypeCheckRule.IN_PORT }),
+
+		DISPATCH_TRIGGER("dispatch trigger",
+				new Enum[] { TypeCheckRule.IN_EVENT_PORT, TypeCheckRule.IN_EVENT_DATA_PORT }),
+
+		MODE_SWITCH_TRIGGER("mode switch trigger",
+				new Enum[] { TypeCheckRule.IN_EVENT_PORT, TypeCheckRule.IN_EVENT_DATA_PORT }),
+
+		DISPATCH_TRIGGER_CONDITION("dispatch trigger condition", new Enum[] { TypeCheckRule.IN_EVENT_PORT,
+				TypeCheckRule.IN_EVENT_DATA_PORT, FeatureType.PROVIDES_SUBPROGRAM_ACCESS }),
+
+		// Always include at the end of an array:
+		// because data subcomponent and data access are very high level feature types.
+		DATA_COMPONENT_REFERENCE_FIRST_NAME(
+				"data subcomponent" + STRING_TYPE_SEPARATOR + "data access" + STRING_TYPE_SEPARATOR
+						+ "behavior variable" + STRING_TYPE_SEPARATOR + "data access feature prototype",
+				new Enum[] { FeatureType.DATA_SUBCOMPONENT, TypeCheckRule.DATA_ACCESS,
+						TypeCheckRule.DATA_ACCESS_PROTOTYPE, TypeCheckRule.FEATURE_PROTOTYPE,
+						BehaviorFeatureType.BEHAVIOR_VARIABLE }),
+
+		DATA_COMPONENT_REFERENCE_OTHER_NAMES("data field",
+				new Enum[] { FeatureType.DATA_SUBCOMPONENT, TypeCheckRule.DATA_ACCESS,
+						TypeCheckRule.DATA_ACCESS_PROTOTYPE, TypeCheckRule.FEATURE_PROTOTYPE,
+						FeatureType.CLASSIFIER_VALUE }),
+
+		// Always include at the end of an array:
+		// because data subcomponent and data access are very high level feature types.
+		VV_COMPONENT_REFERENCE_FIRST_NAME(
+				DATA_COMPONENT_REFERENCE_FIRST_NAME._literal + STRING_TYPE_SEPARATOR + "in parameter"
+						+ STRING_TYPE_SEPARATOR + "incomming port (prototype)" + STRING_TYPE_SEPARATOR
+						+ "iterative variable",
+				new Enum[] { TypeCheckRule.DATA_COMPONENT_REFERENCE_FIRST_NAME, TypeCheckRule.IN_PARAMETER,
+						TypeCheckRule.IN_PORT, TypeCheckRule.IN_PORT_PROTOTYPE,
+						BehaviorFeatureType.ITERATIVE_VARIABLE }),
+
+		PROPERTY("property", new Enum[] { FeatureType.PROPERTY_CONSTANT, FeatureType.PROPERTY_VALUE }),
+
+		PORT_COUNT_VALUE("port count value", new Enum[] { TypeCheckRule.PORT }),
+
+		PORT_FRESH_VALUE("port fresh value", new Enum[] { TypeCheckRule.PORT }),
+
+		PORT_DEQUEUE_VALUE("port dequeue value", new Enum[] { TypeCheckRule.IN_PORT }),
+
+		ELEMENT_VALUES("element values", new Enum[] { TypeCheckRule.EVENT_DATA_PORT, TypeCheckRule.PARAMETER,
+				TypeCheckRule.DATA_COMPONENT_REFERENCE_FIRST_NAME }),
+
+		// Always include at the end of an array:
+		// because data subcomponent and data access are very high level feature types.
+		TARGET_COMPONENT_REFERENCE_FIRST_NAME(
+				DATA_COMPONENT_REFERENCE_FIRST_NAME._literal + STRING_TYPE_SEPARATOR + "out parameter"
+						+ STRING_TYPE_SEPARATOR + "outgoing port (prototype)",
+				new Enum[] { TypeCheckRule.DATA_COMPONENT_REFERENCE_FIRST_NAME, TypeCheckRule.OUT_PARAMETER,
+						TypeCheckRule.OUT_PORT, TypeCheckRule.OUT_PORT_PROTOTYPE }),
+
+		SHARED_DATA_ACTION("shared data action", new Enum[] { FeatureType.REQUIRES_DATA_ACCESS }),
+
+		PORT_DEQUEUE_ACTION("port dequeue action", new Enum[] { TypeCheckRule.IN_PORT }),
+
+		PORT_FREEZE_ACTION("port freeze action", new Enum[] { TypeCheckRule.IN_PORT }),
+
+		SUBPROGRAM_CALL_ACTION_FIRST_NAME("subprogram call action",
+				new Enum[] { FeatureType.SUBPROGRAM_SUBCOMPONENT, FeatureType.SUBPROGRAM_PROTOTYPE,
+						FeatureType.SUBPROGRAM_CLASSIFIER, FeatureType.REQUIRES_SUBPROGRAM_ACCESS,
+						FeatureType.REQUIRES_DATA_ACCESS, FeatureType.DATA_SUBCOMPONENT,
+						BehaviorFeatureType.BEHAVIOR_VARIABLE, TypeCheckRule.OUT_PORT }),
+
+		SUBPROGRAM_CALL_ACTION_SD_NAME("subprogram call action", new Enum[] { FeatureType.PROVIDES_SUBPROGRAM_ACCESS }),
+
+		DATA_UCCR("data unique component classifier reference", new Enum[] { FeatureType.DATA_CLASSIFIER }),
+
+		SUBPROGRAM_UCCR("subprogram unique component classifier reference",
+				new Enum[] { FeatureType.SUBPROGRAM_CLASSIFIER }),
+
+		GROUPS("group (prototype)", new Enum[] { FeatureType.FEATURE_GROUP,
+				FeatureType.REQUIRES_SUBPROGRAM_GROUP_ACCESS, FeatureType.PROVIDES_SUBPROGRAM_GROUP_ACCESS,
+				FeatureType.THREAD_GROUP, FeatureType.SUBPROGRAM_GROUP, FeatureType.THREAD_GROUP_PROTOTYPE,
+				FeatureType.SUBPROGRAM_GROUP_PROTOTYPE, FeatureType.FEATURE_GROUP_PROTOTYPE,
+				FeatureType.FEATURE_GROUP_PROTOTYPE_BINDING, FeatureType.REQUIRES_SUBPROGRAM_GROUP_ACCESS_PROTOTYPE,
+				FeatureType.PROVIDES_SUBPROGRAM_GROUP_ACCESS_PROTOTYPE }),
+
+		TARGET_STOP_RULE("target stop rule", new Enum[] { TypeCheckRule.OUT_PORT, TypeCheckRule.OUT_PORT_PROTOTYPE }),
+
+		VV_STOP_RULE("value variable stop rule", new Enum[] { TypeCheckRule.IN_PORT, TypeCheckRule.IN_PORT_PROTOTYPE }),
+
+		PROCESSOR_RULE("processor unique component classifier reference",
+				new Enum[] { FeatureType.PROCESSOR_CLASSIFIER }),
+
+		ASSIGNMENT_TARGET("assignment left hand side", new Enum[] { TypeCheckRule.TARGET_STOP_RULE });
+
+		String _literal;
+		Enum<?>[] _acceptableTypes;
+
+		TypeCheckRule(String literal, Enum<?>[] acceptableTypes) {
+			_literal = literal;
+			_acceptableTypes = acceptableTypes;
+		}
+
+		/**
+		 * Returns the expected feature type names separated by the given type
+		 * separator string.
+		 * <BR><BR>
+		 * Note : this method is not recursive.
+		 *
+		 * @param typeSeparator the given type separator string
+		 * @return the the expected feature type names separated by the given type
+		 * separator string.
+		 */
+		public String getExpectedTypes(String typeSeparator) {
+			Enum<?>[] ea = this._acceptableTypes;
+
+			String[] sa = new String[ea.length];
+			int i = 0;
+
+			for (Enum<?> e : ea) {
+				sa[i] = ((Enumerator) e).getLiteral();
+				i++;
+			}
+
+			return Aadl2Utils.concatenateString(typeSeparator, sa);
+		}
+
+		/**
+		 * Returns the rule's matching FeatureType or BehaviorAnnexFeatureType
+		 * enumeration of the given DeclarativeBehaviorElement object. If there is
+		 * no matching, it returns {@code null}. This test is recursive.
+		 *
+		 * @param dbe the given DeclarativeBehaviorElement object
+		 * @param baParentContainer behavior parent component
+		 * @return the rule's matching feature type or {@code null}
+		 */
+		public Enum<?> test(DeclarativeBehaviorElement dbe, ComponentClassifier baParentContainer) {
+			Enum<?> testedEnum = AadlBaModelResolver.getType(dbe);
+
+			// Resolves feature prototype binding in order to compare the rule
+			// to the resolved feature prototype.
+			if (testedEnum.equals(FeatureType.FEATURE_PROTOTYPE_BINDING)) {
+				FeaturePrototypeBinding fpb = (FeaturePrototypeBinding) AadlBaModelResolver.getBindedElement(dbe);
+				testedEnum = AadlBaUtils.getFeatPrototypeType(fpb);
+			}
+
+			// Resolves component prototype binding in order to compare the rule
+			// to the resolved component prototype.
+			if (testedEnum.equals(FeatureType.COMPONENT_PROTOTYPE_BINDING)) {
+				ComponentPrototypeBinding cpb = (ComponentPrototypeBinding) AadlBaModelResolver.getBindedElement(dbe);
+				testedEnum = AadlBaUtils.getCompPrototypeType(cpb);
+			}
+
+			return testTypeCheckRule(testedEnum);
+		}
+
+		public Enum<?> testTypeCheckRule(Enum<?> other) {
+			return testTypeCheckRule(this, other);
+		}
+
+		private static Enum<?> testTypeCheckRule(TypeCheckRule tcr, Enum<?> other) {
+			for (Enum<?> e : tcr._acceptableTypes) {
+				if (e instanceof TypeCheckRule) {
+					Enum<?> result = testTypeCheckRule((TypeCheckRule) e, other);
+
+					if (result != null) {
+						return result;
+					} else {
+						continue;
+					}
+				} else {
+					if (e.equals(other)) {
+						return other;
+					} else {
+						continue;
+					}
+				}
+			}
+
+			return null;
+		}
+
+		@Override
+		public String getLiteral() {
+			return _literal;
+		}
+
+		@Override
+		public String getName() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int getValue() {
+			throw new UnsupportedOperationException();
+		}
+	}
+}

--- a/ba/org.osate.ba/src/org/osate/ba/analyzers/AadlBaNameResolver.java
+++ b/ba/org.osate.ba/src/org/osate/ba/analyzers/AadlBaNameResolver.java
@@ -163,11 +163,24 @@ public class AadlBaNameResolver {
 	* @param ba the given behavior annex
 	* @param errManager the given error reporter manager
 	*/
+	@Deprecated
 	public AadlBaNameResolver(BehaviorAnnex ba, AnalysisErrorReporterManager errManager) {
+		this(ba, AadlBaVisitors.getParentComponent(ba), errManager);
+	}
+
+	/**
+	 * Constructs an AADL behavior annex name resolver with explicit component context.
+	 *
+	 * @param ba the given behavior annex
+	 * @param parentContainer the component which owns the behavior annex
+	 * @param errManager the given error reporter manager
+	 */
+	public AadlBaNameResolver(BehaviorAnnex ba, ComponentClassifier parentContainer,
+			AnalysisErrorReporterManager errManager) {
 		_ba = ba;
 		_errManager = errManager;
-		_baParentContainer = AadlBaVisitors.getParentComponent(ba);
-		_contextsTab = AadlBaVisitors.getBaPackageSections(_ba);
+		_baParentContainer = AadlBaVisitors.getParentComponent(ba, parentContainer);
+		_contextsTab = AadlBaVisitors.getBaPackageSections(_ba, _baParentContainer);
 	}
 
 	private boolean assignmentActionResolver(AssignmentAction act) {
@@ -1003,7 +1016,7 @@ public class AadlBaNameResolver {
 
 			// If the current id is found, fetch the container for the next id.
 			if (currentIdResult && it.hasNext()) {
-				Element el = AadlBaTypeChecker.getBindedElement(id);
+				Element el = AadlBaModelResolver.getBindedElement(id);
 
 				// AadlBaUtils.getClassifier is not useful as BehaviorVariables have
 				// not been type checked already.
@@ -1168,7 +1181,7 @@ public class AadlBaNameResolver {
 	// Checks behavior time's time unit according to property set Time_Units and
 	// binds if checking is successful.
 	private boolean timeUnitResolver(Identifier unitIdentifier) {
-		PackageSection context = Aadl2Visitors.getContainingPackageSection(_ba);
+		PackageSection context = _contextsTab[0];
 
 		NamedElement pt = Aadl2Visitors.findElementInPropertySet(TIME_UNITS_PROPERTY_ID, TIME_UNITS_PROPERTY_SET,
 				context);
@@ -1204,7 +1217,7 @@ public class AadlBaNameResolver {
 
 		// Now check the type in each current package's sections.
 		for (PackageSection context : _contextsTab) {
-			NamedElement parent = (NamedElement) _ba.eContainer().eContainer();
+			NamedElement parent = _baParentContainer;
 			ne = Aadl2Visitors.findSubcomponentInComponent((Classifier) parent, qne.getBaName().getId());
 			if (ne == null) {
 				ne = Aadl2Visitors.findFeatureInComponent((Classifier) parent, qne.getBaName().getId());
@@ -2067,7 +2080,7 @@ public class AadlBaNameResolver {
 			packageName = qne.getBaNamespace().getId();
 		}
 		NamedElement propNE = Aadl2Visitors.findElementInPropertySet(qne.getBaName().getId(), packageName,
-				Aadl2Visitors.getContainingPackageSection(_ba));
+				_contextsTab[0]);
 		return (Property) propNE;
 	}
 

--- a/ba/org.osate.ba/src/org/osate/ba/analyzers/AadlBaRulesCheckersDriver.java
+++ b/ba/org.osate.ba/src/org/osate/ba/analyzers/AadlBaRulesCheckersDriver.java
@@ -29,6 +29,7 @@ import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.osate.aadl2.AnnexSubclause;
+import org.osate.aadl2.ComponentClassifier;
 import org.osate.aadl2.Element;
 import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
 import org.osate.ba.aadlba.AadlBaPackage;
@@ -49,7 +50,6 @@ import org.osate.ba.aadlba.LoopStatement;
 import org.osate.ba.aadlba.Otherwise;
 import org.osate.ba.aadlba.TimedAction;
 import org.osate.ba.aadlba.util.AadlBaSwitch;
-import org.osate.ba.declarative.DeclarativeBehaviorTransition;
 import org.osate.ba.declarative.Identifier;
 
 public class AadlBaRulesCheckersDriver {
@@ -69,13 +69,19 @@ public class AadlBaRulesCheckersDriver {
 	private AadlBaSemanticRulesChecker _semantic;
 	private AadlBaConsistencyRulesChecker _consistency;
 	private AnalysisErrorReporterManager _errManager;
-	private DeclarativeBehaviorTransition _currentBt;
+	private BehaviorTransition _currentBt;
 
+	@Deprecated
 	public AadlBaRulesCheckersDriver(BehaviorAnnex ba, AnalysisErrorReporterManager errManager) {
+		this(ba, org.osate.ba.utils.AadlBaVisitors.getParentComponent(ba), errManager);
+	}
+
+	public AadlBaRulesCheckersDriver(BehaviorAnnex ba, ComponentClassifier parentContainer,
+			AnalysisErrorReporterManager errManager) {
 		_ba = ba;
-		_legality = new AadlBaLegalityRulesChecker(ba, errManager);
+		_legality = new AadlBaLegalityRulesChecker(ba, parentContainer, errManager);
 		_semantic = new AadlBaSemanticRulesChecker(errManager);
-		_consistency = new AadlBaConsistencyRulesChecker(ba, errManager);
+		_consistency = new AadlBaConsistencyRulesChecker(ba, parentContainer, errManager);
 		_errManager = errManager;
 		this.initSwitches();
 	}
@@ -177,10 +183,9 @@ public class AadlBaRulesCheckersDriver {
 
 				for (BehaviorState s : ba.getStates()) {
 					for (BehaviorTransition bt : ba.getTransitions()) {
-						DeclarativeBehaviorTransition tmp = (DeclarativeBehaviorTransition) bt;
-						for (Identifier src : tmp.getSrcStates()) {
+						for (Identifier src : BehaviorTransitionContext.getSourceIdentifiers(bt)) {
 							if (s.getName().equalsIgnoreCase(src.getId())) {
-								btTmp.add(tmp);
+								btTmp.add(bt);
 							}
 						}
 					}
@@ -212,11 +217,11 @@ public class AadlBaRulesCheckersDriver {
 			}
 
 			public Boolean caseBehaviorTransition(BehaviorTransition tmp) {
-				_currentBt = (DeclarativeBehaviorTransition) tmp;
+				_currentBt = tmp;
 
 				boolean result = true;
 
-				List<Identifier> sourceStateList = _currentBt.getSrcStates();
+				List<Identifier> sourceStateList = BehaviorTransitionContext.getSourceIdentifiers(_currentBt);
 
 				// Check source identifiers.
 

--- a/ba/org.osate.ba/src/org/osate/ba/analyzers/AadlBaSemanticRulesChecker.java
+++ b/ba/org.osate.ba/src/org/osate/ba/analyzers/AadlBaSemanticRulesChecker.java
@@ -29,7 +29,6 @@ import org.osate.ba.aadlba.BehaviorElement;
 import org.osate.ba.aadlba.BehaviorState;
 import org.osate.ba.aadlba.BehaviorTransition;
 import org.osate.ba.aadlba.DispatchTriggerConditionStop;
-import org.osate.ba.declarative.DeclarativeBehaviorTransition;
 import org.osate.ba.declarative.Identifier;
 
 public class AadlBaSemanticRulesChecker {
@@ -47,14 +46,11 @@ public class AadlBaSemanticRulesChecker {
 	* Object : Check semantic rule D.3.(18) 
 	* Keys : execute condition state pure initial
 	*/
-	public boolean D_3_18_Checker(DeclarativeBehaviorTransition bt) {
-		BehaviorState bs;
+	public boolean D_3_18_Checker(BehaviorTransition bt) {
 		boolean result = true;
 
-		List<Identifier> sourceStateList = bt.getSrcStates();
-
-		for (Identifier srcState : sourceStateList) {
-			bs = (BehaviorState) srcState.getBaRef();
+		for (Identifier srcState : BehaviorTransitionContext.getSourceIdentifiers(bt)) {
+			BehaviorState bs = (BehaviorState) srcState.getBaRef();
 
 			// Error case : only transition out of execution states or pure
 			// initial state may have execute condition.
@@ -89,18 +85,15 @@ public class AadlBaSemanticRulesChecker {
 	* Object : Check semantic rule D.4.(6)
 	* Keys : stop dispatch initiation finalization complete final execute states
 	*/
-	public boolean D_4_6_Check(DispatchTriggerConditionStop stopStatement, DeclarativeBehaviorTransition btOwner,
+	public boolean D_4_6_Check(DispatchTriggerConditionStop stopStatement, BehaviorTransition btOwner,
 			EList<BehaviorTransition> allTransitions) {
 		boolean result = true;
 
-		List<Identifier> sourceStateList = btOwner.getSrcStates();
+		List<BehaviorState> sourceStateList = BehaviorTransitionContext.getSourceStates(btOwner);
 
 		// Check the source states : they must be complete states.
-		BehaviorState tmpState;
-		for (Identifier srcState : sourceStateList) {
-			tmpState = (BehaviorState) srcState.getBaRef();
-
-			if (!tmpState.isComplete()) {
+		for (BehaviorState sourceState : sourceStateList) {
+			if (!sourceState.isComplete()) {
 				this.reportSemanticError(stopStatement,
 						"The stop dispatch trigger " + "statement must be declared in an outgoing transition of a "
 								+ "complete state: Behavior Annex D.4.(6) semantic rule failed");
@@ -111,7 +104,7 @@ public class AadlBaSemanticRulesChecker {
 
 		// Create a transitions array because the array will be modified.
 		// See transitionEndToFinalStateDriver.
-		DeclarativeBehaviorTransition[] transArray = new DeclarativeBehaviorTransition[allTransitions.size()];
+		BehaviorTransition[] transArray = new BehaviorTransition[allTransitions.size()];
 
 		allTransitions.toArray(transArray);
 
@@ -128,9 +121,13 @@ public class AadlBaSemanticRulesChecker {
 		return result;
 	}
 
-	private boolean transitionEndToFinalStateDriver(DeclarativeBehaviorTransition btOwner, int btOwnerIndex,
-			DeclarativeBehaviorTransition[] transArray) {
-		String destState = btOwner.getDestState().getId();
+	private boolean transitionEndToFinalStateDriver(BehaviorTransition btOwner, int btOwnerIndex,
+			BehaviorTransition[] transArray) {
+		BehaviorState destination = BehaviorTransitionContext.getDestinationState(btOwner);
+		if (destination == null) {
+			return false;
+		}
+		String destState = destination.getName();
 
 		// As more than one transition can have the owner's destination state
 		// as a source state, it must
@@ -139,16 +136,14 @@ public class AadlBaSemanticRulesChecker {
 		// possibly via one or more execution states.
 		transArray[btOwnerIndex] = null;
 
-		DeclarativeBehaviorTransition bt;
+		BehaviorTransition bt;
 
 		for (int i = 0; i < transArray.length; i++) {
 			bt = transArray[i];
 
 			if (bt != null) {
-				List<Identifier> sourceStateList = bt.getSrcStates();
-
-				for (Identifier srcState : sourceStateList) {
-					if (srcState.getId().equalsIgnoreCase(destState)) {
+				for (BehaviorState sourceState : BehaviorTransitionContext.getSourceStates(bt)) {
+					if (sourceState.getName().equalsIgnoreCase(destState)) {
 
 						if (transitionEndToFinalStateCheck(bt, i, transArray)) {
 							return true;
@@ -166,10 +161,12 @@ public class AadlBaSemanticRulesChecker {
 
 	// Check the destination states : the transition must end to a final state
 	// possibly via one or more execution states.
-	private boolean transitionEndToFinalStateCheck(DeclarativeBehaviorTransition bt, int btIndex,
-			DeclarativeBehaviorTransition[] transArray) {
-		BehaviorState tmpState;
-		tmpState = (BehaviorState) bt.getDestState().getBaRef();
+	private boolean transitionEndToFinalStateCheck(BehaviorTransition bt, int btIndex,
+			BehaviorTransition[] transArray) {
+		BehaviorState tmpState = BehaviorTransitionContext.getDestinationState(bt);
+		if (tmpState == null) {
+			return false;
+		}
 
 		// Error cases : destination state is not execute or final.
 		if (!tmpState.isFinal() && (tmpState.isComplete() || tmpState.isInitial())) {

--- a/ba/org.osate.ba/src/org/osate/ba/analyzers/AadlBaTypeChecker.java
+++ b/ba/org.osate.ba/src/org/osate/ba/analyzers/AadlBaTypeChecker.java
@@ -21,2959 +21,430 @@
 
 package org.osate.ba.analyzers;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.ListIterator;
-
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.Enumerator;
-import org.eclipse.emf.ecore.InternalEObject;
-import org.osate.aadl2.Aadl2Factory;
-import org.osate.aadl2.ArrayDimension;
-import org.osate.aadl2.ArraySize;
-import org.osate.aadl2.BasicProperty;
-import org.osate.aadl2.CalledSubprogram;
-import org.osate.aadl2.Classifier;
-import org.osate.aadl2.ClassifierValue;
+import org.eclipse.emf.common.util.TreeIterator;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.osate.aadl2.ComponentClassifier;
-import org.osate.aadl2.ComponentPrototype;
-import org.osate.aadl2.ComponentPrototypeActual;
-import org.osate.aadl2.ComponentPrototypeBinding;
-import org.osate.aadl2.DataAccess;
 import org.osate.aadl2.DataClassifier;
-import org.osate.aadl2.DataPort;
-import org.osate.aadl2.DataSubcomponent;
-import org.osate.aadl2.DirectionType;
 import org.osate.aadl2.Element;
-import org.osate.aadl2.EnumerationLiteral;
-import org.osate.aadl2.EventDataPort;
-import org.osate.aadl2.EventPort;
-import org.osate.aadl2.Feature;
-import org.osate.aadl2.FeaturePrototypeBinding;
-import org.osate.aadl2.NamedElement;
-import org.osate.aadl2.NumberValue;
-import org.osate.aadl2.Parameter;
-import org.osate.aadl2.Port;
-import org.osate.aadl2.ProcessorClassifier;
 import org.osate.aadl2.Property;
-import org.osate.aadl2.PropertyAssociation;
-import org.osate.aadl2.PropertyConstant;
-import org.osate.aadl2.PropertyExpression;
-import org.osate.aadl2.PropertySet;
-import org.osate.aadl2.PropertyType;
-import org.osate.aadl2.Prototype;
-import org.osate.aadl2.PrototypeBinding;
-import org.osate.aadl2.Subprogram;
-import org.osate.aadl2.SubprogramAccess;
-import org.osate.aadl2.SubprogramImplementation;
-import org.osate.aadl2.SubprogramPrototype;
-import org.osate.aadl2.SubprogramSubcomponent;
-import org.osate.aadl2.SubprogramType;
-import org.osate.aadl2.UnitLiteral;
 import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
-import org.osate.aadl2.parsesupport.LocationReference;
-import org.osate.ba.aadlba.*;
-import org.osate.ba.declarative.ArrayableIdentifier;
-import org.osate.ba.declarative.CommAction;
-import org.osate.ba.declarative.DeclarativeArrayDimension;
-import org.osate.ba.declarative.DeclarativeBehaviorElement;
-import org.osate.ba.declarative.DeclarativePropertyName;
-import org.osate.ba.declarative.DeclarativePropertyReference;
-import org.osate.ba.declarative.DeclarativeTime;
-import org.osate.ba.declarative.Identifier;
-import org.osate.ba.declarative.NamedValue;
-import org.osate.ba.declarative.QualifiedNamedElement;
-import org.osate.ba.declarative.Reference;
+import org.osate.ba.aadlba.Any;
+import org.osate.ba.aadlba.AssignmentAction;
+import org.osate.ba.aadlba.BasicAction;
+import org.osate.ba.aadlba.BehaviorAction;
+import org.osate.ba.aadlba.BehaviorActionBlock;
+import org.osate.ba.aadlba.BehaviorActionCollection;
+import org.osate.ba.aadlba.BehaviorActions;
+import org.osate.ba.aadlba.BehaviorAnnex;
+import org.osate.ba.aadlba.BehaviorCondition;
+import org.osate.ba.aadlba.BehaviorElement;
+import org.osate.ba.aadlba.BehaviorTransition;
+import org.osate.ba.aadlba.BehaviorVariable;
+import org.osate.ba.aadlba.CondStatement;
+import org.osate.ba.aadlba.DataRepresentation;
+import org.osate.ba.aadlba.ElementHolder;
+import org.osate.ba.aadlba.ElementValues;
+import org.osate.ba.aadlba.ElseStatement;
+import org.osate.ba.aadlba.ExecuteCondition;
+import org.osate.ba.aadlba.Factor;
+import org.osate.ba.aadlba.ForOrForAllStatement;
+import org.osate.ba.aadlba.IfStatement;
+import org.osate.ba.aadlba.IntegerRange;
+import org.osate.ba.aadlba.IterativeVariable;
+import org.osate.ba.aadlba.PortDequeueAction;
+import org.osate.ba.aadlba.PortSendAction;
+import org.osate.ba.aadlba.Relation;
+import org.osate.ba.aadlba.SimpleExpression;
+import org.osate.ba.aadlba.Term;
+import org.osate.ba.aadlba.ValueExpression;
+import org.osate.ba.aadlba.WhileOrDoUntilStatement;
 import org.osate.ba.texteditor.AadlBaHyperlink;
-import org.osate.ba.texteditor.DefaultAadlBaHyperlink;
-import org.osate.ba.unparser.AadlBaUnparser;
 import org.osate.ba.utils.AadlBaUtils;
 import org.osate.ba.utils.AadlBaVisitors;
 import org.osate.ba.utils.DimensionException;
-import org.osate.utils.internal.Aadl2Utils;
 
 /**
- * AADL Behavior annex feature's type and data representation checker.
- *
- * Data type checking is delegated to the given DataTypeChecker implementation
- * (Dependency Injection).
- *
+ * Checks an already resolved strict Behavior Annex model. Name binding, ambiguity resolution, holder construction, and
+ * containment replacement are performed before this checker runs; this class never mutates the supplied model.
  */
 public class AadlBaTypeChecker {
-
-	private BehaviorAnnex _ba;
-
-	private ComponentClassifier _baParentContainer;
-
-	private AnalysisErrorReporterManager _errManager;
-
-	private static final String STRING_TYPE_SEPARATOR = " or ";
-
-	private static final String STRING_PARAMETER_SEPARATOR = ", ";
-
-	private final DataTypeChecker _dataChecker;
-
-	private final static AadlBaFactory _fact = AadlBaFactory.eINSTANCE;
-
-	private AadlBaHyperlink _hl = new DefaultAadlBaHyperlink();
+	private final BehaviorAnnex ba;
+	private final ComponentClassifier baParentContainer;
+	private final DataTypeChecker dataChecker;
+	private final AnalysisErrorReporterManager errManager;
 
 	/**
-	 * Constructs an AADL behavior annex type checker.
-	 * Reports any errors with the given error reporter manager.
-	 *
-	 * @param ba the given behavior annex
-	 * @param dataChecker the given data type checker implementation
-	 * @param errManager the given error reporter manager
+	 * @deprecated use {@link #AadlBaTypeChecker(BehaviorAnnex, ComponentClassifier, DataTypeChecker,
+	 *             AnalysisErrorReporterManager)} when the behavior annex may be detached
 	 */
+	@Deprecated
 	public AadlBaTypeChecker(BehaviorAnnex ba, DataTypeChecker dataChecker, AnalysisErrorReporterManager errManager) {
-		_ba = ba;
-		_baParentContainer = AadlBaVisitors.getParentComponent(ba);
-		_dataChecker = dataChecker;
-		_errManager = errManager;
-	}
-
-	public void setAadlBaHyperlink(AadlBaHyperlink hl) {
-		_hl = hl;
+		this(ba, AadlBaVisitors.getParentComponent(ba), dataChecker, errManager);
 	}
 
 	/**
-	 * Checks the type of the objects referenced during the name resolution phase.
-	 * Reports any error.
+	 * Constructs a type checker for an already resolved strict Behavior Annex model.
 	 *
-	 * @return {@code true} if all the objects have the excepted types.
-	 * {@code false} otherwise.
+	 * @param ba the behavior annex
+	 * @param parentContainer the component which owns the behavior annex
+	 * @param dataChecker the data type checker
+	 * @param errManager the error reporter manager
+	 */
+	public AadlBaTypeChecker(BehaviorAnnex ba, ComponentClassifier parentContainer, DataTypeChecker dataChecker,
+			AnalysisErrorReporterManager errManager) {
+		this.ba = ba;
+		this.baParentContainer = AadlBaVisitors.getParentComponent(ba, parentContainer);
+		this.dataChecker = dataChecker;
+		this.errManager = errManager;
+	}
+
+	/**
+	 * Retained for source compatibility. Hyperlinks are created while the strict model is resolved, before type
+	 * checking.
+	 *
+	 * @param hyperlink the hyperlink builder
+	 */
+	public void setAadlBaHyperlink(AadlBaHyperlink hyperlink) {
+		// Resolution owns hyperlink creation. A read-only checker has nothing to record.
+	}
+
+	/**
+	 * Checks the type consistency of the resolved strict model without changing it.
+	 *
+	 * @return {@code true} when all checked types are consistent
 	 */
 	public boolean checkTypes() {
-		return behaviorVariableCheck() & behaviorTransitionCheck();
+		boolean result = checkResolvedModel();
+		for (BehaviorVariable variable : ba.getVariables()) {
+			result &= checkBehaviorVariable(variable);
+		}
+		for (BehaviorTransition transition : ba.getTransitions()) {
+			result &= checkBehaviorTransition(transition);
+		}
+		return result;
 	}
 
-	/**
-	 * Document: AADL Behavior Annex draft
-	 * Version : 0.94
-	 * Type : Semantic rule
-	 * Section : D.3 Behavior Specification
-	 * Object : Check semantic rule D.3.(28)
-	 * Keys : local variables explicitly typed valid data component classifier
-	 */
-	private boolean behaviorVariableCheck() {
+	private boolean checkResolvedModel() {
 		boolean result = true;
-		IntegerValueConstant ivc = null;
-		QualifiedNamedElement uccr;
-
-		for (BehaviorVariable bv : _ba.getVariables()) {
-			uccr = (QualifiedNamedElement) bv.getDataClassifier();
-
-			DataClassifier dc = (DataClassifier) uniqueNamedElementReferenceResolver(uccr, TypeCheckRule.DATA_UCCR);
-
-			_hl.addToHyperlinking(uccr.getAadlBaLocationReference(), dc);
-
-			result &= dc != null;
-			bv.setDataClassifier(dc);
-
-			for (PropertyAssociation pa : bv.getOwnedPropertyAssociations()) {
-				Property p = (Property) uniqueNamedElementReferenceResolver((QualifiedNamedElement) pa.getProperty(),
-						TypeCheckRule.PROPERTY);
-				pa.setProperty(p);
-			}
-
-			ListIterator<ArrayDimension> it = bv.getArrayDimensions().listIterator();
-
-			while (it.hasNext()) {
-				ArrayDimension tmp = it.next();
-				DeclarativeArrayDimension dad = (DeclarativeArrayDimension) tmp;
-
-				ivc = dad.getDimension();
-				ivc = integerValueConstantCheck(ivc);
-				result &= ivc != null;
-
-				// The returned value may be different from the tested value
-				// because of semantic ambiguity resolution in
-				// integervalueConstantCheck method. So replace if needed.
-				if (ivc != null) {
-					it.set(integerValueConstantToArrayDimension(ivc));
-				}
+		for (TreeIterator<EObject> contents = EcoreUtil.getAllContents(ba, true); contents.hasNext();) {
+			EObject object = contents.next();
+			if (object instanceof ElementHolder && ((ElementHolder) object).getElement() == null) {
+				reportError((Element) object, "resolved behavior annex holder has no element");
+				result = false;
 			}
 		}
-
 		return result;
 	}
 
-	private String unparseQualifiedNamedElement(QualifiedNamedElement qne) {
-		StringBuilder sb = new StringBuilder();
-		if (qne.getBaNamespace() != null) {
-			sb.append(qne.getBaNamespace().getId());
-			sb.append("::");
+	private boolean checkBehaviorVariable(BehaviorVariable variable) {
+		boolean result = variable.getDataClassifier() instanceof DataClassifier;
+		if (!result) {
+			reportError(variable, "behavior variable data classifier is not resolved");
 		}
-
-		sb.append(qne.getBaName().getId());
-
-		return sb.toString();
-	}
-
-	private Element uniqueNamedElementReferenceResolver(QualifiedNamedElement qne, TypeCheckRule rule) {
-		String unparsed = unparseQualifiedNamedElement(qne);
-
-		boolean succeed = typeCheck(qne, unparsed, rule, true) != null;
-
-		if (succeed) {
-			return qne.getOsateRef();
-		} else {
-			return null;
-		}
-	}
-
-	private ArrayDimension integerValueConstantToArrayDimension(IntegerValueConstant ivc) {
-		ArrayDimension result = Aadl2Factory.eINSTANCE.createArrayDimension();
-		ArraySize size = result.createSize();
-		result.setSize(size);
-		result.setLocationReference(ivc.getLocationReference());
-		size.setLocationReference(ivc.getLocationReference());
-
-		if (ivc instanceof BehaviorIntegerLiteral) {
-			size.setSize(((BehaviorIntegerLiteral) ivc).getValue());
-		} else if (ivc instanceof BehaviorPropertyConstant) {
-			PropertyExpression pe = null;
-			PropertyConstant pc = ((BehaviorPropertyConstant) ivc).getProperty();
-			pe = pc.getConstantValue();
-
-			if (pe instanceof NumberValue) {
-				double value = ((NumberValue) pe).getScaledValue();
-				size.setSize((long) value);
-			} else {
-				String msg = "cannot evaluate the property constant";
-				_errManager.warning(ivc, msg);
+		for (org.osate.aadl2.PropertyAssociation association : variable.getOwnedPropertyAssociations()) {
+			if (!(association.getProperty() instanceof Property)) {
+				reportError(variable, "behavior variable property association is not resolved");
+				result = false;
 			}
-		} else if (ivc instanceof PropertyReference) {
-			PropertyReference pr = (PropertyReference) ivc;
-			PropertyNameHolder last = pr.getProperties().get(pr.getProperties().size() - 1);
-			Element el = last.getProperty().getElement();
-
-			if (el instanceof NumberValue) {
-				double value = ((NumberValue) el).getScaledValue();
-				size.setSize((long) value);
-			} else {
-				String msg = "cannot evaluate the property value";
-				_errManager.warning(ivc, msg);
-			}
-		} else {
-			String errorMsg = "integerValueConstantToArrayDimension : " + ivc.getClass().getSimpleName()
-					+ " is not supported yet.";
-			System.err.println(errorMsg);
-			throw new UnsupportedOperationException(errorMsg);
 		}
-
 		return result;
 	}
 
-	// This method checks the given object and returns an object resolved from
-	// semantic ambiguities. On error, reports error and returns null.
-	private IntegerValueConstant integerValueConstantCheck(IntegerValueConstant ivc) {
-		ValueAndTypeHolder holder = valueConstantCheck(ivc);
-
-		if (typeCheck(ivc, null, holder, DataRepresentation.INTEGER)) {
-			return (IntegerValueConstant) holder.value;
-		} else {
-			return null;
-		}
-	}
-
-	// This method checks the given object and returns an object resolved from
-	// semantic ambiguities. On error, reports error and returns null.
-	private IntegerValue integerValueCheck(IntegerValue iv) {
-		// Ambiguity between property constant and name without array index
-		// has already been resolved in the name resolution phase.
-
-		if (iv instanceof IntegerValueConstant) {
-			return integerValueConstantCheck((IntegerValueConstant) iv);
-		} else {
-			return integerValueVariableCheck((IntegerValueVariable) iv);
-		}
-	}
-
-	// This method checks the given object and returns an object resolved from
-	// semantic ambiguities. On error, reports error and returns null.
-	private IntegerValueVariable integerValueVariableCheck(IntegerValueVariable ivv) {
-		ValueAndTypeHolder holder = valueVariableCheck(ivv);
-
-		if (typeCheck(ivv, null, holder, DataRepresentation.INTEGER)) {
-			return (IntegerValueVariable) holder.value;
-		} else {
-			return null;
-		}
-	}
-
-	private boolean behaviorTransitionCheck() {
+	private boolean checkBehaviorTransition(BehaviorTransition transition) {
 		boolean result = true;
-
-		for (BehaviorTransition trans : _ba.getTransitions()) {
-			BehaviorCondition cond = trans.getCondition();
-
-			if (cond instanceof DispatchCondition) {
-				result &= dispatchConditionCheck((DispatchCondition) cond);
-			} else if (cond instanceof ModeSwitchTriggerLogicalExpression) {
-				result &= modeSwitchTriggerLogicalExpressionCheck((ModeSwitchTriggerLogicalExpression) cond);
-			} else {
-				result &= executeConditionCheck((ExecuteCondition) cond);
-			}
-
-			if (trans.getActionBlock() != null) {
-				result &= behaviorActionBlockCheck(trans.getActionBlock());
-			}
+		BehaviorCondition condition = transition.getCondition();
+		if (condition instanceof ExecuteCondition) {
+			result &= checkExecuteCondition((ExecuteCondition) condition);
 		}
-
+		if (transition.getActionBlock() != null) {
+			result &= checkBehaviorActionBlock(transition.getActionBlock());
+		}
 		return result;
 	}
 
-	private boolean modeSwitchTriggerLogicalExpressionCheck(ModeSwitchTriggerLogicalExpression dtle) {
+	private boolean checkExecuteCondition(ExecuteCondition condition) {
+		if (condition instanceof ValueExpression) {
+			TypeHolder type = checkValueExpression((ValueExpression) condition);
+			return checkRepresentation((BehaviorElement) condition, "the execute condition", type,
+					DataRepresentation.BOOLEAN);
+		}
+		return true;
+	}
+
+	private boolean checkBehaviorActionBlock(BehaviorActionBlock block) {
+		return checkBehaviorActions(block.getContent());
+	}
+
+	private boolean checkBehaviorActions(BehaviorActions actions) {
+		if (actions == null) {
+			return true;
+		} else if (actions instanceof BehaviorAction) {
+			return checkBehaviorAction((BehaviorAction) actions);
+		}
+
 		boolean result = true;
-
-		ElementHolder elHolder = null;
-
-		for (ModeSwitchConjunction msc : dtle.getModeSwitchConjunctions()) {
-			ListIterator<ModeSwitchTrigger> it = msc.getModeSwitchTriggers().listIterator();
-
-			while (it.hasNext()) {
-				Reference e = (Reference) it.next();
-
-				elHolder = dispatchTriggerResolver(e, TypeCheckRule.MODE_SWITCH_TRIGGER);
-
-				if (elHolder != null) {
-					it.set((ModeSwitchTrigger) elHolder);
-				} else {
-					result = false;
-				}
-			}
+		for (BehaviorAction action : ((BehaviorActionCollection) actions).getActions()) {
+			result &= checkBehaviorAction(action);
 		}
-
 		return result;
 	}
 
-	/**
-	 * Document: AADL Behavior Annex draft
-	 * Version : 0.94
-	 * Type : Naming rule
-	 * Section : D.4 Thread Dispatch Behavior Specification
-	 * Object : Check naming rules D.4.(N1), D.4.(N2)
-	 * Keys : frozen port, subprogram access feature, dispatch trigger condition
-	 */
-	private boolean dispatchConditionCheck(DispatchCondition cond) {
-		boolean result = false;
-
-		DispatchTriggerCondition dtc = cond.getDispatchTriggerCondition();
-
-		if (dtc != null) {
-			DispatchTriggerCondition tmp = dispatchTriggerConditionCheck(dtc);
-			result = tmp != null;
-
-			// The returned DispatchTriggerCondition may be different from the
-			// tested one because of semantic ambiguity resolution in
-			// dispatchTriggerConditionCheck method. So replace if needed.
-			if (tmp != dtc && result) {
-				cond.setDispatchTriggerCondition(tmp);
-			}
-		} else {
-			result = true;
+	private boolean checkBehaviorAction(BehaviorAction action) {
+		if (action instanceof BehaviorActionBlock) {
+			return checkBehaviorActionBlock((BehaviorActionBlock) action);
+		} else if (action instanceof BasicAction) {
+			return checkBasicAction((BasicAction) action);
+		} else if (action instanceof CondStatement) {
+			return checkConditionalStatement((CondStatement) action);
 		}
+		return true;
+	}
 
-		if (cond.isSetFrozenPorts()) {
-			PortHolder portHolder = null;
-
-			ListIterator<ActualPortHolder> it = cond.getFrozenPorts().listIterator();
-
-			while (it.hasNext()) {
-				Reference ref = (Reference) it.next();
-
-				portHolder = frozenPortCheck(ref);
-
-				if (portHolder != null) {
-					it.set((ActualPortHolder) portHolder);
-				} else {
-					result = false;
-				}
-			}
+	private boolean checkBasicAction(BasicAction action) {
+		if (action instanceof AssignmentAction) {
+			return checkAssignment((AssignmentAction) action);
+		} else if (action instanceof PortSendAction) {
+			return checkPortSend((PortSendAction) action);
+		} else if (action instanceof PortDequeueAction) {
+			return checkPortDequeue((PortDequeueAction) action);
 		}
-
-		return result;
+		return true;
 	}
 
-	private PortHolder frozenPortCheck(Reference ref) {
-		PortHolder result = null;
-
-		TypeCheckRule stopOnThisRule = TypeCheckRule.FROZEN_PORT;
-		TypeCheckRule checkRules = stopOnThisRule;
-
-		List<ElementHolder> resolvedRef = refResolver(ref, null, stopOnThisRule, checkRules);
-
-		if (resolvedRef != null) {
-			result = (PortHolder) resolvedRef.get(0);
-		}
-
-		return result;
-	}
-
-	private void reportError(BehaviorElement el, String msg) {
-		_errManager.error(el, msg);
-	}
-
-	private void reportTypeError(BehaviorElement el, String name, String expectedTypes, String typeFound) {
-		String message = "type error for \'" + name + "\', \'" + expectedTypes + "\' expected, found \'" + typeFound
-				+ "\'.";
-
-		reportError(el, message);
-	}
-
-	private String unparseNameElement(BehaviorElement e) {
-		if (e instanceof Reference) {
-			return unparseReference((Reference) e);
-		} else {
-			AadlBaUnparser unparser = new AadlBaUnparser();
-			unparser.process(e);
-			return unparser.getOutput();
-		}
-	}
-
-	private String unparseReference(Reference ref) {
-		return ref.getIds().get(ref.getIds().size() - 1).getId();
-	}
-
-	// This method checks the given object and returns an object resolved from
-	// semantic ambiguities. On error, reports error and returns null.
-	private DispatchTriggerCondition dispatchTriggerConditionCheck(DispatchTriggerCondition dtc) {
-		if (dtc instanceof DispatchTriggerLogicalExpression) {
-			DispatchTriggerLogicalExpression dtle = (DispatchTriggerLogicalExpression) dtc;
-
-			// dispatch trigger logical expression.
-			// Resolves ambiguity between a single dispatch trigger and subprogram
-			// access.
-			if (dtle.getDispatchConjunctions().size() == 1) {
-				DispatchConjunction dc = dtle.getDispatchConjunctions().get(0);
-
-				List<DispatchTrigger> dispatchTriggers = dc.getDispatchTriggers();
-
-				if (dispatchTriggers.size() == 1) {
-					Reference ref = (Reference) dispatchTriggers.get(0);
-
-					ElementHolder el = dispatchTriggerResolver(ref, TypeCheckRule.DISPATCH_TRIGGER_CONDITION);
-					if (el != null) {
-						if (el instanceof DispatchTrigger) {
-							dispatchTriggers.set(0, (DispatchTrigger) el);
-							return dtc;
-						} else // Subprogram access case.
-						{
-							return (DispatchTriggerCondition) el;
-						}
-					} else {
-						return null;
-					}
-				} else {
-					return dispatchTriggerLogicalExpressionCheck(dtle) ? dtc : null;
-				}
-			} else {
-				return dispatchTriggerLogicalExpressionCheck(dtle) ? dtc : null;
-			}
-		} else {
-			// CompletionRelativeTimeout case.
-			if (dtc instanceof CompletionRelativeTimeout) {
-				CompletionRelativeTimeout tmp = _fact.createCompletionRelativeTimeout();
-
-				if (behaviorTimeCheck((DeclarativeTime) dtc, tmp)) {
-					return tmp;
-				} else {
-					return null;
-				}
-			} else // Cases of DispatchTriggerConditionStop and TimeoutCatch:
-					// There isn't any type to check.
-			{
-				return dtc;
-			}
-		}
-	}
-
-	private ElementHolder dispatchTriggerResolver(Reference ref, TypeCheckRule rule) {
-		TypeCheckRule stopOnThisRule = rule;
-		TypeCheckRule checkRules = stopOnThisRule;
-		List<ElementHolder> resolvedRef = refResolver(ref, null, stopOnThisRule, checkRules);
-		if (resolvedRef != null) {
-			return resolvedRef.get(0);
-		} else {
-			return null;
-		}
-	}
-
-	private boolean behaviorTimeCheck(DeclarativeTime dbt, BehaviorTime result) {
-		IntegerValue tmp = integerValueCheck(dbt.getIntegerValue());
-
-		// The returned value may be different from the tested value
-		// because of semantic ambiguity resolution in integerValueCheck
-		// method. So replace if needed.
-		if (tmp != null) {
-			result.setIntegerValue(tmp);
-			Identifier unitId = dbt.getUnitId();
-			result.setUnit((UnitLiteral) unitId.getOsateRef());
-			result.setLocationReference(dbt.getLocationReference());
-		}
-
-		return tmp != null;
-	}
-
-	private boolean dispatchTriggerLogicalExpressionCheck(DispatchTriggerLogicalExpression dtle) {
-		boolean result = true;
-
-		ElementHolder elHolder = null;
-
-		for (DispatchConjunction dc : dtle.getDispatchConjunctions()) {
-			ListIterator<DispatchTrigger> it = dc.getDispatchTriggers().listIterator();
-
-			while (it.hasNext()) {
-				Reference e = (Reference) it.next();
-
-				elHolder = dispatchTriggerResolver(e, TypeCheckRule.DISPATCH_TRIGGER);
-
-				if (elHolder != null) {
-					it.set((DispatchTrigger) elHolder);
-				} else {
-					result = false;
-				}
-			}
-		}
-
-		return result;
-	}
-
-	private boolean executeConditionCheck(ExecuteCondition cond) {
-		if (cond instanceof ValueExpression) {
-			ValueAndTypeHolder holder = valueExpressionCheck((ValueExpression) cond);
-
-			// Execute condition is only defined for logical value expression.
-			return typeCheck(cond, "the execute condition", holder, DataRepresentation.BOOLEAN);
-		} else // Timeout catch and Otherwise cases : no type to check.
-		{
+	private boolean checkAssignment(AssignmentAction action) {
+		if (action.getValueExpression() instanceof Any) {
 			return true;
 		}
+
+		TypeHolder targetType = getType(action.getTarget());
+		TypeHolder expressionType = checkValueExpression(action.getValueExpression());
+		if (targetType == null || expressionType == null) {
+			return false;
+		}
+		if (!dataChecker.conformsTo(targetType, expressionType, true)) {
+			reportTypeError(action.getValueExpression(), "assignment", targetType.toString(), expressionType.toString());
+			return false;
+		}
+		return true;
 	}
 
-	// This method checks the given object and returns a value expression
-	// resolved from semantic ambiguities and its data representation. On error,
-	// reports error and returns null.
-	/**
-	 * Document: AADL Behavior Annex draft
-	 * Version : 0.94
-	 * Type : Legality rule
-	 * Section : D.7 Behavior Expression Language
-	 * Object : Check legality rules D.7.(L3), partially D.7.(L6)
-	 * Keys : operand logical operators boolean
-	 */
-	private ValueAndTypeHolder valueExpressionCheck(ValueExpression ve) {
-		EList<Relation> rl = ve.getRelations();
-
-		TypeHolder[] typea = new TypeHolder[rl.size()];
-		EList<LogicalOperator> opl = ve.getLogicalOperators();
-		boolean isTopLevelTypePossible = true;
-
-		// Checks all relations.
-		for (int i = 0; i < rl.size(); i++) {
-			typea[i] = relationCheck(rl.get(i));
-
-			// Current checking has failed but continues because all relations have
-			// to be checked.
-			if (typea[i] == null) {
-				isTopLevelTypePossible = false;
-			}
+	private boolean checkPortSend(PortSendAction action) {
+		if (action.getPort() == null || action.getValueExpression() == null) {
+			return true;
 		}
-
-		// If the relation checking are successful, checks operators definition
-		// and evaluates top level value variable type representation.
-		if (isTopLevelTypePossible) {
-			if (rl.size() > 1) {
-				for (int i = 1; i < rl.size(); i++) {
-					typea[i] = _dataChecker.checkDefinition(ve, opl.get(i - 1), typea[i - 1], typea[i]);
-					// Error case : the current operator is not defined.
-					if (typea[i] == null) {
-						return null;
-					}
-				}
-
-				return new ValueAndTypeHolder(ve, typea[typea.length - 1]);
-			} else // As there isn't any operator set, top level type is the unique
-					// relation's one.
-			{
-				return new ValueAndTypeHolder(ve, typea[0]);
-			}
-		} else // Relation checking has failed.
-		{
-			return null;
+		TypeHolder portType = getType(action.getPort());
+		TypeHolder valueType = checkValueExpression(action.getValueExpression());
+		if (portType == null || valueType == null) {
+			return false;
 		}
+		if (!dataChecker.conformsTo(portType, valueType, true)) {
+			reportTypeError(action, "port send action", portType.toString(), valueType.toString());
+			return false;
+		}
+		return true;
 	}
 
-	// Returns the top-level relation data representation or null on error.
-	// Reports any error.
-	/**
-	 * Document: AADL Behavior Annex draft
-	 * Version : 0.94
-	 * Type : Legality rule
-	 * Section : D.7 Behavior Expression Language
-	 * Object : Check legality rule D.7.(L4)
-	 * Keys : operand relational operators supports comparison
-	 */
-	private TypeHolder relationCheck(Relation r) {
-		TypeHolder th1 = simpleExpressionCheck(r.getFirstExpression());
-		TypeHolder th2 = null;
-
-		if (r.isSetRelationalOperator()) {
-			th2 = simpleExpressionCheck(r.getSecondExpression());
-		} else {
-			return th1;
+	private boolean checkPortDequeue(PortDequeueAction action) {
+		if (action.getTarget() == null) {
+			return true;
 		}
-
-		if (th1 != null && th2 != null) {
-			return _dataChecker.checkDefinition(r, r.getRelationalOperator(), th1, th2);
-		} else {
-			return null;
+		TypeHolder portType = getType(action.getPort());
+		TypeHolder targetType = getType(action.getTarget());
+		if (portType == null || targetType == null) {
+			return false;
 		}
+		if (!dataChecker.conformsTo(portType, targetType, true)) {
+			reportTypeError(action, "port dequeue action", portType.toString(), targetType.toString());
+			return false;
+		}
+		return true;
 	}
 
-	// Returns the top-level simple expression type representation or null on
-	// error. Reports any error.
-	/**
-	 * Document: AADL Behavior Annex draft
-	 * Version : 0.94
-	 * Type : Legality rule
-	 * Section : D.7 Behavior Expression Language
-	 * Object : Check legality rule D.7.(L5)
-	 * Keys : adding other numeric operators support numeric operations
-	 */
-	private TypeHolder simpleExpressionCheck(SimpleExpression se) {
-		EList<Term> tl = se.getTerms();
-		TypeHolder[] typea = new TypeHolder[tl.size()];
-		EList<BinaryAddingOperator> opl = se.getBinaryAddingOperators();
-		boolean isTopLevelTypePossible = true;
-
-		// Checks all terms.
-		for (int i = 0; i < tl.size(); i++) {
-			typea[i] = termCheck(tl.get(i));
-
-			// Current checking has failed but continues because all terms have to
-			// be checked.
-			if (typea[i] == null) {
-				isTopLevelTypePossible = false;
+	private boolean checkConditionalStatement(CondStatement statement) {
+		if (statement instanceof IfStatement) {
+			IfStatement ifStatement = (IfStatement) statement;
+			boolean result = checkBooleanExpression(ifStatement.getLogicalValueExpression());
+			result &= checkBehaviorActions(ifStatement.getBehaviorActions());
+			ElseStatement elseStatement = ifStatement.getElseStatement();
+			if (elseStatement != null) {
+				result &= elseStatement instanceof IfStatement ? checkConditionalStatement((IfStatement) elseStatement)
+						: checkBehaviorActions(elseStatement.getBehaviorActions());
 			}
-		}
-
-		// If the term checking are successful, checks operators definition and
-		// evaluates top level simple expression type representation.
-		if (isTopLevelTypePossible) {
-			if (se.isSetUnaryAddingOperator()) {
-				typea[0] = _dataChecker.checkDefinition(se, se.getUnaryAddingOperator(), typea[0]);
-				// Error case : the unary adding operator is not defined.
-				if (typea[0] == null) {
-					return null;
-				}
-			}
-
-			if (tl.size() > 1) {
-				for (int i = 1; i < tl.size(); i++) {
-					typea[i] = _dataChecker.checkDefinition(se, opl.get(i - 1), typea[i - 1], typea[i]);
-
-					// Error case : the current operator is not defined.
-					if (typea[i] == null) {
-						return null;
-					}
-				}
-
-				return typea[typea.length - 1];
-			} else // As there isn't any operator set, top level type is the unique
-					// term's one.
-			{
-				return typea[0];
-			}
-		} else // Term checking has failed.
-		{
-			return null;
-		}
-	}
-
-	// Returns the top-level term type representation or null on error.
-	// Reports any error.
-	/**
-	 * Document: AADL Behavior Annex draft
-	 * Version : 0.94
-	 * Type : Legality rule
-	 * Section : D.7 Behavior Expression Language
-	 * Object : Check legality rule D.7.(L5)
-	 * Keys : multiplying other numeric operators support numeric operations
-	 */
-	private TypeHolder termCheck(Term t) {
-		EList<Factor> fl = t.getFactors();
-		TypeHolder[] typea = new TypeHolder[fl.size()];
-		EList<MultiplyingOperator> opl = t.getMultiplyingOperators();
-		boolean isTopLevelTypePossible = true;
-
-		// Checks all the factors.
-		for (int i = 0; i < fl.size(); i++) {
-			typea[i] = factorCheck(fl.get(i));
-
-			// Current checking has failed but continues because all factors have to
-			// be checked.
-			if (typea[i] == null) {
-				isTopLevelTypePossible = false;
-			}
-		}
-
-		// If the factor checking are successful, checks operators definition
-		// and evaluates top level term type representation.
-		if (isTopLevelTypePossible) {
-			if (fl.size() > 1) {
-				for (int i = 1; i < fl.size(); i++) {
-					typea[i] = _dataChecker.checkDefinition(t, opl.get(i - 1), typea[i - 1], typea[i]);
-					// Error case : the current operator is not defined.
-					if (typea[i] == null) {
-						return null;
-					}
-				}
-
-				return typea[typea.length - 1];
-			} else // As there isn't any operator set, top level type is the unique
-					// factor's one.
-			{
-				return typea[0];
-			}
-		} else {
-			return null;
-		}
-	}
-
-	// Returns the top-level factor type representation or null on error.
-	// Reports any error.
-	/**
-	 * Document: AADL Behavior Annex draft
-	 * Version : 0.94
-	 * Type : Legality rule
-	 * Section : D.7 Behavior Expression Language
-	 * Object : Check legality rule D.7.(L5)
-	 * Keys : other numeric operators support numeric operations
-	 */
-	private TypeHolder factorCheck(Factor f) {
-		Value fValue = f.getFirstValue();
-		Value sdValue = f.getSecondValue();
-		ValueAndTypeHolder vth1 = valueCheck(fValue);
-		ValueAndTypeHolder vth2 = null;
-
-		if (sdValue != null) {
-			// Checks second value even if the first value checking has failed.
-			vth2 = valueCheck(sdValue);
-		}
-
-		if (vth1 != null) // Don't check operator definition on value checking error.
-		{
-			// The returned value may be different from the tested value
-			// because of semantic ambiguity resolution in valueCheck
-			// method. So replace if needed.
-			f.setFirstValue(vth1.value);
-			fValue = vth1.value;
-
-			// Checks Unary operators.
-			if (f.isSetUnaryNumericOperator() || f.isSetUnaryBooleanOperator()) {
-				Enumerator op;
-
-				op = ((f.isSetUnaryBooleanOperator()) ? f.getUnaryBooleanOperator() : f.getUnaryNumericOperator());
-
-				return _dataChecker.checkDefinition(f, op, vth1.typeHolder);
-			} else {
-				if (f.isSetBinaryNumericOperator()) {
-					if (vth2 != null) {
-						// The returned value may be different from the tested value
-						// because of semantic ambiguity resolution in valueCheck
-						// method. So replace if needed.
-						f.setSecondValue(vth2.value);
-						sdValue = vth2.value;
-
-						return _dataChecker.checkDefinition(f, f.getBinaryNumericOperator(), vth1.typeHolder,
-								vth2.typeHolder);
-					} else // Second value error case.
-					{
-						return null;
-					}
-				} else // As there isn's any operator, the top level type is the unique
-						// value' one.
-				{
-					return vth1.typeHolder;
-				}
-			}
-		} else // First value error case.
-		{
-			return null;
-		}
-	}
-
-	// This method checks the given object and returns a value
-	// resolved from semantic ambiguities and its data representation. On error,
-	// reports error and returns null.
-	private ValueAndTypeHolder valueCheck(Value v) {
-		if (v instanceof ValueConstant) {
-			return valueConstantCheck((ValueConstant) v);
-		} else {
-			if (v instanceof ValueVariable) {
-				return valueVariableCheck((ValueVariable) v);
-			} else // Value expression case.
-			{
-				return valueExpressionCheck((ValueExpression) v);
-			}
-		}
-	}
-
-	// This method checks the given object and returns a value variable
-	// resolved from semantic ambiguities and its data representation. On error,
-	// reports error and returns null.
-	private ValueAndTypeHolder valueVariableCheck(ValueVariable v) {
-		List<ElementHolder> ehl = null;
-		ValueVariable tmpResult = null;
-		ActualPortHolder port;
-		TypeCheckRule stopRule;
-		TypeCheckRule[] checkRules;
-
-		if (v instanceof Reference) {
-			port = null;
-			stopRule = TypeCheckRule.VV_STOP_RULE;
-
-			checkRules = new TypeCheckRule[] { TypeCheckRule.VV_COMPONENT_REFERENCE_FIRST_NAME,
-					TypeCheckRule.DATA_COMPONENT_REFERENCE_OTHER_NAMES };
-		} else // NamedValue case.
-		{
-			NamedValue nv = (NamedValue) v;
-			v = nv.getReference();
-
-			if (nv.isCount()) {
-				port = _fact.createPortCountValue();
-				stopRule = TypeCheckRule.PORT_COUNT_VALUE;
-			} else if (nv.isDequeue()) {
-				port = _fact.createPortDequeueValue();
-				stopRule = TypeCheckRule.PORT_DEQUEUE_VALUE;
-			} else {
-				port = _fact.createPortFreshValue();
-				stopRule = TypeCheckRule.PORT_FRESH_VALUE;
-			}
-
-			port.setLocationReference(v.getLocationReference());
-			checkRules = new TypeCheckRule[] { stopRule };
-		}
-
-		ehl = refResolver((Reference) v, port, stopRule, checkRules);
-		if (ehl != null) {
-			tmpResult = referenceToValueVariable(ehl);
-
-			if (tmpResult instanceof PortFreshValue) {
-				PortFreshValue pfv = (PortFreshValue) tmpResult;
-				AadlBaVisitors.putFreshPort(_ba, pfv.getPort());
-			}
-
-			return this.getValueAndTypeHolder(tmpResult, v);
-		} else {
-			return null;
-		}
-	}
-
-	// Null proof.
-	@SuppressWarnings("all")
-	private ValueVariable referenceToValueVariable(List<ElementHolder> resolvedRef) {
-		ValueVariable result = null;
-
-		if (resolvedRef != null) {
-			if (resolvedRef.size() > 1) {
-				DataComponentReference dcr = _fact.createDataComponentReference();
-				dcr.setLocationReference(resolvedRef.get(0).getLocationReference());
-				dcr.getData().addAll((Collection<? extends DataHolder>) resolvedRef);
-				result = dcr;
-			} else {
-				result = (ValueVariable) resolvedRef.get(0);
-			}
-		}
-
-		return result;
-	}
-
-	private ValueAndTypeHolder getValueAndTypeHolder(Value v, Element errorRef) {
-		try {
-			return new ValueAndTypeHolder(v, AadlBaUtils.getTypeHolder(v, _baParentContainer));
-		} catch (DimensionException e) {
-			e.setElement(errorRef);
-			reportDimensionException(e);
-			return null;
-		}
-	}
-
-	// Checks group rules by default.
-	// Special attention is provided for Value or Target that are not
-	// data component references (ex: PortHolder): if stopOnThisRule is found
-	// and extra information exists (ex: port.port which syntactically correct but
-	// semantically wrong), it will report extraneous information error.
-	// If given port is not null, elementHolderResolver will try to set it
-	// (optimize reinstanciation when using design pattern decoration, for
-	// PortActions and PortValues).
-	// Also, IterativeVariable and BehaviorVariable instances can't have any
-	// group information. It will report extraneous information error if
-	// groups are provided.
-	// This method can't detect if there is not enought information (currently
-	// just for required_data_access_name.provided_subprogram_access_name case).
-	private List<ElementHolder> refResolver(Reference ref, ActualPortHolder port, TypeCheckRule stopOnThisRule,
-			TypeCheckRule... checkRules) {
-		List<ElementHolder> result = new ArrayList<ElementHolder>(ref.getIds().size());
-		Enum<?> currentResult = null;
-
-		ElementHolder currentElementholder = null;
-		int currentIndexRule = 0;
-		TypeCheckRule currentRule = checkRules[currentIndexRule];
-		TypeCheckRule lastRule = checkRules[checkRules.length - 1];
-		boolean hasToContinue = true;
-
-		ArrayList<GroupHolder> grpl = new ArrayList<GroupHolder>(ref.getIds().size());
-
-		ListIterator<ArrayableIdentifier> it = ref.getIds().listIterator();
-
-		while (it.hasNext()) {
-			ArrayableIdentifier id = it.next();
-
-			currentResult = typeCheck(id, id.getId(), TypeCheckRule.GROUPS, false);
-
-			// The current id represents a group, so store it in the groups stack.
-			if (currentResult != null) {
-				currentElementholder = elementHolderResolver(id, currentResult, port);
-				grpl.add((GroupHolder) currentElementholder);
-			} else // Checks given rules: if ref.getIds().size > rules.length then
-					// use the last given rule for the extra ids.
-			{
-				currentResult = typeCheck(id, id.getId(), currentRule, true);
-
-				if (currentResult != null) {
-					currentElementholder = elementHolderResolver(id, currentResult, port);
-					result.add(currentElementholder);
-
-					if (currentElementholder instanceof GroupableElement) {
-						if (false == grpl.isEmpty()) {
-							GroupableElement ge = (GroupableElement) currentElementholder;
-
-							// Flush GroupHolder List.
-							if (false == grpl.isEmpty()) {
-								ge.getGroupHolders().addAll(grpl);
-								grpl.clear();
-							}
-						}
-					} else if (false == grpl.isEmpty()) {
-						// Reports error of a not GroupableHolder that have group information.
-						String msg = id.getId() + " can't have group information.";
-						reportError(id, msg);
-						return null;
-					}
-
-					// Tests if a type that stop the checking is found.
-					hasToContinue = stopOnThisRule.testTypeCheckRule(currentResult) == null;
-					if (it.hasNext()) {
-						currentIndexRule++;
-
-						// Extra information (it passes the name resolved),
-						// has been given whereas the stop type is reached.
-						// So report error.
-						if (hasToContinue == false) {
-							// To much information.
-							String msg = id.getId() + " can't have any more tokens.";
-							reportError(id, msg);
-							return null;
-						} else // Stop type is not reached or is null that means there is
-								// not id number limit.
-						{
-							// If the number of ids is greater than the number of given
-							// rules: use the last rule for the extra ids. Only for data
-							// component reference.
-							currentRule = (currentIndexRule < checkRules.length) ? checkRules[currentIndexRule]
-									: lastRule;
-						}
-					}
-				} else {
-					// Error reporting has already been done.
-					return null;
-				}
-			}
-
-			// Checks array indexes.
-			if (id.isSetArrayIndexes()) {
-				if (currentElementholder instanceof IndexableElement) {
-					IndexableElement currentIndexableElement = (IndexableElement) currentElementholder;
-
-					boolean isConsistent = true;
-
-					List<IntegerValue> resolvedValues = new ArrayList<IntegerValue>(id.getArrayIndexes().size());
-
-					for (IntegerValue iv : id.getArrayIndexes()) {
-						// Reports any error.
-						IntegerValue resolvedValue = integerValueCheck(iv);
-						if (resolvedValue != null) {
-							resolvedValues.add(resolvedValue);
-						} else {
-							isConsistent = false;
-						}
-					}
-
-					// Avoid collection concurrency modification between id's integer values
-					// and currentIndexableElement's one.
-					if (isConsistent) {
-						currentIndexableElement.getArrayIndexes().addAll(resolvedValues);
-					}
-				} else {
-					// Not an arrayable element.
-					String msg = currentElementholder.getElement().getName() + " can't have array index.";
-					reportError(currentElementholder, msg);
-					return null;
-				}
-			}
-		} // End of for.
-		if (result.isEmpty()) {
-			String expectedTypes = currentRule.getExpectedTypes(STRING_TYPE_SEPARATOR);
-			String errMsg = "Wrong type in " + stopOnThisRule.getLiteral() + "; expected types are: " + expectedTypes;
-			this.reportError(ref, errMsg);
-			return null;
-		}
-		return result;
-	}
-
-	// It doesn't perform any check.
-	// It just builds an element holder according to the given type.
-	// If port is not null, it will set the given port.
-	private ElementHolder elementHolderResolver(ArrayableIdentifier id, Enum<?> type, ActualPortHolder port) {
-		ElementHolder result = null;
-
-		if (type instanceof FeatureType) {
-			FeatureType t = (FeatureType) type;
-
-			switch (t) {
-			case IN_DATA_PORT:
-			case OUT_DATA_PORT:
-			case IN_OUT_DATA_PORT: {
-				if (port == null) {
-					DataPortHolder tmp = _fact.createDataPortHolder();
-					tmp.setDataPort((DataPort) id.getOsateRef());
-					result = tmp;
-				} else {
-					port.setPort((Port) id.getOsateRef());
-					result = port;
-				}
-
-				break;
-			}
-
-			case IN_EVENT_DATA_PORT:
-			case OUT_EVENT_DATA_PORT:
-			case IN_OUT_EVENT_DATA_PORT: {
-				if (port == null) {
-					EventDataPortHolder tmp = _fact.createEventDataPortHolder();
-					tmp.setEventDataPort((EventDataPort) id.getOsateRef());
-					result = tmp;
-				} else {
-					port.setPort((Port) id.getOsateRef());
-					result = port;
-				}
-
-				break;
-			}
-
-			case IN_EVENT_PORT:
-			case OUT_EVENT_PORT:
-			case IN_OUT_EVENT_PORT: {
-				if (port == null) {
-					EventPortHolder tmp = _fact.createEventPortHolder();
-					tmp.setEventPort((EventPort) id.getOsateRef());
-					result = tmp;
-				} else {
-					port.setPort((Port) id.getOsateRef());
-					result = port;
-				}
-
-				break;
-			}
-
-			case REQUIRES_DATA_ACCESS:
-			case PROVIDES_DATA_ACCESS: {
-				DataAccessHolder tmp = _fact.createDataAccessHolder();
-				tmp.setDataAccess((DataAccess) id.getOsateRef());
-				result = tmp;
-				break;
-			}
-
-			case DATA_SUBCOMPONENT: {
-				DataSubcomponentHolder tmp = _fact.createDataSubcomponentHolder();
-				tmp.setDataSubcomponent((DataSubcomponent) id.getOsateRef());
-				result = tmp;
-				break;
-			}
-
-			case CLASSIFIER_VALUE: {
-				ClassifierValue cv = (ClassifierValue) id.getOsateRef();
-				DataClassifier dc = (DataClassifier) cv.getClassifier();
-
-				StructUnionElement sue = _fact.createStructUnionElement();
-				sue.setLocationReference(Aadl2Utils.getLocationReference(dc));
-				sue.setDataClassifier(dc);
-				sue.setName(id.getId());
-
-				StructUnionElementHolder sueHolder = _fact.createStructUnionElementHolder();
-				sueHolder.setStructUnionElement(sue);
-
-				// Set econtainer as ElementHolder::element is not containment.
-				InternalEObject parent = (InternalEObject) sueHolder;
-				InternalEObject child = (InternalEObject) sue;
-
-				child.eBasicSetContainer(parent, AadlBaPackage.STRUCT_UNION_ELEMENT_HOLDER__STRUCT_UNION_ELEMENT, null);
-				result = sueHolder;
-				break;
-			}
-
-			case IN_PARAMETER:
-			case OUT_PARAMETER:
-			case IN_OUT_PARAMETER: {
-				ParameterHolder tmp = _fact.createParameterHolder();
-				tmp.setParameter((Parameter) id.getOsateRef());
-				result = tmp;
-				break;
-			}
-
-			case SUBPROGRAM_CLASSIFIER:
-			case SUBPROGRAM_SUBCOMPONENT: {
-				SubprogramHolder tmp = _fact.createSubprogramHolder();
-				tmp.setSubprogram((Subprogram) id.getOsateRef());
-				result = tmp;
-				break;
-			}
-
-			case REQUIRES_SUBPROGRAM_ACCESS:
-			case PROVIDES_SUBPROGRAM_ACCESS: {
-				SubprogramAccessHolder tmp = _fact.createSubprogramAccessHolder();
-				tmp.setSubprogramAccess((SubprogramAccess) id.getOsateRef());
-				result = tmp;
-				break;
-			}
-
-			case FEATURE_GROUP:
-			case SUBPROGRAM_GROUP:
-			case THREAD_GROUP:
-			case REQUIRES_SUBPROGRAM_GROUP_ACCESS:
-			case PROVIDES_SUBPROGRAM_GROUP_ACCESS: {
-				GroupHolder tmp = _fact.createGroupHolder();
-				tmp.setGroup((NamedElement) id.getOsateRef());
-				result = tmp;
-				break;
-			}
-
-			case SUBPROGRAM_PROTOTYPE: {
-				Element el = id.getOsateRef();
-				SubprogramPrototypeHolder tmp = _fact.createSubprogramPrototypeHolder();
-				if (el instanceof PrototypeBinding) {
-					PrototypeBinding pb = (PrototypeBinding) el;
-					tmp.setPrototype(pb.getFormal());
-					tmp.setPrototypeBinding(pb);
-				} else {
-					Prototype p = (Prototype) el;
-					tmp.setPrototype(p);
-				}
-
-				result = tmp;
-				break;
-			}
-
-			case IN_DATA_PORT_PROTOTYPE:
-			case OUT_DATA_PORT_PROTOTYPE:
-			case IN_OUT_DATA_PORT_PROTOTYPE:
-			case IN_EVENT_DATA_PORT_PROTOTYPE:
-			case OUT_EVENT_DATA_PORT_PROTOTYPE:
-			case IN_OUT_EVENT_DATA_PORT_PROTOTYPE:
-			case IN_EVENT_PORT_PROTOTYPE:
-			case OUT_EVENT_PORT_PROTOTYPE:
-			case IN_OUT_EVENT_PORT_PROTOTYPE: {
-				Element el = id.getOsateRef();
-				PortPrototypeHolder tmp = _fact.createPortPrototypeHolder();
-				if (el instanceof PrototypeBinding) {
-					PrototypeBinding pb = (PrototypeBinding) el;
-					tmp.setPrototype(pb.getFormal());
-					tmp.setPrototypeBinding(pb);
-				} else {
-					Prototype p = (Prototype) el;
-					tmp.setPrototype(p);
-				}
-
-				result = tmp;
-				break;
-			}
-
-			case REQUIRES_DATA_ACCESS_PROTOTYPE:
-			case PROVIDES_DATA_ACCESS_PROTOTYPE: {
-				Element el = id.getOsateRef();
-				DataAccessPrototypeHolder tmp = _fact.createDataAccessPrototypeHolder();
-				if (el instanceof PrototypeBinding) {
-					PrototypeBinding pb = (PrototypeBinding) el;
-					tmp.setPrototype(pb.getFormal());
-					tmp.setPrototypeBinding(pb);
-				} else {
-					Prototype p = (Prototype) el;
-					tmp.setPrototype(p);
-				}
-
-				result = tmp;
-				break;
-			}
-
-			case FEATURE_GROUP_PROTOTYPE:
-			case FEATURE_GROUP_PROTOTYPE_BINDING:
-			case SUBPROGRAM_GROUP_PROTOTYPE:
-			case THREAD_GROUP_PROTOTYPE:
-			case REQUIRES_SUBPROGRAM_GROUP_ACCESS_PROTOTYPE:
-			case PROVIDES_SUBPROGRAM_GROUP_ACCESS_PROTOTYPE: {
-				Element el = id.getOsateRef();
-				GroupPrototypeHolder tmp = _fact.createGroupPrototypeHolder();
-				if (el instanceof PrototypeBinding) {
-					PrototypeBinding pb = (PrototypeBinding) el;
-					tmp.setPrototype(pb.getFormal());
-					tmp.setPrototypeBinding(pb);
-				} else {
-					Prototype p = (Prototype) el;
-					tmp.setPrototype(p);
-				}
-				result = tmp;
-				break;
-			}
-
-			case IN_FEATURE_PROTOTYPE:
-			case OUT_FEATURE_PROTOTYPE:
-			case IN_OUT_FEATURE_PROTOTYPE: {
-				Element el = id.getOsateRef();
-				FeaturePrototypeHolder tmp = _fact.createFeaturePrototypeHolder();
-				if (el instanceof PrototypeBinding) {
-					PrototypeBinding pb = (PrototypeBinding) el;
-					tmp.setPrototype(pb.getFormal());
-					tmp.setPrototypeBinding(pb);
-				} else {
-					Prototype p = (Prototype) el;
-					tmp.setPrototype(p);
-				}
-
-				result = tmp;
-				break;
-			}
-
-			default: {
-				String errorMsg = "type: " + type.toString() + " is not supported yet.";
-				System.err.println(errorMsg);
-				throw new UnsupportedOperationException(errorMsg);
-			}
-			}
-		} else {
-			BehaviorFeatureType t = (BehaviorFeatureType) type;
-
-			switch (t) {
-			case BEHAVIOR_VARIABLE: {
-				BehaviorVariableHolder tmp = _fact.createBehaviorVariableHolder();
-				tmp.setVariable((BehaviorVariable) id.getBaRef());
-				result = tmp;
-				break;
-			}
-
-			case ITERATIVE_VARIABLE: {
-				IterativeVariableHolder ivh = _fact.createIterativeVariableHolder();
-				ivh.setIterativeVariable((IterativeVariable) id.getBaRef());
-				result = ivh;
-				break;
-			}
-
-			default: {
-				String errorMsg = "type: " + type.toString() + " is not supported yet.";
-				System.err.println(errorMsg);
-				throw new UnsupportedOperationException(errorMsg);
-			}
-			}
-		}
-
-		result.setLocationReference(id.getLocationReference());
-
-		_hl.addToHyperlinking(id.getAadlBaLocationReference(), result);
-
-		return result;
-	}
-
-	private void reportDimensionException(DimensionException de) {
-		StringBuilder msg = new StringBuilder();
-
-		if (de.getElement() instanceof BehaviorElement) {
-			msg.append('"');
-			msg.append(this.unparseNameElement((BehaviorElement) de.getElement()));
-			msg.append("\" ");
-		}
-
-		msg.append(de.getMessage());
-
-		_errManager.error(de.getElement(), msg.toString());
-	}
-
-	// This method checks the given object and returns a value constant
-	// resolved from semantic ambiguities and its data representation. On error,
-	// reports error and returns null.
-	private ValueAndTypeHolder valueConstantCheck(ValueConstant v) {
-		ValueAndTypeHolder result = null;
-		ValueConstant tmpResult = null;
-
-		if (v instanceof DeclarativePropertyReference) {
-			tmpResult = propertyReferenceResolver((DeclarativePropertyReference) v);
-		} else // Literal cases. Nothing to do.
-		{
-			tmpResult = v;
-		}
-
-		if (tmpResult != null) {
-			result = getValueAndTypeHolder(tmpResult, v);
-		}
-
-		return result;
-	}
-
-	private ValueConstant propertyReferenceResolver(DeclarativePropertyReference ref) {
-		ValueConstant result = null;
-
-		if (ref.isPropertySet()) {
-			DeclarativePropertyName firstName = ref.getPropertyNames().get(0);
-
-			// Property constant from a property set.
-			if (firstName.getOsateRef() instanceof PropertyConstant) {
-				BehaviorPropertyConstant tmp = _fact.createBehaviorPropertyConstant();
-				tmp.setProperty((PropertyConstant) firstName.getOsateRef());
-				if (ref.getQualifiedName() != null) {
-					tmp.setPropertySet((PropertySet) ref.getQualifiedName().getOsateRef());
-				}
-				result = tmp;
-			} else // Property value case.
-			{
-				PropertySetPropertyReference tmp = _fact.createPropertySetPropertyReference();
-				propertyNameListResolver(ref.getPropertyNames(), tmp.getProperties());
-
-				if (ref.getQualifiedName() != null) {
-					tmp.setPropertySet((PropertySet) ref.getQualifiedName().getOsateRef());
-				}
-				result = tmp;
-			}
-		} else if (ref.getQualifiedName() != null) // [qualified] classifier case.
-		{
-			ClassifierPropertyReference tmp = _fact.createClassifierPropertyReference();
-			tmp.setClassifier((Classifier) ref.getQualifiedName().getOsateRef());
-			propertyNameListResolver(ref.getPropertyNames(), tmp.getProperties());
-			result = tmp;
-		} else // Classifier feature case.
-		{
-			ClassifierFeaturePropertyReference tmp = _fact.createClassifierFeaturePropertyReference();
-
-			classifierFeatureResolver(tmp, ref.getReference());
-			propertyNameListResolver(ref.getPropertyNames(), tmp.getProperties());
-			result = tmp;
-		}
-
-		result.setLocationReference(ref.getLocationReference());
-		return result;
-	}
-
-	private void propertyNameListResolver(EList<DeclarativePropertyName> dpns, EList<PropertyNameHolder> result) {
-		PropertyNameHolder pnh = null;
-		PropertyElementHolder peh = null;
-		EList<IntegerValue> indexes = null;
-		LocationReference loc = null;
-		Element global, primary;
-
-		for (DeclarativePropertyName dpn : dpns) {
-			pnh = _fact.createPropertyNameHolder();
-			pnh.setLocationReference(dpn.getLocationReference());
-
-			global = dpn.getOsateRef();
-			primary = dpn.getPropertyName().getOsateRef();
-
-			if (primary != global) // Item list case.
-			{
-				loc = dpn.getPropertyName().getLocationReference();
-				peh = propertyElementHolderResolver(primary, loc);
-			} else {
-				loc = dpn.getLocationReference();
-				peh = propertyElementHolderResolver(global, loc);
-
-			}
-
-			indexes = peh.getArrayIndexes();
-
-			if (dpn.getField() != null) {
-				pnh.setField(dpn.getField());
-			} else {
-				for (IntegerValue iv : dpn.getIndexes()) {
-					IntegerValue tmp = integerValueCheck(iv); // Report any error.
-					if (tmp != null) {
-						indexes.add(tmp);
-					}
-				}
-			}
-
-			pnh.setProperty(peh);
-			result.add(pnh);
-		}
-	}
-
-	private PropertyElementHolder propertyElementHolderResolver(Element el, LocationReference loc) {
-		PropertyElementHolder result = null;
-
-		if (el instanceof BasicProperty) {
-			BasicProperty bp = (BasicProperty) el;
-			BasicPropertyHolder tmp = _fact.createBasicPropertyHolder();
-			tmp.setBasicProperty(bp);
-			result = tmp;
-		} else if (el instanceof PropertyAssociation) {
-			PropertyAssociation pa = (PropertyAssociation) el;
-			PropertyAssociationHolder tmp = _fact.createPropertyAssociationHolder();
-			tmp.setPropertyAssociation(pa);
-			result = tmp;
-		} else if (el instanceof PropertyExpression) {
-			PropertyExpression pe = (PropertyExpression) el;
-			PropertyExpressionHolder tmp = _fact.createPropertyExpressionHolder();
-			tmp.setPropertyExpression(pe);
-			result = tmp;
-		} else if (el instanceof PropertyType) {
-			PropertyType pt = (PropertyType) el;
-			PropertyTypeHolder tmp = _fact.createPropertyTypeHolder();
-			tmp.setPropertyType(pt);
-			result = tmp;
-		} else if (el instanceof EnumerationLiteral) {
-			EnumerationLiteral enumLit = (EnumerationLiteral) el;
-			EnumLiteralHolder tmp = _fact.createEnumLiteralHolder();
-			tmp.setEnumLiteral(enumLit);
-			result = tmp;
-		} else {
-			String errorMsg = "type: " + el.getClass().getSimpleName() + " is not supported yet.";
-			System.err.println(errorMsg);
-			throw new UnsupportedOperationException(errorMsg);
-		}
-
-		result.setLocationReference(loc);
-		return result;
-	}
-
-	private void classifierFeatureResolver(ClassifierFeaturePropertyReference result, Reference ref) {
-		List<ElementHolder> holders = refResolver(ref, null, TypeCheckRule.NOTHING, TypeCheckRule.ALL);
-		result.setComponent((ClassifierFeatureHolder) holders.get(0));
-	}
-
-	private boolean behaviorActionBlockCheck(BehaviorActionBlock bab) {
-		boolean result = true;
-
-		if (bab.getTimeout() != null) {
-			BehaviorTime resolvedTime = _fact.createBehaviorTime();
-			result = behaviorTimeCheck((DeclarativeTime) bab.getTimeout(), resolvedTime);
-			bab.setTimeout(resolvedTime);
-		}
-
-		result &= behaviorActionsCheck(bab.getContent(), bab);
-
-		return result;
-	}
-
-	private boolean behaviorActionsCheck(BehaviorActions bActs, Object parentContainer) {
-		if (bActs instanceof BehaviorAction) {
-			return behaviorActionCheck((BehaviorAction) bActs, parentContainer);
-		} else // BehaviorCollection case.
-		{
-			boolean result = true;
-
-			ListIterator<BehaviorAction> it = ((BehaviorActionCollection) bActs).getActions().listIterator();
-			while (it.hasNext()) {
-				BehaviorAction bAct = it.next();
-				result &= behaviorActionCheck(bAct, it);
-			}
-
 			return result;
+		} else if (statement instanceof WhileOrDoUntilStatement) {
+			WhileOrDoUntilStatement loop = (WhileOrDoUntilStatement) statement;
+			return checkBooleanExpression(loop.getLogicalValueExpression())
+					& checkBehaviorActions(loop.getBehaviorActions());
+		} else if (statement instanceof ForOrForAllStatement) {
+			return checkForOrForAll((ForOrForAllStatement) statement);
 		}
+		return true;
 	}
 
-	private boolean behaviorActionCheck(BehaviorAction bAct, Object parentContainer) {
-		if (bAct instanceof BehaviorActionBlock) {
-			return behaviorActionBlockCheck((BehaviorActionBlock) bAct);
-		} else {
-			if (bAct instanceof BasicAction) {
-				return basicActionCheck((BasicAction) bAct, parentContainer);
-			} else // Conditional statements cases.
-			{
-				return condStatementCheck((CondStatement) bAct);
-			}
+	private boolean checkForOrForAll(ForOrForAllStatement statement) {
+		boolean result = statement.getIterativeVariable().getDataClassifier() instanceof DataClassifier;
+		if (!result) {
+			reportError(statement.getIterativeVariable(), "iterative variable data classifier is not resolved");
 		}
-	}
-
-	private boolean condStatementCheck(CondStatement stat) {
-		if (stat instanceof IfStatement) {
-			return ifStatementCheck((IfStatement) stat);
-		} else {
-			if (stat instanceof ForOrForAllStatement) {
-				return forOrForAllStatementCheck((ForOrForAllStatement) stat);
-			} else // While or do until statement cases.
-			{
-				return whileOrDoUntilStatementCheck((WhileOrDoUntilStatement) stat);
-			}
-		}
-	}
-
-	private boolean whileOrDoUntilStatementCheck(WhileOrDoUntilStatement stat) {
-		boolean result = behaviorActionsCheck(stat.getBehaviorActions(), stat);
-
-		ValueExpression ve = stat.getLogicalValueExpression();
-
-		ValueAndTypeHolder holder = valueExpressionCheck(ve);
-
-		result &= typeCheck(ve, null, holder, DataRepresentation.BOOLEAN);
-
+		result &= checkElementValues(statement.getIteratedValues(), statement.getIterativeVariable(), statement);
+		result &= checkBehaviorActions(statement.getBehaviorActions());
 		return result;
 	}
 
-	/**
-	 * Document: AADL Behavior Annex draft
-	 * Version : 0.94
-	 * Type : Legality rule
-	 * Section : D.6 Behavior Action Language
-	 * Object : Check legality rule D.6.(L2)
-	 * Keys : for forall iterative variable not valid assignment target
-	 *
-	*/
-	private boolean forOrForAllStatementCheck(ForOrForAllStatement stat) {
-		IterativeVariable itVar = stat.getIterativeVariable();
-		boolean result = iterativeVariableCheck(itVar);
-
-		result &= behaviorActionsCheck(stat.getBehaviorActions(), stat);
-
-		ElementValues tmp = elementValuesCheck(stat.getIteratedValues());
-		result &= tmp != null;
-
-		// The returned element values may be different from the tested one
-		// because of semantic ambiguity resolution in elementValuesCheck
-		// method. So replace if needed.
-		if (tmp != stat.getIteratedValues() && tmp != null) {
-			stat.setIteratedValues(tmp);
-		}
-
-		// Matches the element values data type and the uccr's one.
-		if (result) {
-			TypeHolder eleType;
-			TypeHolder uccrType;
-
-			if (tmp instanceof IntegerRange) {
-				IntegerRange ir = (IntegerRange) tmp;
-				TypeHolder t1, t2;
-				try {
-					t1 = AadlBaUtils.getTypeHolder(ir.getLowerIntegerValue(), _baParentContainer);
-					t2 = AadlBaUtils.getTypeHolder(ir.getUpperIntegerValue(), _baParentContainer);
-				} catch (DimensionException de) {
-					reportDimensionException(de);
-					return false;
-				}
-
-				eleType = _dataChecker.getTopLevelType(t1, t2);
-				// Integer Ranges are one dimension kind of integer collection.
-				// => pass the arrayness checking.
-				eleType.setDimension(1);
-			} else // Name or DataComponentReference cases.
-			{
-				try {
-					eleType = AadlBaUtils.getTypeHolder(tmp);
-				} catch (DimensionException de) {
-					reportDimensionException(de);
-					return false;
-				}
-
-				if (tmp instanceof EventDataPortHolder) {
-					// Event ports are one dimension events queue.
-					// => pass the arrayness checking.
-					eleType.setDimension(1);
-				}
-			}
-
-			try {
-				uccrType = AadlBaUtils.getTypeHolder(itVar);
-			} catch (DimensionException de) {
-				reportDimensionException(de);
+	private boolean checkElementValues(ElementValues values, IterativeVariable variable, ForOrForAllStatement statement) {
+		TypeHolder valuesType;
+		if (values instanceof IntegerRange) {
+			IntegerRange range = (IntegerRange) values;
+			TypeHolder lower = getType(range.getLowerIntegerValue());
+			TypeHolder upper = getType(range.getUpperIntegerValue());
+			if (lower == null || upper == null || !dataChecker.conformsTo(lower, upper, true)) {
+				reportError(range, "'integer range' error type : its integer values are not consistent");
 				return false;
 			}
-
-			// iterative variable's UCCR syntax cannot express array
-			// ([] are not allowed). Also, this implementation of AADL behavior
-			// annex, doesn't allow the use of iterative variable's types which are
-			// declared as array (data model annex).
-			if (uccrType.getDimension() > 0) {
-				StringBuilder message = new StringBuilder(
-						"the for/forall iterative variable's type cannot be an array.");
-
-				message.append(" Found \'");
-				message.append(uccrType.toString());
-				message.append("\'.");
-				reportError(tmp, message.toString());
-				result = false;
-			}
-
-			if (_dataChecker.conformsTo(eleType, uccrType, false)) {
-				result = true;
-			} else {
-				StringBuilder sb = new StringBuilder("\'iterative variable\' type error:");
-				sb.append(" an array of \"");
-				sb.append(uccrType.toString());
-				sb.append("\" expected, found \"");
-				sb.append(eleType.toString());
-				sb.append("\".");
-				reportError(stat, sb.toString());
-			}
-
-			// Checks data component reference arrayness and reports any error.
-			if (eleType.getDimension() == 0) {
-				String message = "\'" + unparseNameElement(tmp) + "\' is not an array";
-				reportError(tmp, message);
-				result = false;
-			}
-		}
-		return result;
-	}
-
-	private boolean iterativeVariableCheck(IterativeVariable itVar) {
-		QualifiedNamedElement qne = (QualifiedNamedElement) itVar.getDataClassifier();
-
-		// The statement's unique component reference reference has to be
-		// data classifier.
-		Classifier dataClassifier = (Classifier) uniqueNamedElementReferenceResolver(qne, TypeCheckRule.DATA_UCCR);
-
-		itVar.setDataClassifier((DataClassifier) dataClassifier);
-
-		return dataClassifier != null;
-	}
-
-	// This method checks the given object and returns a element values
-	// resolved from semantic ambiguities. On error, reports error and returns
-	// null.
-	private ElementValues elementValuesCheck(ElementValues ev) {
-		if (ev instanceof IntegerRange) {
-			if (integerRangeCheck((IntegerRange) ev)) {
-				return ev;
-			} else // Integer range error case.
-			{
-				return null;
-			}
+			valuesType = dataChecker.getTopLevelType(lower, upper);
+			valuesType.setDimension(1);
 		} else {
-			TypeCheckRule stopRule = TypeCheckRule.EVENT_DATA_PORT;
-			TypeCheckRule[] checkRules = new TypeCheckRule[] { TypeCheckRule.ELEMENT_VALUES,
-					TypeCheckRule.DATA_COMPONENT_REFERENCE_OTHER_NAMES };
-
-			List<ElementHolder> ehl = refResolver((Reference) ev, null, stopRule, checkRules);
-
-			// Can reuse this method as PortHolder and DataComponentVariable are also
-			// ElementValues.
-			return (ElementValues) referenceToValueVariable(ehl);
-		}
-	}
-
-	// Checks the given integer range and checks the consistency between
-	// the integer values.
-	private boolean integerRangeCheck(IntegerRange ir) {
-		boolean result = false;
-
-		IntegerValue original = ir.getLowerIntegerValue();
-		IntegerValue tmp = integerValueCheck(original);
-
-		result = tmp != null;
-
-		if (result && tmp != original) {
-			ir.setLowerIntegerValue(tmp);
-		}
-
-		original = ir.getUpperIntegerValue();
-		tmp = integerValueCheck(original);
-		result &= tmp != null;
-
-		if (tmp != null && tmp != original) {
-			ir.setUpperIntegerValue(tmp);
-		}
-
-		// Matches the two integer value data types.
-		if (result) {
-			TypeHolder t1, t2;
-
-			try {
-				t1 = AadlBaUtils.getTypeHolder(ir.getLowerIntegerValue(), _baParentContainer);
-				t2 = AadlBaUtils.getTypeHolder(ir.getUpperIntegerValue(), _baParentContainer);
-			} catch (DimensionException de) {
-				reportDimensionException(de);
+			valuesType = getType(values);
+			if (valuesType == null) {
 				return false;
 			}
-
-			if (!_dataChecker.conformsTo(t1, t2, true)) {
-				result = false;
-				reportError(ir, "\'integer range\' error type : its integer values" + " are not consistent");
+			if (values instanceof org.osate.ba.aadlba.EventDataPortHolder) {
+				valuesType.setDimension(1);
 			}
 		}
 
+		TypeHolder variableType = getType(variable);
+		boolean result = variableType != null && dataChecker.conformsTo(valuesType, variableType, false);
+		if (!result && variableType != null) {
+			reportError(statement, "'iterative variable' type error: an array of \"" + variableType
+					+ "\" expected, found \"" + valuesType + "\".");
+		}
+		if (valuesType.getDimension() == 0) {
+			reportError(values, "iterated values are not an array");
+			result = false;
+		}
 		return result;
 	}
 
-	private boolean ifStatementCheck(IfStatement stat) {
-		boolean result;
-		ValueAndTypeHolder holder = null;
-
-		ValueExpression ve = stat.getLogicalValueExpression();
-		holder = valueExpressionCheck(ve);
-		result = typeCheck(ve, null, holder, DataRepresentation.BOOLEAN);
-
-		result &= behaviorActionsCheck(stat.getBehaviorActions(), stat);
-
-		ElseStatement elseStat = stat.getElseStatement();
-
-		if (elseStat != null) {
-			// Elif case.
-			if (elseStat instanceof IfStatement) {
-				result &= ifStatementCheck((IfStatement) elseStat);
-			} else {
-				result &= behaviorActionsCheck(elseStat.getBehaviorActions(), elseStat);
-			}
-		}
-
-		return result;
+	private boolean checkBooleanExpression(ValueExpression expression) {
+		TypeHolder type = checkValueExpression(expression);
+		return checkRepresentation(expression, null, type, DataRepresentation.BOOLEAN);
 	}
 
-	@SuppressWarnings("all")
-	private boolean basicActionCheck(BasicAction ba, Object parentContainer) {
-		if (ba instanceof AssignmentAction) {
-			return assignmentActionCheck((AssignmentAction) ba);
-		} else {
-			if (ba instanceof CommunicationAction) {
-				CommunicationAction resolvedCommAct = communicationActionCheck((CommunicationAction) ba);
-				boolean result = resolvedCommAct != null;
-
-				// The returned communication action may be different from the
-				// tested one because of semantic ambiguity resolution in
-				// communicationActionCheck method. So replace if needed.
-				if (resolvedCommAct != ba && result) {
-					// [DEBUG]
-					boolean hasBeenReplaced = false;
-
-					if (parentContainer instanceof ListIterator<?>) {
-						((ListIterator) parentContainer).set(resolvedCommAct);
-						hasBeenReplaced = true;
-					} else if (parentContainer instanceof ElseStatement) {
-						// And also IfStatement.
-						((ElseStatement) parentContainer).setBehaviorActions(resolvedCommAct);
-						hasBeenReplaced = true;
-					} else if (parentContainer instanceof LoopStatement) {
-						((LoopStatement) parentContainer).setBehaviorActions(resolvedCommAct);
-						hasBeenReplaced = true;
-					} else if (parentContainer instanceof BehaviorActionBlock) {
-						((BehaviorActionBlock) parentContainer).setContent(resolvedCommAct);
-						hasBeenReplaced = true;
-					}
-
-					if (!hasBeenReplaced) {
-						String msg = "The resolved communication action: " + unparseNameElement(resolvedCommAct)
-								+ " hasn't been set";
-
-						System.err.println(msg);
-						throw new RuntimeException(msg);
-					}
-				}
-
-				return result;
-			} else // Timed action case.
-			{
-				return timedActionCheck((TimedAction) ba);
-			}
-		}
-	}
-
-	private boolean timedActionCheck(TimedAction ta) {
-		BehaviorTime resolvedTime = _fact.createBehaviorTime();
-
-		boolean result = behaviorTimeCheck((DeclarativeTime) ta.getLowerTime(), resolvedTime);
-		ta.setLowerTime(resolvedTime);
-
-		if (ta.getUpperTime() != null) {
-			resolvedTime = _fact.createBehaviorTime();
-			result &= behaviorTimeCheck((DeclarativeTime) ta.getUpperTime(), resolvedTime);
-			ta.setUpperTime(resolvedTime);
-		}
-
-		if (ta.isSetProcessorClassifier()) {
-			List<ProcessorClassifier> qnes = new ArrayList<ProcessorClassifier>(ta.getProcessorClassifier().size());
-			qnes.addAll(ta.getProcessorClassifier());
-			ta.unsetProcessorClassifier();
-
-			QualifiedNamedElement qne;
-			Classifier tmp;
-
-			for (int i = 0; i < qnes.size(); i++) {
-				qne = (QualifiedNamedElement) qnes.get(i);
-				tmp = (Classifier) uniqueNamedElementReferenceResolver(qne, TypeCheckRule.PROCESSOR_RULE);
-				if (tmp != null) {
-					try {
-						ta.getProcessorClassifier().add((ProcessorClassifier) tmp);
-					} catch (IllegalArgumentException e) {
-						// if the user set the same more than once.
-						System.out.println("catch IllegalArgumentException AadlTypeChecker");
-					}
-				} else {
-					result = false;
-				}
-			}
-		}
-
-		return result;
-	}
-
-	private PortDequeueAction portDequeueActionResolver(CommAction comAct) {
-		// if already resolved, check port ref is event or event data port
-		QualifiedNamedElement qne = comAct.getQualifiedName();
-
-		if (qne != null) {
-			boolean isOfExpectedType = qne.getOsateRef() instanceof EventPort
-					|| qne.getOsateRef() instanceof EventDataPort;
-			if (!isOfExpectedType) {
-				String name = "referenced object";
-				if (qne.getOsateRef() instanceof NamedElement) {
-					NamedElement ne = (NamedElement) qne.getOsateRef();
-					name = ne.getName();
-				} else if (qne.getBaRef() instanceof BehaviorNamedElement) {
-					BehaviorNamedElement bne = (BehaviorNamedElement) qne.getBaRef();
-					name = bne.getName();
-				} else if (qne.getBaName().getId() != null) {
-					name = qne.getBaName().getId();
-				} else if (qne.getName() != null) {
-					name = qne.getName();
-				}
-				reportError(comAct, "incorrect port dequeue action, " + name + " is not an event [data] port");
-				return null;
-			}
-		} else if (comAct.getReference() == null) {
+	private TypeHolder checkValueExpression(ValueExpression expression) {
+		EList<Relation> relations = expression.getRelations();
+		if (relations.isEmpty()) {
 			return null;
 		}
-
-		Target tarTmp = null;
-		boolean tarCheckResult = true;
-
-		TypeCheckRule stopOnThisRule = TypeCheckRule.IN_PORT;
-		TypeCheckRule checkRule = TypeCheckRule.PORT_DEQUEUE_VALUE;
-		List<ElementHolder> resolvedRef = refResolver(comAct.getReference(), null, stopOnThisRule, checkRule);
-		if (resolvedRef != null) {
-			PortHolder portHolder = (PortHolder) resolvedRef.get(0);
-			return portDequeueActionResolver(portHolder, comAct);
-		} else {
-			return null;
+		TypeHolder result = checkRelation(relations.get(0));
+		for (int i = 1; result != null && i < relations.size(); i++) {
+			TypeHolder next = checkRelation(relations.get(i));
+			result = next == null ? null
+					: dataChecker.checkDefinition(expression, expression.getLogicalOperators().get(i - 1), result, next);
 		}
+		return result;
 	}
 
-	private CommunicationAction qualifiedSubprogramClassifierCallOrPortCommunicationActionResolver(CommAction comAct) {
-		QualifiedNamedElement qne = comAct.getQualifiedName();
+	private TypeHolder checkRelation(Relation relation) {
+		TypeHolder first = checkSimpleExpression(relation.getFirstExpression());
+		if (!relation.isSetRelationalOperator()) {
+			return first;
+		}
+		TypeHolder second = checkSimpleExpression(relation.getSecondExpression());
+		return first == null || second == null ? null
+				: dataChecker.checkDefinition(relation, relation.getRelationalOperator(), first, second);
+	}
 
-		if (qne.getOsateRef() instanceof EventPort) {
-			EventPortHolder tmp = _fact.createEventPortHolder();
-			tmp.setEventPort((EventPort) qne.getOsateRef());
-			if (comAct.isPortDequeue()) {
-				return portDequeueActionResolver(tmp, comAct);
-			}
-			return portSendActionResolver(tmp, comAct);
-		} else if (qne.getOsateRef() instanceof EventDataPort) {
-			EventDataPortHolder tmp = _fact.createEventDataPortHolder();
-			tmp.setEventDataPort((EventDataPort) qne.getOsateRef());
-			if (comAct.isPortDequeue()) {
-				return portDequeueActionResolver(tmp, comAct);
-			}
-			return portSendActionResolver(tmp, comAct);
-		} else if (qne.getOsateRef() instanceof SubprogramAccess) {
-			SubprogramAccessHolder sah = _fact.createSubprogramAccessHolder();
-			sah.setSubprogramAccess((SubprogramAccess) qne.getOsateRef());
-			List<ElementHolder> refs = new ArrayList<ElementHolder>();
-			refs.add(sah);
-			return subprogramCallActionResolver(refs, comAct);
-		} else if (qne.getOsateRef() instanceof SubprogramSubcomponent) {
-			SubprogramSubcomponentHolder ssh = _fact.createSubprogramSubcomponentHolder();
-			ssh.setSubprogramSubcomponent((SubprogramSubcomponent) qne.getOsateRef());
-			List<ElementHolder> refs = new ArrayList<ElementHolder>();
-			refs.add(ssh);
-			return subprogramCallActionResolver(refs, comAct);
+	private TypeHolder checkSimpleExpression(SimpleExpression expression) {
+		EList<Term> terms = expression.getTerms();
+		if (terms.isEmpty()) {
+			return null;
+		}
+		TypeHolder result = checkTerm(terms.get(0));
+		if (result != null && expression.isSetUnaryAddingOperator()) {
+			result = dataChecker.checkDefinition(expression, expression.getUnaryAddingOperator(), result);
+		}
+		for (int i = 1; result != null && i < terms.size(); i++) {
+			TypeHolder next = checkTerm(terms.get(i));
+			result = next == null ? null : dataChecker.checkDefinition(expression,
+					expression.getBinaryAddingOperators().get(i - 1), result, next);
+		}
+		return result;
+	}
+
+	private TypeHolder checkTerm(Term term) {
+		EList<Factor> factors = term.getFactors();
+		if (factors.isEmpty()) {
+			return null;
+		}
+		TypeHolder result = checkFactor(factors.get(0));
+		for (int i = 1; result != null && i < factors.size(); i++) {
+			TypeHolder next = checkFactor(factors.get(i));
+			result = next == null ? null
+					: dataChecker.checkDefinition(term, term.getMultiplyingOperators().get(i - 1), result, next);
+		}
+		return result;
+	}
+
+	private TypeHolder checkFactor(Factor factor) {
+		TypeHolder first = getType(factor.getFirstValue());
+		if (first == null) {
+			return null;
+		}
+		if (factor.isSetUnaryBooleanOperator() || factor.isSetUnaryNumericOperator()) {
+			Enumerator operator = factor.isSetUnaryBooleanOperator() ? factor.getUnaryBooleanOperator()
+					: factor.getUnaryNumericOperator();
+			return dataChecker.checkDefinition(factor, operator, first);
+		} else if (factor.isSetBinaryNumericOperator()) {
+			TypeHolder second = getType(factor.getSecondValue());
+			return second == null ? null
+					: dataChecker.checkDefinition(factor, factor.getBinaryNumericOperator(), first, second);
+		}
+		return first;
+	}
+
+	private TypeHolder getType(Element element) {
+		if (element == null) {
+			return null;
+		} else if (element instanceof ValueExpression) {
+			return checkValueExpression((ValueExpression) element);
+		}
+		try {
+			return AadlBaUtils.getTypeHolder(element, baParentContainer);
+		} catch (DimensionException exception) {
+			reportDimensionException(exception);
+		} catch (UnsupportedOperationException exception) {
+			reportError(element, exception.getMessage());
 		}
 		return null;
 	}
 
-	private PortDequeueAction portDequeueActionResolver(PortHolder portHolder, CommAction comAct) {
-		PortDequeueAction portDequeueAction = _fact.createPortDequeueAction();
-
-		TypeCheckRule stopOnThisRule = TypeCheckRule.IN_PORT;
-
-		if (comAct.getTarget() != null) {
-			final Target tarTmp = targetCheck(comAct.getTarget(), stopOnThisRule);
-			if (tarTmp == null) {
-				return null;
-			}
-
-			portDequeueAction.setTarget(tarTmp);
-
-			// Matches the target's data type with the input port's one
-			// when port dequeue action.
-			TypeHolder tarType, portType;
-
-			try {
-				portType = AadlBaUtils.getTypeHolder(portHolder, _baParentContainer);
-				tarType = AadlBaUtils.getTypeHolder(tarTmp, _baParentContainer);
-			} catch (DimensionException de) {
-				de.setElement(comAct);
-				reportDimensionException(de);
-				return null;
-			}
-
-			if (false == _dataChecker.conformsTo(portType, tarType, true)) {
-				reportTypeError(comAct, "port dequeue action", portType.toString(), tarType.toString());
-				return null;
-			}
-		}
-		portDequeueAction.setPort((ActualPortHolder) portHolder);
-		portDequeueAction.setLocationReference(comAct.getLocationReference());
-		return portDequeueAction;
-	}
-
-	// This method checks the given object and returns a communication action
-	// resolved from semantic ambiguities. On error, reports error and returns
-	// null.
-	/**
-	 * Document: AADL Behavior Annex draft
-	 * Version : 0.94
-	 * Type : Legality rule
-	 * Section : D.6 Behavior Action Language
-	 * Object : Check legality rule D.6.(L6)
-	 * Keys : dequeue value port target
-	 */
-	private CommunicationAction communicationActionCheck(CommunicationAction ca) {
-		CommAction comAct = (CommAction) ca;
-
-		// Subprogram qualified classifier call.
-		if (isSubprogramClassifierCallOrPortCommunicationAction(comAct)) {
-			return qualifiedSubprogramClassifierCallOrPortCommunicationActionResolver(comAct);
-		}
-		// Port dequeue call.
-		else if (comAct.isPortDequeue()) {
-			return portDequeueActionResolver(comAct);
-		}
-		// Port freeze call.
-		else if (comAct.isPortFreeze()) {
-			return portFreezeActionResolver(comAct);
-		}
-		// Shared action call.
-		else if (comAct.isLock() || comAct.isUnlock()) {
-			return sharedActionResolver(comAct);
-		} else // Ambiguous cases.
-		{
-			return subprogramCallActionAndPortSendActionResolver(comAct);
-		}
-	}
-
-	private boolean isSubprogramClassifierCallOrPortCommunicationAction(CommAction comAct) {
-		QualifiedNamedElement qne = comAct.getQualifiedName();
-
-		if (qne == null) {
+	private boolean checkRepresentation(BehaviorElement element, String name, TypeHolder type,
+			DataRepresentation expected) {
+		if (type == null) {
 			return false;
 		}
-
-		if (qne.getOsateRef() instanceof EventPort || qne.getOsateRef() instanceof EventDataPort
-				|| qne.getOsateRef() instanceof SubprogramAccess
-				|| qne.getOsateRef() instanceof SubprogramSubcomponent) {
-			return true;
-		}
-		return false;
-	}
-
-	// Resolves semantic ambiguities (subprogram call and port send action).
-	// On error, reports error and returns null.
-	private CommunicationAction subprogramCallActionAndPortSendActionResolver(CommAction comAct) {
-		if (comAct.getQualifiedName() != null) {
-			TypeCheckRule rule = TypeCheckRule.SUBPROGRAM_UCCR;
-			Subprogram sub = (Subprogram) uniqueNamedElementReferenceResolver(comAct.getQualifiedName(), rule);
-			if (sub != null) {
-				// Gets subprogram type.
-				Classifier subprogType = subprogramTypeCheck(comAct);
-
-				// Checks and resolves parameter labels.
-				// Event if the subprogram call action doesn't have any parameter labels,
-				// the subprogram type may have and vice versa:
-				// subprogramParameterListCheck is also design for these cases.
-				// It also binds the subprogram type found to the subprogram call action.
-				if (subprogType != null) {
-					if (subprogramParameterListCheck(comAct, comAct.getParameters(), subprogType)) {
-						SubprogramCallAction result = _fact.createSubprogramCallAction();
-						SubprogramHolder sh = _fact.createSubprogramHolder();
-						sh.setLocationReference(comAct.getLocationReference());
-						sh.setSubprogram(sub);
-						result.setSubprogram(sh);
-						result.setLocationReference(comAct.getLocationReference());
-						result.getParameterLabels().addAll(comAct.getParameters());
-						return result;
-					}
-				}
-			}
-		} else if (comAct.getReference() != null) {
-			TypeCheckRule stopOnThisRule = TypeCheckRule.OUT_PORT;
-			TypeCheckRule[] checkRules = new TypeCheckRule[] { TypeCheckRule.SUBPROGRAM_CALL_ACTION_FIRST_NAME,
-					TypeCheckRule.SUBPROGRAM_CALL_ACTION_SD_NAME };
-
-			List<ElementHolder> resolvedRef = refResolver(comAct.getReference(), null, stopOnThisRule, checkRules);
-
-			if (resolvedRef != null) {
-				// Port send action case.
-				if (resolvedRef.get(0) instanceof PortHolder) {
-					ActualPortHolder portHolder = (ActualPortHolder) resolvedRef.get(0);
-					return portSendActionResolver(portHolder, comAct);
-				} else // Subprogram call action case.
-				{
-					return subprogramCallActionResolver(resolvedRef, comAct);
-				}
-			}
-		}
-		return null;
-	}
-
-	private SubprogramCallAction subprogramCallActionResolver(List<ElementHolder> resolvedRef, CommAction comAct) {
-		// Gets subprogram type.
-		Classifier subprogType = subprogramTypeCheck(comAct);
-
-		// Checks and resolves parameter labels.
-		// Event if the subprogram call action doesn't have any parameter labels,
-		// the subprogram type may have and vice versa :
-		// subprogramParameterListCheck is also design for these cases.
-		// It also binds the subprogram type found to the subprogram call action.
-		if (subprogType != null) {
-			if (subprogramParameterListCheck(comAct, comAct.getParameters(), subprogType)) {
-				SubprogramCallAction result = _fact.createSubprogramCallAction();
-				result.getParameterLabels().addAll(comAct.getParameters());
-
-				ElementHolder firstHolder = resolvedRef.get(0);
-				ElementHolder secondHolder = null;
-
-				if (resolvedRef.size() == 2) {
-					secondHolder = resolvedRef.get(1);
-				}
-
-				if (firstHolder instanceof SubprogramHolderProxy) {
-					// RefResolver can't detect that error. So do it.
-					if (resolvedRef.size() != 2) {
-						String msg = "missing subprogram access for : " + firstHolder.getElement().getName();
-
-						reportError(firstHolder, msg);
-
-						return null;
-					} else {
-						result.setProxy((SubprogramHolderProxy) firstHolder);
-						result.setSubprogram((CalledSubprogramHolder) secondHolder);
-					}
-				} else {
-					result.setSubprogram((CalledSubprogramHolder) firstHolder);
-				}
-
-				result.setLocationReference(comAct.getLocationReference());
-
-				return result;
-			} else {
-				return null;
-			}
-		} else {
-			return null;
-		}
-	}
-
-	private CommunicationAction portSendActionResolver(ActualPortHolder portHolder, CommAction comAct) {
-		PortSendAction portSendActionResult = _fact.createPortSendAction();
-
-		if (comAct.isSetParameters()) {
-			List<ParameterLabel> pll = comAct.getParameters();
-
-			if (pll.size() == 1) {
-				ValueExpression ve = (ValueExpression) pll.get(0);
-
-				ValueAndTypeHolder tmp = valueExpressionCheck(ve);
-
-				if (tmp != null) {
-					portSendActionResult.setPort(portHolder);
-
-					// Matches the value expression top level data type
-					// with the port data type.
-					TypeHolder portType;
-
-					try {
-						portType = AadlBaUtils.getTypeHolder(portHolder, _baParentContainer);
-					} catch (DimensionException de) {
-						reportDimensionException(de);
-						return null;
-					}
-
-					if (!_dataChecker.conformsTo(portType, tmp.typeHolder, true)) {
-						reportTypeError(comAct, "port send action", portType.toString(), tmp.typeHolder.toString());
-						return null;
-					} else {
-						ValueExpression veTmp = (ValueExpression) tmp.value;
-						portSendActionResult.setValueExpression(veTmp);
-					}
-				} else // Value expression checking has failed.
-				{
-					return null;
-				}
-			} else // Error case : Port send action has only one value expression.
-			{
-				return null;
-			}
-		} else {
-			portSendActionResult.setPort(portHolder);
-		}
-
-		portSendActionResult.setLocationReference(comAct.getLocationReference());
-
-		return portSendActionResult;
-	}
-
-	private SharedDataAction sharedActionResolver(CommAction comAct) {
-		DataAccessHolder dah = null;
-		SharedDataAction result = null;
-
-		if (comAct.getReference() != null) {
-			TypeCheckRule checkRules = TypeCheckRule.SHARED_DATA_ACTION;
-			TypeCheckRule stopOnThisRule = checkRules;
-			List<ElementHolder> resolvedRef = refResolver(comAct.getReference(), null, stopOnThisRule, checkRules);
-			if (resolvedRef != null) {
-				dah = (DataAccessHolder) resolvedRef.get(0);
-			} else {
-				return null;
-			}
-		}
-
-		if (comAct.isLock()) {
-			result = _fact.createLockAction();
-			if (comAct.getQualifiedName() != null && comAct.getQualifiedName().getOsateRef() != null
-					&& comAct.getQualifiedName().getOsateRef() instanceof DataAccess) {
-				dah = _fact.createDataAccessHolder();
-				dah.setElement((DataAccess) comAct.getQualifiedName().getOsateRef());
-			}
-
-		} else {
-			result = _fact.createUnlockAction();
-			if (comAct.getQualifiedName() != null && comAct.getQualifiedName().getOsateRef() != null
-					&& comAct.getQualifiedName().getOsateRef() instanceof DataAccess) {
-				dah = _fact.createDataAccessHolder();
-				dah.setElement((DataAccess) comAct.getQualifiedName().getOsateRef());
-			}
-		}
-
-		result.setDataAccess(dah);
-		result.setLocationReference(comAct.getLocationReference());
-
-		return result;
-	}
-
-	private PortFreezeAction portFreezeActionResolver(CommAction comAct) {
-		TypeCheckRule checkRules = TypeCheckRule.IN_PORT;
-		TypeCheckRule stopOnThisRule = TypeCheckRule.PORT_FREEZE_ACTION;
-
-		PortFreezeAction pfa = _fact.createPortFreezeAction();
-
-		List<ElementHolder> resolvedRef = refResolver(comAct.getReference(), pfa, stopOnThisRule, checkRules);
-		if (resolvedRef != null) {
-			return (PortFreezeAction) resolvedRef.get(0);
-		} else {
-			return null;
-		}
-	}
-
-	// Recursive method.
-	private Classifier getSubprogramType(CalledSubprogram sc) {
-		Classifier result = null;
-
-		if (sc instanceof SubprogramImplementation) {
-			result = ((SubprogramImplementation) sc).getType();
-		} else if (sc instanceof SubprogramType) {
-			result = (SubprogramType) sc;
-		} else if (sc instanceof SubprogramAccess) {
-			SubprogramAccess sa = (SubprogramAccess) sc;
-			result = sa.getClassifier();
-		} else if (sc instanceof SubprogramSubcomponent) {
-			SubprogramSubcomponent ss = (SubprogramSubcomponent) sc;
-			result = ss.getClassifier();
-		}
-
-		return result;
-	}
-
-	// Gets subprogram type binded to the given subprogram call action.
-	// On error, reports error and returns null.
-	private Classifier subprogramTypeCheck(CommAction comAct) {
-		Element el = null;
-
-		if (comAct.getReference() != null) {
-			el = comAct.getReference().getOsateRef();
-		} else {
-			el = comAct.getQualifiedName().getOsateRef();
-		}
-
-		Classifier result = null;
-		String errorMsg = null;
-
-		if (el instanceof ComponentPrototype) {
-			ComponentPrototype cp = (ComponentPrototype) el;
-
-			if (cp instanceof SubprogramPrototype) {
-				ComponentClassifier cc = cp.getConstrainingClassifier();
-
-				if (cc != null && cc instanceof SubprogramType) {
-					result = cc;
-				} else {
-					errorMsg = " is not a defined subprogram prototype";
-					result = null;
-				}
-			} else {
-				errorMsg = " is not an subprogram prototype";
-				result = null;
-			}
-		} else if (el instanceof CalledSubprogram) // Always after ComponentPrototype
-		{ // case.
-			result = getSubprogramType((CalledSubprogram) el);
-		} else if (el instanceof ComponentPrototypeBinding) {
-			ComponentPrototypeBinding cpb = (ComponentPrototypeBinding) el;
-
-			// Takes the last binding.
-			ComponentPrototypeActual cpa = cpb.getActuals().get(cpb.getActuals().size() - 1);
-
-			if (cpa.getSubcomponentType() instanceof SubprogramType) {
-				result = (SubprogramType) cpa.getSubcomponentType();
-			} else {
-				errorMsg = " is not an subprogram prototype";
-				result = null;
-			}
-		} else // Error case : the binded object is not an subprogram.
-		{
-			errorMsg = "is not subprogram";
-			result = null;
-		}
-
-		// Error reporting.
-		if (result == null && errorMsg != null) {
-			String subprogramName = unparseReference(comAct.getReference());
-			reportError(comAct, '\'' + subprogramName + '\'' + errorMsg);
-		}
-
-		return result;
-	}
-
-	// This method checks the given parameter labels and matches them against the
-	// subprogram parameters. It resolves target/value expression semantic
-	// ambiguities. On error, reports error and returns false.
-	// Event if the subprogram call action doesn't have any parameter labels,
-	// the subprogram type may have and vice versa : subprogramParameterListCheck
-	/// is also design for these cases.
-	/**
-	 * Document: AADL Behavior Annex draft
-	 * Version : 0.94
-	 * Type : Legality rule
-	 * Section : D.6 Behavior Action Language
-	 * Object : Check legality rule D.6.(L5)
-	 * Keys : parameter list match signature subprogram call
-	 */
-	private boolean subprogramParameterListCheck(CommAction comAct, EList<ParameterLabel> callParams,
-			Classifier subprogType) {
-		// Fetches sorted subprogram feature list.
-
-		List<Feature> tmp = Aadl2Utils.orderFeatures(subprogType);
-		List<Feature> subprogFeat = new ArrayList<Feature>(tmp.size());
-
-		for (Feature feat : tmp) {
-			if (feat instanceof DataAccess || feat instanceof Parameter) {
-				subprogFeat.add(feat);
-			}
-		}
-
-		// Matching the parameter labels with the subprogram signature.
-		// Resolves ambiguity between target and value expression:
-		// value expression are for in parameter, target are for out parameter.
-
-		// Preliminary checking : on error, reports error and exit early.
-		if (callParams.size() != subprogFeat.size()) {
-			String subprogramName = null;
-
-			if (comAct.getReference() != null) {
-				subprogramName = unparseReference(comAct.getReference());
-			} else {
-				subprogramName = unparseQualifiedNamedElement(comAct.getQualifiedName());
-			}
-
-			reportError(comAct, "Invalid number of argument(s) for the subprogram " + subprogramName);
+		if (type.getDataRep() != expected) {
+			reportTypeError(element, name == null ? "expression" : name, expected.getName(), type.toString());
 			return false;
 		}
-
-		boolean isconsistent = true;
-		boolean hasCheckingPassed = true;
-
-		Enum<?> currentDirRight;
-		ValueExpression valueExp;
-		ListIterator<ParameterLabel> it = callParams.listIterator();
-		Value v;
-		Target tar;
-		TypeHolder t1, t2;
-		ValueAndTypeHolder vth;
-
-		List<TypeHolder> typesFound = new ArrayList<TypeHolder>(callParams.size());
-		List<Enum<?>> dirRightsFound = new ArrayList<Enum<?>>(callParams.size());
-
-		List<TypeHolder> expectedTypes = new ArrayList<TypeHolder>(subprogFeat.size());
-		List<Enum<?>> expectedDirRight = new ArrayList<Enum<?>>(subprogFeat.size());
-
-		// As AADL standard doesn't allow subprogram overloading (two subprogram
-		// classifier names can't be the same), parameter labels checking is
-		// driven by the subprogram signature.
-		for (Feature feat : subprogFeat) {
-			if (feat instanceof Parameter) {
-				Parameter param = (Parameter) feat;
-				currentDirRight = param.getDirection();
-				expectedDirRight.add(currentDirRight);
-			} else // DataAccess case.
-			{
-				DataAccess data = (DataAccess) feat;
-				currentDirRight = Aadl2Utils.getDataAccessRight(data);
-				expectedDirRight.add(currentDirRight);
-			}
-
-			valueExp = (ValueExpression) it.next();
-
-			Classifier klass = AadlBaUtils.getClassifier(feat, _baParentContainer);
-
-			// ValueExpression case.
-			if (currentDirRight == DirectionType.IN || currentDirRight == Aadl2Utils.DataAccessRight.read_only) {
-				vth = valueExpressionCheck(valueExp);
-
-				if (vth != null) {
-					try {
-						t1 = AadlBaUtils.getTypeHolder(klass);
-					} catch (DimensionException de) {
-						reportDimensionException(de);
-						return false;
-					}
-
-					t2 = vth.typeHolder;
-					expectedTypes.add(t1);
-					typesFound.add(t2);
-					dirRightsFound.add(DirectionType.IN);
-
-					if (!_dataChecker.conformsTo(t1, t2, true)) {
-						isconsistent = false;
-					}
-				} else // Value expression checking error case.
-				{
-					// Error reporting has already been done.
-					hasCheckingPassed = false;
-				}
-			} else if (currentDirRight != Aadl2Utils.DataAccessRight.unknown) {
-				v = AadlBaUtils.isOnlyOneValue(valueExp);
-
-				boolean isOnlyOneReference = false;
-				if (v instanceof Reference) {
-					Reference r = (Reference) v;
-					if (r.getIds().size() == 1) {
-						isOnlyOneReference = true;
-					}
-				}
-				if (v instanceof Target && isOnlyOneReference) // Target but not reference case.
-				{
-					TypeCheckRule stopOnThisRule = TypeCheckRule.DATA_ACCESS;
-					tar = targetCheck((Target) v, stopOnThisRule);
-
-					if (tar != null) {
-						try {
-							t1 = AadlBaUtils.getTypeHolder(klass);
-							t2 = AadlBaUtils.getTypeHolder(tar, _baParentContainer);
-						} catch (DimensionException de) {
-							reportDimensionException(de);
-							return false;
-						}
-
-						expectedTypes.add(t1);
-						typesFound.add(t2);
-
-						Enum<?> dirRightFound = AadlBaUtils.getDirectionType(tar);
-
-						if (dirRightFound == null) {
-							dirRightFound = AadlBaUtils.getDataAccessRight(tar);
-						}
-
-						dirRightsFound.add(dirRightFound);
-
-						if (!_dataChecker.conformsTo(t1, t2, true)) {
-							isconsistent = false;
-						} else {
-							// As checking passed and ambiguity between
-							// ValueExpression and Target has been resolved, it replaces
-							// the value expression by the target as parameter label.
-							it.set(tar);
-						}
-					} else // Target checking error case.
-					{
-						// Error reporting has already been done.
-						hasCheckingPassed = false;
-					}
-				} else // Value expression taken as a target -> warning arithmetic pointer operation.
-				{
-					// Due to target/value expression semantic ambiguity, the parsing
-					// phase may have introduced a semantic errors :
-
-					// If v == null :
-					// The parameter label has
-					// to be a value expression with a single value when the expected
-					// subprogram parameter is IN_OUT or OUT.
-
-					// If v is not instanceof Target but ValueExpression or Value
-					// like :
-					// _ IntegerConstant or ValueConstant
-					// _ PortFreshValue
-					// _ PortCountValue
-					// _ PortDequeueValue
-					// It resolves the type in order to format the warning message:
-
-					vth = valueExpressionCheck(valueExp);
-
-					if (vth != null) {
-						try {
-							t1 = AadlBaUtils.getTypeHolder(klass);
-						} catch (DimensionException de) {
-							reportDimensionException(de);
-							return false;
-						}
-
-						t2 = vth.typeHolder;
-						expectedTypes.add(t1);
-						typesFound.add(t2);
-
-						boolean inconsistentDir = false;
-						if (v instanceof Reference) {
-							Reference ref = (Reference) v;
-							ArrayableIdentifier refRootId = ref.getIds().get(0);
-							Enum<?> dirRightFound = null;
-							if (refRootId.getOsateRef() != null) {
-								dirRightFound = AadlBaUtils.getDirectionType(refRootId.getOsateRef());
-							}
-							if (dirRightFound == null && refRootId.getOsateRef() instanceof DataAccess) {
-								dirRightFound = Aadl2Utils.getDataAccessRight((DataAccess) refRootId.getOsateRef());
-							}
-							if (dirRightFound == DirectionType.IN
-									|| dirRightFound == Aadl2Utils.DataAccessRight.read_only) {
-								inconsistentDir = true;
-							}
-						} else {
-							inconsistentDir = true;
-							dirRightsFound.add(DirectionType.IN);
-						}
-
-						if (inconsistentDir) {
-							StringBuilder msg = new StringBuilder();
-							msg.append('\'');
-							msg.append(unparseNameElement(valueExp));
-							msg.append("\': is a read only value and it is used as a writable value");
-
-							// Reports a warning.
-							reportWarning(valueExp, msg.toString());
-						}
-					} else {
-						// Error reporting has already been done.
-						hasCheckingPassed = false;
-					}
-				}
-			} else {
-				reportError(valueExp,
-						"can't fetch data access right. Set the default " + "right in memory_properties.aadl");
-			}
-		}
-
-		// Reports consistency error.
-		if (!isconsistent && hasCheckingPassed) {
-			String subprogramName = null;
-
-			if (comAct.getReference() != null) {
-				subprogramName = unparseReference(comAct.getReference());
-			} else {
-				subprogramName = unparseQualifiedNamedElement(comAct.getQualifiedName());
-			}
-
-			reportSubprogParamMatchingError(comAct, subprogramName, expectedTypes, expectedDirRight, typesFound,
-					dirRightsFound);
-		}
-
-		return isconsistent && hasCheckingPassed;
+		return true;
 	}
 
-	private void reportWarning(Element el, String msg) {
-		_errManager.warning(el, msg);
+	private void reportDimensionException(DimensionException exception) {
+		errManager.error(exception.getElement(), exception.getMessage());
 	}
 
-	private void reportSubprogParamMatchingError(BehaviorElement e, String subprogramName,
-			List<TypeHolder> expectedTypes, List<Enum<?>> expectedDirections, List<TypeHolder> typesFound,
-			List<Enum<?>> directionsFound) {
-		StringBuilder msg = new StringBuilder("The subprogram ");
-		msg.append(subprogramName);
-		msg.append('(');
-
-		if (!expectedTypes.isEmpty()) {
-			int index = 0;
-
-			for (TypeHolder th : expectedTypes) {
-				msg.append(expectedDirections.get(index++));
-				msg.append(' ');
-				msg.append(th.toString());
-				msg.append(STRING_PARAMETER_SEPARATOR);
-			}
-
-			// Remove the last separator.
-			msg.delete(msg.length() - STRING_PARAMETER_SEPARATOR.length(), msg.length());
-		}
-
-		msg.append(") is not applicable for the arguments (");
-
-		if (!typesFound.isEmpty()) {
-			int index = 0;
-
-			for (TypeHolder th : typesFound) {
-				msg.append(directionsFound.get(index++));
-				msg.append(' ');
-				msg.append(th.toString());
-				msg.append(STRING_PARAMETER_SEPARATOR);
-			}
-
-			// Remove the last separator.
-			msg.delete(msg.length() - STRING_PARAMETER_SEPARATOR.length(), msg.length());
-
-		}
-
-		msg.append(')');
-
-		reportError(e, msg.toString());
+	private void reportTypeError(BehaviorElement element, String name, String expectedTypes, String typeFound) {
+		reportError(element,
+				"type error for '" + name + "', '" + expectedTypes + "' expected, found '" + typeFound + "'.");
 	}
 
-	/**
-	 * Document: AADL Behavior Annex draft
-	 * Version : 0.94
-	 * Type : Legality rule
-	 * Section : D.6 Behavior Action Language
-	 * Object : Check legality rule D.6.(L1)
-	 * Keys : assignment action value expression target match type consistency
-	 */
-	private boolean assignmentActionCheck(AssignmentAction aa) {
-		TypeCheckRule stopOnThisRule = TypeCheckRule.ASSIGNMENT_TARGET;
-		Target tmp = targetCheck(aa.getTarget(), stopOnThisRule);
-
-		boolean result = tmp != null;
-
-		TypeHolder tarType, expType;
-		tarType = expType = null;
-
-		// The returned target may be different from the tested target
-		// because of semantic ambiguity resolution in targetCheck
-		// method. So replace if needed.
-		if (tmp != aa.getTarget() && result) {
-			aa.setTarget(tmp);
-		}
-
-		ValueExpression ve = aa.getValueExpression();
-
-		if (ve != null && (false == ve instanceof Any)) {
-			ValueAndTypeHolder vth = valueExpressionCheck(aa.getValueExpression());
-			if (vth != null) {
-				expType = vth.typeHolder;
-			} else {
-				result = false;
-			}
-
-			if (result) {
-				// Performs data type consistency checking.
-				try {
-					tarType = AadlBaUtils.getTypeHolder(tmp, _baParentContainer);
-				} catch (DimensionException de) {
-					reportDimensionException(de);
-					return false;
-				}
-
-				result = _dataChecker.conformsTo(tarType, expType, true);
-
-				if (!result) {
-					reportTypeError(vth.value, "assignment", tarType.toString(), expType.toString());
-				}
-			}
-		}
-
-		return result;
+	private void reportError(Element element, String message) {
+		errManager.error(element, message);
 	}
 
-	// Semantic rule about iterative variable assignment is checked.
-	// This method checks the given object and returns an object resolved from
-	// semantic ambiguities. On error, reports error and returns null.
-	private Target targetCheck(Target tar, TypeCheckRule stopOnThisRule) {
-		TypeCheckRule[] checkRules = new TypeCheckRule[] { TypeCheckRule.TARGET_COMPONENT_REFERENCE_FIRST_NAME,
-				TypeCheckRule.DATA_COMPONENT_REFERENCE_OTHER_NAMES };
-
-		List<ElementHolder> resolvedRef = refResolver((Reference) tar, null, stopOnThisRule, checkRules);
-
-		return (Target) referenceToValueVariable(resolvedRef);
-	}
-
-	// Compares the given expected data representation to the ValueAndTypeHolder
-	// one. Returns true is the data representation are the same.
-	// Otherwise returns false and reports error.
-	// If the given ValueAndTypeHolder object is null, it returns false without
-	// reporting any error (error reporting has already been done ?).
-	// If the given name is null, the method will unparse the given element.
-	private boolean typeCheck(BehaviorElement e, String name, ValueAndTypeHolder holder,
-			DataRepresentation expectedDataRepresentation) {
-		boolean result = false;
-
-		if (holder != null) {
-			result = expectedDataRepresentation == holder.typeHolder.getDataRep();
-
-			if (!result) {
-				if (name == null) {
-					name = unparseNameElement(e);
-				}
-				reportTypeError(e, name, expectedDataRepresentation.getName(), holder.typeHolder.toString());
-			}
-		}
-
-		return result;
-	}
-
-	/**
-	 * Return the element binded to the given declarative behavior element.
-	 *
-	 * @param el the given declarative behavior element
-	 * @return the binded element
-	 */
-	static Element getBindedElement(DeclarativeBehaviorElement el) {
-		org.osate.aadl2.Element result = el.getOsateRef();
-
-		if (result == null) {
-			result = el.getBaRef();
-		}
-
-		return result;
-	}
-
-	/**
-	 * Returns the feature type of the element binded to the given behavior
-	 * annex element.
-	 *
-	 * @param el the given behavior annex element
-	 * @return the feature type of the binded element
-	 */
-	static Enum<?> getType(DeclarativeBehaviorElement el) {
-		org.osate.aadl2.Element testedEl = AadlBaTypeChecker.getBindedElement(el);
-
-		Enum<?> result;
-
-		if (testedEl instanceof BehaviorElement) {
-			result = AadlBaUtils.getBehaviorAnnexFeatureType((BehaviorElement) testedEl);
-		} else {
-			result = AadlBaUtils.getFeatureType(testedEl);
-		}
-
-		return result;
-	}
-
-	/**
-	 * Checks the type of the reference binded to the given declarative behavior
-	 * element within the given rule's expected types. Returns the
-	 * matching feature type or {@code null} otherwise. Reports any error if
-	 * hasToReport is {@code true}.
-	 *
-	 * @param dbe the declarative behavior element to be checked
-	 * @param name the behavior element's name
-	 * @param rule the checking rule that contains the expected types
-	 * @param hasToReport flag for report error
-	 * @return the matching feature type or {@code null}
-	 */
-	private Enum<?> typeCheck(DeclarativeBehaviorElement dbe, String name, TypeCheckRule rule, boolean hasToReport) {
-		Enum<?> result = rule.test(dbe, _baParentContainer);
-
-		if (result == null && hasToReport) {
-
-			Enum<?> testedEnum = AadlBaTypeChecker.getType(dbe);
-
-			// Resolves feature prototype binding.
-			if (testedEnum == FeatureType.FEATURE_PROTOTYPE_BINDING) {
-				Element el = AadlBaTypeChecker.getBindedElement(dbe);
-				testedEnum = AadlBaUtils.getFeatPrototypeType((FeaturePrototypeBinding) el);
-			}
-
-			String expectedTypes = rule.getExpectedTypes(STRING_TYPE_SEPARATOR);
-			String typeFound = ((Enumerator) testedEnum).getLiteral();
-			reportTypeError(dbe, name, expectedTypes, typeFound);
-		}
-
-		return result;
-	}
-
-	// Convenient class that holds a value and its type representation.
-	private class ValueAndTypeHolder {
-		Value value;
-		TypeHolder typeHolder;
-
-		public ValueAndTypeHolder(Value v, TypeHolder typeHolder) {
-			this.value = v;
-			this.typeHolder = typeHolder;
-		}
-	}
-
-	// Behavior annex type checking rules.
-	// Based on a design pattern command.
-	private enum TypeCheckRule implements Enumerator {
-		ALL("any type", new Enum[] {}) {
-			@Override
-			public Enum<?> testTypeCheckRule(Enum<?> other) {
-				return other;
-			}
-		},
-
-		NOTHING("no type", new Enum[] {}) {
-			@Override
-			public Enum<?> test(DeclarativeBehaviorElement dbe, ComponentClassifier baParentContainer) {
-				return null;
-			}
-		},
-
-		IN_EVENT_PORT("in event port", new Enum[] { FeatureType.IN_EVENT_PORT, FeatureType.IN_OUT_EVENT_PORT }),
-
-		IN_EVENT_DATA_PORT("in event data port",
-				new Enum[] { FeatureType.IN_EVENT_DATA_PORT, FeatureType.IN_OUT_EVENT_DATA_PORT }),
-
-		EVENT_DATA_PORT("event data port", new Enum[] { FeatureType.IN_EVENT_DATA_PORT, FeatureType.OUT_EVENT_DATA_PORT,
-				FeatureType.IN_OUT_EVENT_DATA_PORT }),
-
-		IN_PORT("in port",
-				new Enum[] { FeatureType.IN_DATA_PORT, FeatureType.IN_OUT_DATA_PORT, FeatureType.IN_EVENT_PORT,
-						FeatureType.IN_OUT_EVENT_PORT, FeatureType.IN_EVENT_DATA_PORT,
-						FeatureType.IN_OUT_EVENT_DATA_PORT }),
-
-		OUT_PORT("out port",
-				new Enum[] { FeatureType.OUT_DATA_PORT, FeatureType.IN_OUT_DATA_PORT, FeatureType.OUT_EVENT_PORT,
-						FeatureType.IN_OUT_EVENT_PORT, FeatureType.OUT_EVENT_DATA_PORT,
-						FeatureType.IN_OUT_EVENT_DATA_PORT }),
-
-		PORT("port", new Enum[] { FeatureType.IN_DATA_PORT, FeatureType.IN_OUT_DATA_PORT, FeatureType.OUT_DATA_PORT,
-				FeatureType.IN_EVENT_PORT, FeatureType.IN_OUT_EVENT_PORT, FeatureType.OUT_EVENT_PORT,
-				FeatureType.IN_EVENT_DATA_PORT, FeatureType.IN_OUT_EVENT_DATA_PORT, FeatureType.OUT_EVENT_DATA_PORT }),
-
-		IN_PORT_PROTOTYPE("in port prototype",
-				new Enum[] { FeatureType.IN_DATA_PORT_PROTOTYPE, FeatureType.IN_OUT_DATA_PORT_PROTOTYPE,
-						FeatureType.IN_EVENT_PORT_PROTOTYPE, FeatureType.IN_OUT_EVENT_PORT_PROTOTYPE,
-						FeatureType.IN_EVENT_DATA_PORT_PROTOTYPE, FeatureType.IN_OUT_EVENT_DATA_PORT_PROTOTYPE }),
-
-		OUT_PORT_PROTOTYPE("out port prototype",
-				new Enum[] { FeatureType.OUT_DATA_PORT_PROTOTYPE, FeatureType.IN_OUT_DATA_PORT_PROTOTYPE,
-						FeatureType.OUT_EVENT_PORT_PROTOTYPE, FeatureType.IN_OUT_EVENT_PORT_PROTOTYPE,
-						FeatureType.OUT_EVENT_DATA_PORT_PROTOTYPE, FeatureType.IN_OUT_EVENT_DATA_PORT_PROTOTYPE }),
-
-		FEATURE_PROTOTYPE("feature prototype", new Enum[] { FeatureType.IN_FEATURE_PROTOTYPE,
-				FeatureType.OUT_FEATURE_PROTOTYPE, FeatureType.IN_OUT_FEATURE_PROTOTYPE }),
-
-		IN_PARAMETER("in parameter", new Enum[] { FeatureType.IN_PARAMETER, FeatureType.IN_OUT_PARAMETER }),
-
-		OUT_PARAMETER("out parameter", new Enum[] { FeatureType.OUT_PARAMETER, FeatureType.IN_OUT_PARAMETER }),
-
-		PARAMETER("parameter",
-				new Enum[] { FeatureType.IN_PARAMETER, FeatureType.OUT_PARAMETER, FeatureType.IN_OUT_PARAMETER }),
-
-		DATA_ACCESS("data access", new Enum[] { FeatureType.REQUIRES_DATA_ACCESS, FeatureType.PROVIDES_DATA_ACCESS }),
-
-		DATA_ACCESS_PROTOTYPE("data access prototype",
-				new Enum[] { FeatureType.REQUIRES_DATA_ACCESS_PROTOTYPE, FeatureType.PROVIDES_DATA_ACCESS_PROTOTYPE }),
-
-		FROZEN_PORT("frozen port", new Enum[] { TypeCheckRule.IN_PORT }),
-
-		DISPATCH_TRIGGER("dispatch trigger",
-				new Enum[] { TypeCheckRule.IN_EVENT_PORT, TypeCheckRule.IN_EVENT_DATA_PORT }),
-
-		MODE_SWITCH_TRIGGER("mode switch trigger",
-				new Enum[] { TypeCheckRule.IN_EVENT_PORT, TypeCheckRule.IN_EVENT_DATA_PORT }),
-
-		DISPATCH_TRIGGER_CONDITION("dispatch trigger condition", new Enum[] { TypeCheckRule.IN_EVENT_PORT,
-				TypeCheckRule.IN_EVENT_DATA_PORT, FeatureType.PROVIDES_SUBPROGRAM_ACCESS }),
-
-		// Always include at the end of an array:
-		// because data subcomponent and data access are very high level feature types.
-		DATA_COMPONENT_REFERENCE_FIRST_NAME(
-				"data subcomponent" + STRING_TYPE_SEPARATOR + "data access" + STRING_TYPE_SEPARATOR
-						+ "behavior variable" + STRING_TYPE_SEPARATOR + "data access feature prototype",
-				new Enum[] { FeatureType.DATA_SUBCOMPONENT, TypeCheckRule.DATA_ACCESS,
-						TypeCheckRule.DATA_ACCESS_PROTOTYPE, TypeCheckRule.FEATURE_PROTOTYPE,
-						BehaviorFeatureType.BEHAVIOR_VARIABLE }),
-
-		DATA_COMPONENT_REFERENCE_OTHER_NAMES("data field",
-				new Enum[] { FeatureType.DATA_SUBCOMPONENT, TypeCheckRule.DATA_ACCESS,
-						TypeCheckRule.DATA_ACCESS_PROTOTYPE, TypeCheckRule.FEATURE_PROTOTYPE,
-						FeatureType.CLASSIFIER_VALUE }),
-
-		// Always include at the end of an array:
-		// because data subcomponent and data access are very high level feature types.
-		VV_COMPONENT_REFERENCE_FIRST_NAME(
-				DATA_COMPONENT_REFERENCE_FIRST_NAME._literal + STRING_TYPE_SEPARATOR + "in parameter"
-						+ STRING_TYPE_SEPARATOR + "incomming port (prototype)" + STRING_TYPE_SEPARATOR
-						+ "iterative variable",
-				new Enum[] { TypeCheckRule.DATA_COMPONENT_REFERENCE_FIRST_NAME, TypeCheckRule.IN_PARAMETER,
-						TypeCheckRule.IN_PORT, TypeCheckRule.IN_PORT_PROTOTYPE,
-						BehaviorFeatureType.ITERATIVE_VARIABLE }),
-
-		PROPERTY("property", new Enum[] { FeatureType.PROPERTY_CONSTANT, FeatureType.PROPERTY_VALUE }),
-
-		PORT_COUNT_VALUE("port count value", new Enum[] { TypeCheckRule.PORT }),
-
-		PORT_FRESH_VALUE("port fresh value", new Enum[] { TypeCheckRule.PORT }),
-
-		PORT_DEQUEUE_VALUE("port dequeue value", new Enum[] { TypeCheckRule.IN_PORT }),
-
-		ELEMENT_VALUES("element values", new Enum[] { TypeCheckRule.EVENT_DATA_PORT, TypeCheckRule.PARAMETER,
-				TypeCheckRule.DATA_COMPONENT_REFERENCE_FIRST_NAME }),
-
-		// Always include at the end of an array:
-		// because data subcomponent and data access are very high level feature types.
-		TARGET_COMPONENT_REFERENCE_FIRST_NAME(
-				DATA_COMPONENT_REFERENCE_FIRST_NAME._literal + STRING_TYPE_SEPARATOR + "out parameter"
-						+ STRING_TYPE_SEPARATOR + "outgoing port (prototype)",
-				new Enum[] { TypeCheckRule.DATA_COMPONENT_REFERENCE_FIRST_NAME, TypeCheckRule.OUT_PARAMETER,
-						TypeCheckRule.OUT_PORT, TypeCheckRule.OUT_PORT_PROTOTYPE }),
-
-		SHARED_DATA_ACTION("shared data action", new Enum[] { FeatureType.REQUIRES_DATA_ACCESS }),
-
-		PORT_DEQUEUE_ACTION("port dequeue action", new Enum[] { TypeCheckRule.IN_PORT }),
-
-		PORT_FREEZE_ACTION("port freeze action", new Enum[] { TypeCheckRule.IN_PORT }),
-
-		SUBPROGRAM_CALL_ACTION_FIRST_NAME("subprogram call action",
-				new Enum[] { FeatureType.SUBPROGRAM_SUBCOMPONENT, FeatureType.SUBPROGRAM_PROTOTYPE,
-						FeatureType.SUBPROGRAM_CLASSIFIER, FeatureType.REQUIRES_SUBPROGRAM_ACCESS,
-						FeatureType.REQUIRES_DATA_ACCESS, FeatureType.DATA_SUBCOMPONENT,
-						BehaviorFeatureType.BEHAVIOR_VARIABLE, TypeCheckRule.OUT_PORT }),
-
-		SUBPROGRAM_CALL_ACTION_SD_NAME("subprogram call action", new Enum[] { FeatureType.PROVIDES_SUBPROGRAM_ACCESS }),
-
-		DATA_UCCR("data unique component classifier reference", new Enum[] { FeatureType.DATA_CLASSIFIER }),
-
-		SUBPROGRAM_UCCR("subprogram unique component classifier reference",
-				new Enum[] { FeatureType.SUBPROGRAM_CLASSIFIER }),
-
-		GROUPS("group (prototype)", new Enum[] { FeatureType.FEATURE_GROUP,
-				FeatureType.REQUIRES_SUBPROGRAM_GROUP_ACCESS, FeatureType.PROVIDES_SUBPROGRAM_GROUP_ACCESS,
-				FeatureType.THREAD_GROUP, FeatureType.SUBPROGRAM_GROUP, FeatureType.THREAD_GROUP_PROTOTYPE,
-				FeatureType.SUBPROGRAM_GROUP_PROTOTYPE, FeatureType.FEATURE_GROUP_PROTOTYPE,
-				FeatureType.FEATURE_GROUP_PROTOTYPE_BINDING, FeatureType.REQUIRES_SUBPROGRAM_GROUP_ACCESS_PROTOTYPE,
-				FeatureType.PROVIDES_SUBPROGRAM_GROUP_ACCESS_PROTOTYPE }),
-
-		TARGET_STOP_RULE("target stop rule", new Enum[] { TypeCheckRule.OUT_PORT, TypeCheckRule.OUT_PORT_PROTOTYPE }),
-
-		VV_STOP_RULE("value variable stop rule", new Enum[] { TypeCheckRule.IN_PORT, TypeCheckRule.IN_PORT_PROTOTYPE }),
-
-		PROCESSOR_RULE("processor unique component classifier reference",
-				new Enum[] { FeatureType.PROCESSOR_CLASSIFIER }),
-
-		ASSIGNMENT_TARGET("assignment left hand side", new Enum[] { TypeCheckRule.TARGET_STOP_RULE });
-
-		String _literal;
-		Enum<?>[] _acceptableTypes;
-
-		TypeCheckRule(String literal, Enum<?>[] acceptableTypes) {
-			_literal = literal;
-			_acceptableTypes = acceptableTypes;
-		}
-
-		/**
-		 * Returns the expected feature type names separated by the given type
-		 * separator string.
-		 * <BR><BR>
-		 * Note : this method is not recursive.
-		 *
-		 * @param typeSeparator the given type separator string
-		 * @return the the expected feature type names separated by the given type
-		 * separator string.
-		 */
-		public String getExpectedTypes(String typeSeparator) {
-			Enum<?>[] ea = this._acceptableTypes;
-
-			String[] sa = new String[ea.length];
-			int i = 0;
-
-			for (Enum<?> e : ea) {
-				sa[i] = ((Enumerator) e).getLiteral();
-				i++;
-			}
-
-			return Aadl2Utils.concatenateString(typeSeparator, sa);
-		}
-
-		/**
-		 * Returns the rule's matching FeatureType or BehaviorAnnexFeatureType
-		 * enumeration of the given DeclarativeBehaviorElement object. If there is
-		 * no matching, it returns {@code null}. This test is recursive.
-		 *
-		 * @param dbe the given DeclarativeBehaviorElement object
-		 * @param baParentContainer behavior parent component
-		 * @return the rule's matching feature type or {@code null}
-		 */
-		public Enum<?> test(DeclarativeBehaviorElement dbe, ComponentClassifier baParentContainer) {
-			Enum<?> testedEnum = AadlBaTypeChecker.getType(dbe);
-
-			// Resolves feature prototype binding in order to compare the rule
-			// to the resolved feature prototype.
-			if (testedEnum.equals(FeatureType.FEATURE_PROTOTYPE_BINDING)) {
-				FeaturePrototypeBinding fpb = (FeaturePrototypeBinding) AadlBaTypeChecker.getBindedElement(dbe);
-				testedEnum = AadlBaUtils.getFeatPrototypeType(fpb);
-			}
-
-			// Resolves component prototype binding in order to compare the rule
-			// to the resolved component prototype.
-			if (testedEnum.equals(FeatureType.COMPONENT_PROTOTYPE_BINDING)) {
-				ComponentPrototypeBinding cpb = (ComponentPrototypeBinding) AadlBaTypeChecker.getBindedElement(dbe);
-				testedEnum = AadlBaUtils.getCompPrototypeType(cpb);
-			}
-
-			return testTypeCheckRule(testedEnum);
-		}
-
-		public Enum<?> testTypeCheckRule(Enum<?> other) {
-			return testTypeCheckRule(this, other);
-		}
-
-		private static Enum<?> testTypeCheckRule(TypeCheckRule tcr, Enum<?> other) {
-			for (Enum<?> e : tcr._acceptableTypes) {
-				if (e instanceof TypeCheckRule) {
-					Enum<?> result = testTypeCheckRule((TypeCheckRule) e, other);
-
-					if (result != null) {
-						return result;
-					} else {
-						continue;
-					}
-				} else {
-					if (e.equals(other)) {
-						return other;
-					} else {
-						continue;
-					}
-				}
-			}
-
-			return null;
-		}
-
-		@Override
-		public String getLiteral() {
-			return _literal;
-		}
-
-		@Override
-		public String getName() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public int getValue() {
-			throw new UnsupportedOperationException();
-		}
-	}
 }

--- a/ba/org.osate.ba/src/org/osate/ba/analyzers/BehaviorTransitionContext.java
+++ b/ba/org.osate.ba/src/org/osate/ba/analyzers/BehaviorTransitionContext.java
@@ -1,0 +1,69 @@
+/**
+ * AADL-BA-FrontEnd
+ *
+ * Copyright (c) 2011-2021 TELECOM ParisTech and CNRS
+ *
+ * TELECOM ParisTech/LTCI
+ *
+ * Authors: see AUTHORS
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Eclipse Public License as published by Eclipse,
+ * either version 2.0 of the License, or (at your option) any later version.
+ */
+package org.osate.ba.analyzers;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.osate.ba.aadlba.BehaviorState;
+import org.osate.ba.aadlba.BehaviorTransition;
+import org.osate.ba.declarative.DeclarativeBehaviorTransition;
+import org.osate.ba.declarative.DeclarativeFactory;
+import org.osate.ba.declarative.Identifier;
+
+/**
+ * Provides transition state access for both the legacy declarative transition and a detached strict transition.
+ */
+final class BehaviorTransitionContext {
+	private BehaviorTransitionContext() {
+	}
+
+	static List<Identifier> getSourceIdentifiers(BehaviorTransition transition) {
+		if (transition instanceof DeclarativeBehaviorTransition) {
+			return ((DeclarativeBehaviorTransition) transition).getSrcStates();
+		}
+
+		BehaviorState source = transition.getSourceState();
+		if (source == null) {
+			return Collections.emptyList();
+		}
+
+		Identifier identifier = DeclarativeFactory.eINSTANCE.createIdentifier();
+		identifier.setId(source.getName());
+		identifier.setBaRef(source);
+		identifier.setLocationReference(source.getLocationReference());
+		return Collections.singletonList(identifier);
+	}
+
+	static List<BehaviorState> getSourceStates(BehaviorTransition transition) {
+		List<BehaviorState> result = new ArrayList<>();
+		for (Identifier identifier : getSourceIdentifiers(transition)) {
+			if (identifier.getBaRef() instanceof BehaviorState) {
+				result.add((BehaviorState) identifier.getBaRef());
+			}
+		}
+		return result;
+	}
+
+	static BehaviorState getDestinationState(BehaviorTransition transition) {
+		if (transition instanceof DeclarativeBehaviorTransition) {
+			Identifier destination = ((DeclarativeBehaviorTransition) transition).getDestState();
+			return destination != null && destination.getBaRef() instanceof BehaviorState
+					? (BehaviorState) destination.getBaRef()
+					: null;
+		}
+		return transition.getDestinationState();
+	}
+}

--- a/ba/org.osate.ba/src/org/osate/ba/utils/AadlBaVisitors.java
+++ b/ba/org.osate.ba/src/org/osate/ba/utils/AadlBaVisitors.java
@@ -150,8 +150,23 @@ public class AadlBaVisitors {
 	* @return the package sections related to the given BehaviorAnnex.
 	*/
 	public static PackageSection[] getBaPackageSections(BehaviorAnnex ba) {
+		return getBaPackageSections(ba, null);
+	}
+
+	/**
+	 * Return the package sections related to a behavior annex, using the given component classifier when the annex is
+	 * detached from its AADL containment hierarchy.
+	 *
+	 * @param ba the behavior annex
+	 * @param fallback the component classifier to use for a detached annex
+	 * @return the package sections related to the behavior annex
+	 */
+	public static PackageSection[] getBaPackageSections(BehaviorAnnex ba, ComponentClassifier fallback) {
 		PackageSection result[];
 		PackageSection container = Aadl2Visitors.getContainingPackageSection(ba);
+		if (container == null && fallback != null) {
+			container = Aadl2Visitors.getContainingPackageSection(fallback);
+		}
 
 		// Init contexts tab with current package's sections.
 		// Private section is also investigated only if ba is declared in
@@ -231,7 +246,19 @@ public class AadlBaVisitors {
 	* @return the behavior annex's parent component
 	*/
 	public static ComponentClassifier getParentComponent(BehaviorAnnex ba) {
-		return (ComponentClassifier) ba.getContainingClassifier();
+		return getParentComponent(ba, null);
+	}
+
+	/**
+	 * Returns the behavior annex's parent component, using the given classifier when the annex is detached.
+	 *
+	 * @param ba the behavior annex
+	 * @param fallback the component classifier to use for a detached annex
+	 * @return the behavior annex's parent component
+	 */
+	public static ComponentClassifier getParentComponent(BehaviorAnnex ba, ComponentClassifier fallback) {
+		ComponentClassifier result = (ComponentClassifier) ba.getContainingClassifier();
+		return result == null ? fallback : result;
 	}
 
 	protected static final Map<BehaviorAnnex, Set<Port>> _IS_FRESH = new WeakHashMap<BehaviorAnnex, Set<Port>>();


### PR DESCRIPTION
Part of #2445

## Cause

The BA type and rule checkers derived component context from annex containment and the type checker also resolved declarative names, created holders, and replaced containment nodes. A detached strict model produced by the future Xtext translator therefore could not be checked directly.

## Correction

- Add explicit ComponentClassifier context to AadlBaNameResolver, AadlBaTypeChecker, and AadlBaRulesCheckersDriver while retaining deprecated containment-based constructors.
- Move the legacy normalization and holder construction pass into AadlBaModelResolver.
- Make AadlBaTypeChecker read-only over an already resolved strict model.
- Adapt legality, consistency, and semantic transition checks to work with either legacy declarative transitions or detached strict transitions.
- Add fallback-aware parent-component and package-section lookup for detached annexes.

## Regression coverage

CheckerDecouplingTest copies a fully resolved BehaviorAnnex into a detached strict model, supplies the owning classifier explicitly, runs type and rules checking, and verifies the model remains structurally unchanged. Before the production change it failed on the missing explicit-context API.

The existing characterization suite also verifies that diagnostic and resolved-model goldens remain byte-identical.

## Validation

- Focused regression reactor with Maven -T5: 1 test, 0 failures, 0 errors, 0 skipped.
- Characterization suite with Maven -T5: 4 tests, 0 failures, 0 errors, 2 expected skips; all diagnostic and resolved-model goldens unchanged.
- Complete BA reactor with Maven -T5: 61 tests, 0 failures, 0 errors, 12 expected skips.
- Clean root reactor with Maven -T5 and -Dtycho.localArtifacts=ignore: 138 projects, 1,478 tests, 0 failures, 0 errors, 12 expected skips.

## Dependencies

This PR is stacked on #3139. Merge order: #3138, then #3139, then this PR.

## Residual risk

The live ANTLR path still performs its legacy normalization pass before the read-only checker. Phase 5 will replace that pass with the Xtext declarative-to-strict translator; the detached-model regression protects that handoff.