### PR TITLE
Resolve Behavior Annex references in editors 🤖

### DIFF
--- a/ba/org.osate.xtext.aadl2.ba.tests/models/crossReferences/CrossReferenceProperties.aadl
+++ b/ba/org.osate.xtext.aadl2.ba.tests/models/crossReferences/CrossReferenceProperties.aadl
@@ -1,0 +1,3 @@
+property set CrossReferenceProperties is
+	Values: list of aadlinteger => (1, 2, 3) applies to (all);
+end CrossReferenceProperties;

--- a/ba/org.osate.xtext.aadl2.ba.tests/models/crossReferences/CrossReferences.aadl
+++ b/ba/org.osate.xtext.aadl2.ba.tests/models/crossReferences/CrossReferences.aadl
@@ -1,0 +1,41 @@
+package CrossReferences
+public
+	with Base_Types;
+	with CrossReferenceProperties;
+
+	data Payload
+	end Payload;
+
+	data implementation Payload.i
+		subcomponents
+			field: data Base_Types::Integer;
+	end Payload.i;
+
+	system Example
+		features
+			input: in event data port Base_Types::Integer;
+			output: out event data port Base_Types::Integer;
+	end Example;
+
+	system implementation Example.i
+		subcomponents
+			storage: data Payload.i;
+		annex behavior_specification {**
+			variables
+				counter : Base_Types::Integer;
+			states
+				idle : initial state;
+				running : final state;
+			transitions
+				start: idle -[counter = input]-> running {
+					counter := storage.field;
+					output!(counter);
+					for (item : Base_Types::Integer in 0 .. 1) {
+						counter := item
+					};
+					counter := #CrossReferenceProperties::Values[counter];
+					counter := self.input
+				};
+		**};
+	end Example.i;
+end CrossReferences;

--- a/ba/org.osate.xtext.aadl2.ba.tests/src/org/osate/xtext/aadl2/ba/tests/BehaviorAnnexCrossReferenceTest.java
+++ b/ba/org.osate.xtext.aadl2.ba.tests/src/org/osate/xtext/aadl2/ba/tests/BehaviorAnnexCrossReferenceTest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.xtext.aadl2.ba.tests;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.EcoreUtil2;
+import org.eclipse.xtext.resource.EObjectAtOffsetHelper;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.aadl2.DataImplementation;
+import org.osate.aadl2.DataSubcomponent;
+import org.osate.aadl2.DefaultAnnexSubclause;
+import org.osate.aadl2.SystemImplementation;
+import org.osate.testsupport.TestHelper;
+import org.osate.xtext.aadl2.ba.behaviorAnnex.BehaviorAnnex;
+import org.osate.xtext.aadl2.ba.behaviorAnnex.ForStatement;
+
+import com.google.inject.Inject;
+
+/**
+ * Verifies the shared embedded-annex offset contract used by Eclipse hyperlinks and Xtext LSP definitions. Every
+ * symbolic segment must resolve to its declaration, including nested paths, iterative variables, property-index
+ * references, and {@code self}; ordinary Xtext cross-references must continue to resolve through the same helper.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(BehaviorAnnexEmbeddedInjectorProvider.class)
+public class BehaviorAnnexCrossReferenceTest {
+	private static final String MODEL =
+			"org.osate.xtext.aadl2.ba.tests/models/crossReferences/CrossReferences.aadl";
+	private static final String PROPERTIES =
+			"org.osate.xtext.aadl2.ba.tests/models/crossReferences/CrossReferenceProperties.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Inject
+	private EObjectAtOffsetHelper offsetHelper;
+
+	@Test
+	public void resolvesAllReferenceSegmentsForEclipseAndLsp() {
+		var aadlPackage = testHelper.parseFile(MODEL, PROPERTIES);
+		var implementation = aadlPackage.getOwnedPublicSection()
+				.getOwnedClassifiers()
+				.stream()
+				.filter(SystemImplementation.class::isInstance)
+				.map(SystemImplementation.class::cast)
+				.findFirst()
+				.orElseThrow();
+		var defaultAnnex = (DefaultAnnexSubclause) implementation.getOwnedAnnexSubclauses().get(0);
+		var annex = (BehaviorAnnex) defaultAnnex.getParsedAnnexSubclause();
+		var resource = (XtextResource) aadlPackage.eResource();
+		var text = resource.getParseResult().getRootNode().getText();
+
+		var variable = annex.getVariableGroups().get(0).getVariables().get(0);
+		var states = annex.getStateGroups().stream().flatMap(group -> group.getStates().stream()).toList();
+		var input = implementation.findNamedElement("input");
+		var output = implementation.findNamedElement("output");
+		var storage = (DataSubcomponent) implementation.findNamedElement("storage");
+		var field = ((DataImplementation) storage.getDataSubcomponentType()).findNamedElement("field");
+		var loop = EcoreUtil2.getAllContentsOfType(annex, ForStatement.class).get(0);
+
+		assertReference(resource, text, "start: idle", "idle", states.get(0));
+		assertReference(resource, text, "-> running", "running", states.get(1));
+		assertReference(resource, text, "counter = input", "counter", variable);
+		assertReference(resource, text, "counter = input", "input", input);
+		assertReference(resource, text, "counter := storage.field", "counter", variable);
+		assertReference(resource, text, "storage.field", "storage", storage);
+		assertReference(resource, text, "storage.field", "field", field);
+		assertReference(resource, text, "output!(counter)", "output", output);
+		assertReference(resource, text, "output!(counter)", "counter", variable);
+		assertReference(resource, text, "counter := item", "item", loop);
+		assertReference(resource, text, "#CrossReferenceProperties::Values[counter]", "counter", variable);
+		assertReference(resource, text, "self.input", "self", implementation);
+		assertReference(resource, text, "self.input", "input", input);
+	}
+
+	private void assertReference(final XtextResource resource, final String text, final String marker,
+			final String token, final EObject expected) {
+		var markerOffset = text.indexOf(marker);
+		assertTrue("Expected marker in the parsed resource: " + marker, markerOffset >= 0);
+		var tokenOffset = text.indexOf(token, markerOffset);
+		assertTrue("Expected token after marker: " + token, tokenOffset >= markerOffset);
+		for (var offset = tokenOffset; offset < tokenOffset + token.length(); offset++) {
+			assertSame("Eclipse hyperlink target for " + marker, expected,
+					offsetHelper.resolveCrossReferencedElementAt(resource, offset));
+			assertSame("LSP definition target for " + marker, expected, offsetHelper.getElementWithNameAt(resource, offset));
+		}
+	}
+}

--- a/ba/org.osate.xtext.aadl2.ba/plugin.xml
+++ b/ba/org.osate.xtext.aadl2.ba/plugin.xml
@@ -52,4 +52,11 @@ censes only apply to the Third Party Software and not any other portion of this 
             annexName="behavior_specification"
             class="org.osate.xtext.aadl2.ba.parsing.BehaviorAnnexAnnexUnparser" />
     </extension>
+    <extension point="org.osate.annexsupport.textpositionresolver">
+        <textpositionresolver
+            id="org.osate.xtext.aadl2.ba.textpositionresolver"
+            name="Behavior Annex Xtext Reference Resolver"
+            annexName="behavior_specification"
+            class="org.osate.xtext.aadl2.ba.services.BehaviorAnnexTextPositionResolver" />
+    </extension>
 </plugin>

--- a/ba/org.osate.xtext.aadl2.ba/src/org/osate/xtext/aadl2/ba/services/BehaviorAnnexTextPositionResolver.java
+++ b/ba/org.osate.xtext.aadl2.ba/src/org/osate/xtext/aadl2/ba/services/BehaviorAnnexTextPositionResolver.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.xtext.aadl2.ba.services;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.osate.aadl2.ComponentClassifier;
+import org.osate.annexsupport.AnnexTextPositionResolver;
+import org.osate.annexsupport.TextPositionInfo;
+import org.osate.xtext.aadl2.ba.behaviorAnnex.BehaviorAnnex;
+import org.osate.xtext.aadl2.ba.behaviorAnnex.ReferenceSegment;
+import org.osate.xtext.aadl2.ba.behaviorAnnex.UnindexedReferenceSegment;
+import org.osate.xtext.aadl2.ba.translation.DeclarativeToStrictTranslator;
+
+/**
+ * Resolves the symbolic BA reference segments that intentionally remain attributes in the Xtext model. Ordinary Xtext
+ * cross-references fall through to the generic nested-annex offset support.
+ */
+public final class BehaviorAnnexTextPositionResolver implements AnnexTextPositionResolver {
+	private final DeclarativeToStrictTranslator translator = new DeclarativeToStrictTranslator();
+
+	@Override
+	public TextPositionInfo resolveElementAt(final EObject annexRoot, final int offset) {
+		return resolveSymbolicReference(annexRoot, offset);
+	}
+
+	@Override
+	public TextPositionInfo resolveCrossReferencedElementAt(final EObject annexRoot, final int offset) {
+		return resolveSymbolicReference(annexRoot, offset);
+	}
+
+	private TextPositionInfo resolveSymbolicReference(final EObject annexRoot, final int offset) {
+		if (!(annexRoot instanceof BehaviorAnnex annex)
+				|| !(annex.getContainingClassifier() instanceof ComponentClassifier owner)) {
+			return new TextPositionInfo(null, offset, 0);
+		}
+		var segment = findSegment(annex, offset);
+		if (segment == null) {
+			return new TextPositionInfo(null, offset, 0);
+		}
+		var nameNode = getNameNode(segment);
+		if (nameNode == null || offset < nameNode.getOffset() || offset >= nameNode.getEndOffset()) {
+			return new TextPositionInfo(null, offset, 0);
+		}
+		var target = translator.translate(annex, owner).getResolvedReference(segment);
+		return new TextPositionInfo(target, nameNode.getOffset(), nameNode.getLength());
+	}
+
+	private static EObject findSegment(final BehaviorAnnex annex, final int offset) {
+		var root = NodeModelUtils.getNode(annex);
+		if (root == null) {
+			return null;
+		}
+		INode node = NodeModelUtils.findLeafNodeAtOffset(root.getRootNode(), offset);
+		while (node != null) {
+			var semantic = NodeModelUtils.findActualSemanticObjectFor(node);
+			if (semantic instanceof ReferenceSegment || semantic instanceof UnindexedReferenceSegment) {
+				return semantic;
+			}
+			node = node.getParent();
+		}
+		return null;
+	}
+
+	private static INode getNameNode(final EObject segment) {
+		var name = segment.eClass().getEStructuralFeature("name");
+		var nodes = NodeModelUtils.findNodesForFeature(segment, name);
+		return nodes.isEmpty() ? null : nodes.get(0);
+	}
+}

--- a/ba/org.osate.xtext.aadl2.ba/src/org/osate/xtext/aadl2/ba/translation/DeclarativeToStrictTranslator.java
+++ b/ba/org.osate.xtext.aadl2.ba/src/org/osate/xtext/aadl2/ba/translation/DeclarativeToStrictTranslator.java
@@ -157,7 +157,6 @@ import org.osate.xtext.aadl2.ba.behaviorAnnex.PropertyReferenceTail;
 import org.osate.xtext.aadl2.ba.behaviorAnnex.Reference;
 import org.osate.xtext.aadl2.ba.behaviorAnnex.ReferenceExpression;
 import org.osate.xtext.aadl2.ba.behaviorAnnex.ReferenceSegment;
-import org.osate.xtext.aadl2.ba.behaviorAnnex.ReferenceTail;
 import org.osate.xtext.aadl2.ba.behaviorAnnex.TimedAction;
 import org.osate.xtext.aadl2.ba.behaviorAnnex.UnaryExpression;
 import org.osate.xtext.aadl2.ba.behaviorAnnex.WhileStatement;
@@ -204,12 +203,15 @@ public final class DeclarativeToStrictTranslator {
 		private final BehaviorAnnex strictAnnex;
 		private final Map<EObject, EObject> declarativeToStrict;
 		private final Map<EObject, EObject> strictToDeclarative;
+		private final Map<EObject, NamedElement> resolvedReferences;
 
 		private TranslationResult(final BehaviorAnnex strictAnnex, final Map<EObject, EObject> declarativeToStrict,
-				final Map<EObject, EObject> strictToDeclarative) {
+				final Map<EObject, EObject> strictToDeclarative,
+				final Map<EObject, NamedElement> resolvedReferences) {
 			this.strictAnnex = strictAnnex;
 			this.declarativeToStrict = Collections.unmodifiableMap(new IdentityHashMap<>(declarativeToStrict));
 			this.strictToDeclarative = Collections.unmodifiableMap(new IdentityHashMap<>(strictToDeclarative));
+			this.resolvedReferences = Collections.unmodifiableMap(new IdentityHashMap<>(resolvedReferences));
 		}
 
 		public BehaviorAnnex getStrictAnnex() {
@@ -230,6 +232,18 @@ public final class DeclarativeToStrictTranslator {
 
 		public Map<EObject, EObject> getStrictToDeclarativeTrace() {
 			return strictToDeclarative;
+		}
+
+		/**
+		 * Returns the source-model declaration selected for a symbolic reference segment.
+		 *
+		 * @param sourceSegment a {@code ReferenceSegment} or {@code UnindexedReferenceSegment}
+		 * @return the AADL declaration, BA declaration, iterative declaration owner, or {@code null}
+		 */
+		public EObject getResolvedReference(final EObject sourceSegment) {
+			var target = resolvedReferences.get(sourceSegment);
+			var declarativeTarget = strictToDeclarative.get(target);
+			return declarativeTarget == null ? target : declarativeTarget;
 		}
 	}
 
@@ -274,7 +288,7 @@ public final class DeclarativeToStrictTranslator {
 			translateVariables(strict);
 			translateStates(strict);
 			translateTransitions(strict);
-			return new TranslationResult(strict, declarativeToStrict, strictToDeclarative);
+			return new TranslationResult(strict, declarativeToStrict, strictToDeclarative, resolvedReferences);
 		}
 
 		private void translateVariables(final BehaviorAnnex strict) {
@@ -1045,42 +1059,30 @@ public final class DeclarativeToStrictTranslator {
 		}
 
 		private BehaviorElement toReferenceValue(final Reference reference) {
-			return toReferenceValue(reference.getSegments(), reference.getTails(), reference);
+			final List<Segment> segments = new ArrayList<>();
+			for (final var segment : reference.getSegments()) {
+				segments.add(new Segment(segment.getName(), segment.getIndexes(), segment, null));
+			}
+			for (final var tail : reference.getTails()) {
+				segments.add(new Segment(tail.getSegment().getName(), tail.getSegment().getIndexes(), tail.getSegment(),
+						tail.getSeparator()));
+			}
+			return toReferenceValue(segments, reference);
 		}
 
 		private BehaviorElement toReferenceValue(
 				final org.osate.xtext.aadl2.ba.behaviorAnnex.UnindexedReference reference) {
-			final List<ReferenceSegment> segments = new ArrayList<>();
+			final List<Segment> segments = new ArrayList<>();
 			for (final var segment : reference.getSegments()) {
-				final ReferenceSegment copy = org.osate.xtext.aadl2.ba.behaviorAnnex.BehaviorAnnexFactory.eINSTANCE
-						.createReferenceSegment();
-				copy.setName(segment.getName());
-				segments.add(copy);
+				segments.add(new Segment(segment.getName(), List.of(), segment, null));
 			}
-			final List<ReferenceTail> tails = new ArrayList<>();
 			for (final var tail : reference.getTails()) {
-				final ReferenceTail copy = org.osate.xtext.aadl2.ba.behaviorAnnex.BehaviorAnnexFactory.eINSTANCE
-						.createReferenceTail();
-				copy.setSeparator(tail.getSeparator());
-				final ReferenceSegment segment = org.osate.xtext.aadl2.ba.behaviorAnnex.BehaviorAnnexFactory.eINSTANCE
-						.createReferenceSegment();
-				segment.setName(tail.getSegment().getName());
-				copy.setSegment(segment);
-				tails.add(copy);
+				segments.add(new Segment(tail.getSegment().getName(), List.of(), tail.getSegment(), tail.getSeparator()));
 			}
-			return toReferenceValue(segments, tails, reference);
+			return toReferenceValue(segments, reference);
 		}
 
-		private BehaviorElement toReferenceValue(final List<ReferenceSegment> firstSegments,
-				final List<ReferenceTail> tails, final EObject traceSource) {
-			final List<Segment> segments = new ArrayList<>();
-			for (final ReferenceSegment segment : firstSegments) {
-				segments.add(new Segment(segment.getName(), segment.getIndexes(), segment, null));
-			}
-			for (final ReferenceTail tail : tails) {
-				segments.add(new Segment(tail.getSegment().getName(), tail.getSegment().getIndexes(), tail.getSegment(),
-						tail.getSeparator()));
-			}
+		private BehaviorElement toReferenceValue(final List<Segment> segments, final EObject traceSource) {
 			final List<ElementHolder> holders = new ArrayList<>();
 			final List<GroupHolder> groups = new ArrayList<>();
 			NamedElement current = null;
@@ -1096,11 +1098,19 @@ public final class DeclarativeToStrictTranslator {
 						.collect(java.util.stream.Collectors.joining("::"));
 				final Segment segment = segments.get(qualifiedEnd);
 				current = resolveQualified(qualifiedName, false);
+				for (var i = 0; i <= qualifiedEnd; i++) {
+					resolvedReferences.put(segments.get(i).source, current);
+				}
 				addResolvedSegment(current, segment, holders, groups);
 				firstElement = qualifiedEnd + 1;
 			}
 			for (int i = firstElement; i < segments.size(); i++) {
 				final Segment segment = segments.get(i);
+				if (i == 0 && "self".equalsIgnoreCase(segment.name)) {
+					current = owner;
+					resolvedReferences.put(segment.source, current);
+					continue;
+				}
 				current = i == 0 ? resolveFirst(segment.name) : resolveNested(current, segment.name);
 				addResolvedSegment(current, segment, holders, groups);
 			}
@@ -1129,6 +1139,7 @@ public final class DeclarativeToStrictTranslator {
 			if (element == null) {
 				return;
 			}
+			resolvedReferences.put(segment.source, element);
 			final ElementHolder holder = createHolder(element, segment.source, !groups.isEmpty());
 			for (final ArrayIndex index : segment.indexes) {
 				if (holder instanceof IndexableElement indexable) {

--- a/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/util/Aadl2EObjectAtOffsetHelper.java
+++ b/core/org.osate.xtext.aadl2/src/org/osate/xtext/aadl2/util/Aadl2EObjectAtOffsetHelper.java
@@ -79,7 +79,9 @@ public class Aadl2EObjectAtOffsetHelper extends org.eclipse.xtext.resource.EObje
 						EObject actualAnnexElement = AnnexUtil.getParsedAnnex(obj);
 						if (atpr != null && actualAnnexElement != null) {
 							TextPositionInfo tpo = atpr.resolveElementAt(actualAnnexElement, offset);
-							return tpo.getModelObject();
+							if (tpo != null && tpo.getModelObject() != null) {
+								return tpo.getModelObject();
+							}
 						}
 					}
 				}
@@ -133,7 +135,9 @@ public class Aadl2EObjectAtOffsetHelper extends org.eclipse.xtext.resource.EObje
 						EObject actualAnnexElement = AnnexUtil.getParsedAnnex(obj);
 						if (atpr != null && actualAnnexElement != null) {
 							TextPositionInfo tpo = atpr.resolveCrossReferencedElementAt(actualAnnexElement, offset);
-							return tpo.getModelObject();
+							if (tpo != null && tpo.getModelObject() != null) {
+								return tpo.getModelObject();
+							}
 						}
 					}
 				}


### PR DESCRIPTION
## Summary

- Resolve symbolic Behavior Annex reference segments for Eclipse hyperlinks and LSP go-to-definition.
- Cover local variables, AADL features, subcomponents, nested paths, iterative variables, property indexes, qualified names, and `self`.
- Preserve ordinary Xtext cross-reference handling when the annex-specific resolver has no target.

## Cause and correction

General BA `Reference` and `UnindexedReference` segments are stored as string attributes because their targets require context-sensitive translation. The editor therefore had no EObject target for hyperlinking or definition lookup.

The translator now records the declaration selected for each source segment. A BA text-position resolver exposes those targets through the existing annex editor contract, while the generic AADL offset helper falls through to normal nested-Xtext resolution for states, classifiers, properties, and other true cross-references.

## Regression coverage

`BehaviorAnnexCrossReferenceTest` uses an embedded annex model and asserts both editor entry points for every character of each reference token:

- `resolveCrossReferencedElementAt` for Eclipse hyperlinks
- `getElementWithNameAt` for Xtext LSP definitions

Before the fix, the regression failed because the first symbolic `counter` reference resolved to `null`.

## Validation

- Focused regression: 1 test, 0 failures, 0 errors, 0 skipped
- Complete BA Xtext suite: 11 tests, 0 failures, 0 errors, 0 skipped
- EMV2 nested-annex offset regression: 1 test, 0 failures, 0 errors, 0 skipped
- Clean root reactor with `mvn -o -T4 -s releng/osate.releng/settings.xml -Plocal -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -DfailIfNoTests=false clean install`: 143 projects, 1,490 tests, 0 failures, 0 errors, 10 skipped

## Dependencies

Part of #2445.

Depends on #3148 and must merge after it. This PR is based on `2445_remove_legacy_annex_support` at `e461ae9e3a`.

## Residual risk

Navigation uses the same resolution decisions as declarative-to-strict BA translation. Invalid or genuinely unresolved references intentionally remain without a target.