### PR TITLE
Validate Behavior Annex Xtext models 🤖

### DIFF
--- a/ba/org.osate.xtext.aadl2.ba.tests/models/phase4/SemanticError.aadl
+++ b/ba/org.osate.xtext.aadl2.ba.tests/models/phase4/SemanticError.aadl
@@ -1,0 +1,10 @@
+package Phase6_Semantic_Error
+public
+	thread Example
+		annex behavior_specification_xtext {**
+			states
+				first, second : initial state;
+				ready : complete state;
+		**};
+	end Example;
+end Phase6_Semantic_Error;

--- a/ba/org.osate.xtext.aadl2.ba.tests/src/org/osate/xtext/aadl2/ba/tests/BehaviorAnnexIntegrationTest.java
+++ b/ba/org.osate.xtext.aadl2.ba.tests/src/org/osate/xtext/aadl2/ba/tests/BehaviorAnnexIntegrationTest.java
@@ -30,6 +30,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import org.eclipse.xtext.diagnostics.Severity;
@@ -55,8 +58,10 @@ import com.google.inject.Inject;
 
 /**
  * Exercises the temporary Behavior Annex name through the real embedded-AADL parser path. These tests ensure that
- * phase 4 contributes the parser, linker, and unparser together; resolves local BA names and referenced AADL objects;
- * records the deliberate Xtext linking message; and does not accidentally add an annex-library form.
+ * phase 4 contributes the parser, linker, and unparser together; phase 6 runs the legacy semantic checkers through
+ * the translated strict model; local BA names and referenced AADL objects resolve; deliberate Xtext linking messages
+ * gate semantic validation; reviewed checker corrections are explicit and fast; and no annex-library form is
+ * accidentally added.
  */
 @RunWith(XtextRunner.class)
 @InjectWith(BehaviorAnnexEmbeddedInjectorProvider.class)
@@ -111,6 +116,40 @@ public class BehaviorAnnexIntegrationTest {
 				.stream()
 				.map(issue -> issue.getSeverity() + ": " + issue.getMessage())
 				.toList());
+	}
+
+	@Test
+	public void reportsTranslatedCheckerDiagnostic() throws Exception {
+		var result = testHelper.testFile(MODEL_DIRECTORY + "SemanticError.aadl");
+		assertEquals(List.of("ERROR: Phase6_Semantic_Error::Example can't have more than one initial state : "
+				+ "first, second : Behavior Annex D.3.(L3) legality rule failed."), result.getIssues()
+						.stream()
+						.map(issue -> issue.getSeverity() + ": " + issue.getMessage())
+						.toList());
+	}
+
+	@Test(timeout = 30_000)
+	public void reportsReviewedCheckerCorrectionsWithoutResolvingTheWorkspace() throws Exception {
+		var source = Files.readString(
+				Path.of("..", "org.osate.ba.tests", "models", "covering_semantic", "lr_D3_L1_L2.aadl"),
+				StandardCharsets.UTF_8)
+				.replace("annex behavior_specification", "annex behavior_specification_xtext");
+		var result = testHelper.testString(source);
+		assertEquals(List.of(
+				"ERROR: exemple_lr_D3_L1_L2::sub.error1 can't have complete state : compState : "
+						+ "Behavior Annex D.3.(L2) legality rule failed.",
+				"ERROR: exemple_lr_D3_L1_L2::sub.error1 can't have more than one initial state : "
+						+ "initState1, initState2 : Behavior Annex D.3.(L1) legality rule failed.",
+				"ERROR: exemple_lr_D3_L1_L2::sub.error1 has no final state : "
+						+ "Behavior Annex D.3.(L1) legality rule failed.",
+				"ERROR: exemple_lr_D3_L1_L2::sub.error2 has more than one final state : "
+						+ "uniqueState, finalState1 : Behavior Annex D.3.(L1) legality rule failed."),
+				result.getIssues()
+						.stream()
+						.filter(issue -> "org.osate.xtext.aadl2.ba.checker".equals(issue.getCode()))
+						.map(issue -> issue.getSeverity() + ": " + issue.getMessage())
+						.sorted()
+						.toList());
 	}
 
 	private static BehaviorAnnex getBehaviorAnnex(AadlPackage aadlPackage) {

--- a/ba/org.osate.xtext.aadl2.ba/src/org/osate/xtext/aadl2/ba/validation/BehaviorAnnexValidator.java
+++ b/ba/org.osate.xtext.aadl2.ba/src/org/osate/xtext/aadl2/ba/validation/BehaviorAnnexValidator.java
@@ -23,23 +23,170 @@
  */
 package org.osate.xtext.aadl2.ba.validation;
 
+import java.util.List;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
+import org.eclipse.xtext.validation.Check;
+import org.eclipse.xtext.validation.CheckType;
+import org.eclipse.xtext.validation.ValidationMessageAcceptor;
+import org.osate.aadl2.ComponentClassifier;
+import org.osate.aadl2.Element;
+import org.osate.aadl2.modelsupport.errorreporting.AbstractAnalysisErrorReporter;
+import org.osate.aadl2.modelsupport.errorreporting.AnalysisErrorReporterManager;
+import org.osate.ba.analyzers.AadlBaRulesCheckersDriver;
+import org.osate.ba.analyzers.AadlBaTypeChecker;
+import org.osate.ba.analyzers.AdaLikeDataTypeChecker;
+import org.osate.annexsupport.ParseResultHolder;
+import org.osate.xtext.aadl2.ba.behaviorAnnex.BehaviorAnnex;
+import org.osate.xtext.aadl2.ba.behaviorAnnex.BehaviorAnnexPackage;
+import org.osate.xtext.aadl2.ba.translation.DeclarativeToStrictTranslator;
+import org.osate.xtext.aadl2.ba.translation.DeclarativeToStrictTranslator.TranslationResult;
+
+import com.google.inject.Inject;
 
 /**
- * This class contains custom validation rules.
- *
- * See https://www.eclipse.org/Xtext/documentation/303_runtime_concepts.html#validation
+ * Runs the existing strict-model Behavior Annex checkers over the translated Xtext model and retargets their
+ * diagnostics to the declarative source objects. Syntax and linking failures gate this adapter so semantic checking
+ * does not cascade over an incomplete model.
  */
-public class BehaviorAnnexValidator extends AbstractBehaviorAnnexValidator {
+public final class BehaviorAnnexValidator extends AbstractBehaviorAnnexValidator {
+	public static final String CHECKER_DIAGNOSTIC = "org.osate.xtext.aadl2.ba.checker";
+	private static final URI VALIDATION_RESOURCE_URI = URI.createURI("validation:/behavior-annex.aadlba");
 
-//    public static final String INVALID_NAME = "invalidName";
-//
-//    @Check
-//    public void checkGreetingStartsWithCapital(Greeting greeting) {
-//        if (!Character.isUpperCase(greeting.getName().charAt(0))) {
-//            warning("Name should start with a capital",
-//                    BehaviorAnnexPackage.Literals.GREETING__NAME,
-//                    INVALID_NAME);
-//        }
-//    }
+	@Inject
+	private DeclarativeToStrictTranslator translator;
 
+	@Override
+	protected List<EPackage> getEPackages() {
+		return List.of(BehaviorAnnexPackage.eINSTANCE);
+	}
+
+	@Override
+	public boolean isLanguageSpecific() {
+		// Embedded annex objects live in an AADL Xtext resource, but this validator owns only the BA EPackage.
+		return false;
+	}
+
+	@Check(CheckType.NORMAL)
+	public void checkBehaviorAnnex(final BehaviorAnnex source) {
+		if (!(source.getContainingClassifier() instanceof ComponentClassifier owner)
+				|| hasSyntaxOrLinkingErrors(source)) {
+			return;
+		}
+
+		var translation = translator.translate(source, owner);
+		var strictAnnex = translation.getStrictAnnex();
+		synchronized (strictAnnex) {
+			var validationResource = new ResourceImpl(VALIDATION_RESOURCE_URI);
+			validationResource.getContents().add(strictAnnex);
+			try {
+				var errorManager = new AnalysisErrorReporterManager(
+						resource -> new ValidatorErrorReporter(resource, this, translation));
+				var dataTypeChecker = new AdaLikeDataTypeChecker(errorManager);
+				var typeChecker = new AadlBaTypeChecker(strictAnnex, owner, dataTypeChecker, errorManager);
+				if (typeChecker.checkTypes()) {
+					new AadlBaRulesCheckersDriver(strictAnnex, owner, errorManager).process(strictAnnex);
+				}
+			} finally {
+				validationResource.getContents().clear();
+			}
+		}
+	}
+
+	private static boolean hasSyntaxOrLinkingErrors(final BehaviorAnnex source) {
+		var parseResult = ParseResultHolder.Factory.INSTANCE.adapt(source).getParseResult();
+		if ((parseResult != null && parseResult.hasSyntaxErrors()) || hasUnresolvedCrossReference(source)) {
+			return true;
+		}
+		for (var contents = source.eAllContents(); contents.hasNext();) {
+			if (hasUnresolvedCrossReference(contents.next())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean hasUnresolvedCrossReference(final EObject object) {
+		for (var reference : object.eClass().getEAllReferences()) {
+			if (reference.isContainment() || reference.isContainer()) {
+				continue;
+			}
+			var value = object.eGet(reference, false);
+			if (value instanceof EObject target && target.eIsProxy()) {
+				return true;
+			}
+			if (value instanceof List<?> targets) {
+				for (var target : targets) {
+					if (target instanceof EObject eObject && eObject.eIsProxy()) {
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}
+
+	private void reportError(final Element strict, final String message, final TranslationResult translation) {
+		error(message, sourceFor(strict, translation), null, ValidationMessageAcceptor.INSIGNIFICANT_INDEX,
+				CHECKER_DIAGNOSTIC);
+	}
+
+	private void reportWarning(final Element strict, final String message, final TranslationResult translation) {
+		warning(message, sourceFor(strict, translation), null, ValidationMessageAcceptor.INSIGNIFICANT_INDEX,
+				CHECKER_DIAGNOSTIC);
+	}
+
+	private void reportInfo(final Element strict, final String message, final TranslationResult translation) {
+		info(message, sourceFor(strict, translation), null, ValidationMessageAcceptor.INSIGNIFICANT_INDEX,
+				CHECKER_DIAGNOSTIC);
+	}
+
+	private static EObject sourceFor(final EObject strict, final TranslationResult translation) {
+		for (var current = strict; current != null; current = current.eContainer()) {
+			var source = translation.getDeclarative(current);
+			if (source != null) {
+				return source;
+			}
+		}
+		return translation.getDeclarative(translation.getStrictAnnex());
+	}
+
+	private static final class ValidatorErrorReporter extends AbstractAnalysisErrorReporter {
+		private final BehaviorAnnexValidator validator;
+		private final TranslationResult translation;
+
+		private ValidatorErrorReporter(final Resource resource, final BehaviorAnnexValidator validator,
+				final TranslationResult translation) {
+			super(resource);
+			this.validator = validator;
+			this.translation = translation;
+		}
+
+		@Override
+		protected void errorImpl(final Element where, final String message, final String[] attributes,
+				final Object[] values) {
+			validator.reportError(where, message, translation);
+		}
+
+		@Override
+		protected void warningImpl(final Element where, final String message, final String[] attributes,
+				final Object[] values) {
+			validator.reportWarning(where, message, translation);
+		}
+
+		@Override
+		protected void infoImpl(final Element where, final String message, final String[] attributes,
+				final Object[] values) {
+			validator.reportInfo(where, message, translation);
+		}
+
+		@Override
+		protected void deleteMessagesImpl() {
+			// Xtext owns the diagnostic lifecycle.
+		}
+	}
 }


### PR DESCRIPTION
Part of #2445

## Summary

- run the existing read-only BA type and rules checkers on the translated strict model
- retarget checker errors, warnings, and information messages to Xtext source objects through the translation trace
- gate semantic validation when the annex has syntax errors or unresolved Xtext links
- register the validator only for the BA EPackage while allowing it to validate BA objects embedded in AADL resources
- scan links without resolving proxies, avoiding workspace-wide resolution during validation

## Diagnostics

The focused D.3 fixture now reports all four diagnostics required by its model and the existing checker rules. The legacy pipeline omitted the complete-state and missing-final-state diagnostics; this is a reviewed correction rather than compatibility behavior to reproduce.

## Regression coverage

`BehaviorAnnexIntegrationTest` verifies:

- valid embedded parsing, linking, and serialization
- unresolved Xtext links suppress translated semantic checks
- translated checker diagnostics retain their message and severity
- the reviewed four-diagnostic correction
- the non-resolving link gate completes the existing semantic fixture within 30 seconds; the measured focused run completed it in 0.068 seconds

## Validation

- Focused integration, `-T5`: 4 tests, 0 failures/errors/skips
- Complete focused BA/Xtext reactor, `-T5`: 67 tests, 0 failures/errors, 12 skipped
- Clean root reactor with `-T5` and `-Dtycho.localArtifacts=ignore`: 143 projects, 1,483 tests, 0 failures/errors, 12 skipped

## Dependency

This PR is stacked on #3144 and must merge after it.

Merge order: #3138, #3139, #3140, #3141, #3143, #3144, then this PR.

## Residual risk

The Xtext implementation remains registered under the temporary `behavior_specification_xtext` name. Phase 7 still owns the atomic parser switch-over and GE migration.
