### PR TITLE
Show Behavior Annex content in the outline 🤖

### DIFF
--- a/ba/org.osate.xtext.aadl2.ba.tests/src/org/osate/xtext/aadl2/ba/tests/BehaviorAnnexEditorServicesTest.java
+++ b/ba/org.osate.xtext.aadl2.ba.tests/src/org/osate/xtext/aadl2/ba/tests/BehaviorAnnexEditorServicesTest.java
@@ -24,11 +24,19 @@
 package org.osate.xtext.aadl2.ba.tests;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.editor.model.XtextDocument;
+import org.eclipse.xtext.ui.editor.outline.IOutlineNode;
+import org.eclipse.xtext.ui.editor.outline.impl.BackgroundOutlineTreeProvider;
+import org.eclipse.xtext.ui.editor.outline.impl.DocumentRootNode;
+import org.eclipse.xtext.ui.editor.outline.impl.EObjectNode;
+import org.eclipse.xtext.ui.editor.outline.impl.IOutlineTreeStructureProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.osate.aadl2.AadlPackage;
@@ -36,9 +44,12 @@ import org.osate.aadl2.DefaultAnnexSubclause;
 import org.osate.aadl2.SystemImplementation;
 import org.osate.testsupport.TestHelper;
 import org.osate.xtext.aadl2.ba.behaviorAnnex.BehaviorAnnex;
+import org.osate.xtext.aadl2.ba.ui.internal.BaActivator;
 import org.osate.xtext.aadl2.ba.services.BehaviorAnnexReferenceProposalService;
 import org.osate.xtext.aadl2.ba.ui.outline.BehaviorAnnexOutlineTreeProvider;
 import org.osate.xtext.aadl2.ba.ui.quickfix.BehaviorAnnexQuickfixProvider;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 import com.google.inject.Inject;
 
@@ -74,6 +85,27 @@ public class BehaviorAnnexEditorServicesTest {
 	}
 
 	@Test
+	public void embeddedOutlineUsesBackgroundProviderAndParsedAnnex() throws Exception {
+		var defaultAnnex = loadDefaultAnnex();
+		var bundle = FrameworkUtil.getBundle(BaActivator.class);
+		if (bundle.getState() != Bundle.ACTIVE) {
+			bundle.start();
+		}
+		var injector = BaActivator.getInstance().getInjector(BaActivator.ORG_OSATE_XTEXT_AADL2_BA_BEHAVIORANNEX);
+		var outline = injector.getInstance(IOutlineTreeStructureProvider.class);
+		assertTrue("Embedded annex outlines require BackgroundOutlineTreeProvider",
+				outline instanceof BackgroundOutlineTreeProvider);
+
+		var document = injector.getInstance(XtextDocument.class);
+		document.setInput((org.eclipse.xtext.resource.XtextResource) defaultAnnex.eResource());
+		var root = new DocumentRootNode((ImageDescriptor) null, "root", document, outline);
+		var parent = new EObjectNode(defaultAnnex, root, (ImageDescriptor) null, "behavior_specification", false);
+		outline.createChildren(parent, defaultAnnex);
+		assertEquals(List.of("counter", "idle", "running", "start"),
+				parent.getChildren().stream().map(IOutlineNode::getText).map(Object::toString).toList());
+	}
+
+	@Test
 	public void quickFixesAreLimitedToUnambiguousSyntaxCorrections() {
 		assertEquals("elsif", BehaviorAnnexQuickfixProvider.getSyntaxCorrection("elif").orElseThrow());
 		assertEquals("end if", BehaviorAnnexQuickfixProvider.getSyntaxCorrection("endif").orElseThrow());
@@ -82,6 +114,10 @@ public class BehaviorAnnexEditorServicesTest {
 	}
 
 	private BehaviorAnnex loadAnnex() throws Exception {
+		return (BehaviorAnnex) loadDefaultAnnex().getParsedAnnexSubclause();
+	}
+
+	private DefaultAnnexSubclause loadDefaultAnnex() throws Exception {
 		var result = testHelper.testFile(MODEL);
 		var aadlPackage = (AadlPackage) result.getResource().getContents().get(0);
 		var implementation = (SystemImplementation) aadlPackage.getOwnedPublicSection()
@@ -90,7 +126,6 @@ public class BehaviorAnnexEditorServicesTest {
 				.filter(SystemImplementation.class::isInstance)
 				.findFirst()
 				.orElseThrow();
-		var defaultAnnex = (DefaultAnnexSubclause) implementation.getOwnedAnnexSubclauses().get(0);
-		return (BehaviorAnnex) defaultAnnex.getParsedAnnexSubclause();
+		return (DefaultAnnexSubclause) implementation.getOwnedAnnexSubclauses().get(0);
 	}
 }

--- a/ba/org.osate.xtext.aadl2.ba.tests/src/org/osate/xtext/aadl2/ba/tests/BehaviorAnnexEditorServicesTest.java
+++ b/ba/org.osate.xtext.aadl2.ba.tests/src/org/osate/xtext/aadl2/ba/tests/BehaviorAnnexEditorServicesTest.java
@@ -101,7 +101,7 @@ public class BehaviorAnnexEditorServicesTest {
 		var root = new DocumentRootNode((ImageDescriptor) null, "root", document, outline);
 		var parent = new EObjectNode(defaultAnnex, root, (ImageDescriptor) null, "behavior_specification", false);
 		outline.createChildren(parent, defaultAnnex);
-		assertEquals(List.of("counter", "idle", "running", "start"),
+		assertEquals(List.of("Variable counter", "State idle", "State running", "Transition start"),
 				parent.getChildren().stream().map(IOutlineNode::getText).map(Object::toString).toList());
 	}
 

--- a/ba/org.osate.xtext.aadl2.ba.ui/src/org/osate/xtext/aadl2/ba/ui/labeling/BehaviorAnnexLabelProvider.java
+++ b/ba/org.osate.xtext.aadl2.ba.ui/src/org/osate/xtext/aadl2/ba/ui/labeling/BehaviorAnnexLabelProvider.java
@@ -43,14 +43,18 @@ public class BehaviorAnnexLabelProvider extends DefaultEObjectLabelProvider {
 	}
 
 	public String text(final BehaviorVariable variable) {
-		return variable.getName();
+		return appendName("Variable", variable.getName());
 	}
 
 	public String text(final BehaviorState state) {
-		return state.getName();
+		return appendName("State", state.getName());
 	}
 
 	public String text(final BehaviorTransition transition) {
-		return transition.getName() == null ? "<unnamed transition>" : transition.getName();
+		return appendName("Transition", transition.getName());
+	}
+
+	private static String appendName(final String type, final String name) {
+		return name == null || name.isEmpty() ? type : type + " " + name;
 	}
 }

--- a/ba/org.osate.xtext.aadl2.ba.ui/src/org/osate/xtext/aadl2/ba/ui/outline/BehaviorAnnexOutlineTreeProvider.java
+++ b/ba/org.osate.xtext.aadl2.ba.ui/src/org/osate/xtext/aadl2/ba/ui/outline/BehaviorAnnexOutlineTreeProvider.java
@@ -28,7 +28,8 @@ import java.util.stream.Stream;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.ui.editor.outline.IOutlineNode;
-import org.eclipse.xtext.ui.editor.outline.impl.DefaultOutlineTreeProvider;
+import org.eclipse.xtext.ui.editor.outline.impl.BackgroundOutlineTreeProvider;
+import org.osate.aadl2.DefaultAnnexSubclause;
 import org.osate.xtext.aadl2.ba.behaviorAnnex.BehaviorAnnex;
 import org.osate.xtext.aadl2.ba.behaviorAnnex.BehaviorState;
 import org.osate.xtext.aadl2.ba.behaviorAnnex.BehaviorTransition;
@@ -39,21 +40,27 @@ import org.osate.xtext.aadl2.ba.behaviorAnnex.BehaviorVariable;
  *
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#outline
  */
-public class BehaviorAnnexOutlineTreeProvider extends DefaultOutlineTreeProvider {
-	protected void _createChildren(final IOutlineNode parentNode, final BehaviorAnnex annex) {
+public class BehaviorAnnexOutlineTreeProvider extends BackgroundOutlineTreeProvider {
+	@Override
+	protected void internalCreateChildren(final IOutlineNode parentNode, final EObject modelElement) {
+		if (modelElement instanceof DefaultAnnexSubclause defaultAnnex
+				&& defaultAnnex.getParsedAnnexSubclause() instanceof BehaviorAnnex annex) {
+			createBehaviorChildren(parentNode, annex);
+		} else if (modelElement instanceof BehaviorAnnex annex) {
+			createBehaviorChildren(parentNode, annex);
+		} else {
+			super.internalCreateChildren(parentNode, modelElement);
+		}
+	}
+
+	private void createBehaviorChildren(final IOutlineNode parentNode, final BehaviorAnnex annex) {
 		getTopLevelElements(annex).forEach(element -> createNode(parentNode, element));
 	}
 
-	protected boolean _isLeaf(final BehaviorVariable variable) {
-		return true;
-	}
-
-	protected boolean _isLeaf(final BehaviorState state) {
-		return true;
-	}
-
-	protected boolean _isLeaf(final BehaviorTransition transition) {
-		return true;
+	@Override
+	protected boolean isLeaf(final EObject modelElement) {
+		return modelElement instanceof BehaviorVariable || modelElement instanceof BehaviorState
+				|| modelElement instanceof BehaviorTransition || super.isLeaf(modelElement);
 	}
 
 	public static List<EObject> getTopLevelElements(final BehaviorAnnex annex) {


### PR DESCRIPTION
## Summary

- Display embedded Behavior Annex variables, states, and transitions in the OSATE outline view.
- Use the `BackgroundOutlineTreeProvider` contract required by the AADL editor.
- Unwrap `DefaultAnnexSubclause` nodes to the parsed Behavior Annex model.
- Prefix outline labels with semantic element types, matching EMV2: `Variable counter`, `State idle`, and `Transition start`.

## Cause and correction

The generated BA outline provider extended `DefaultOutlineTreeProvider`. The embedded AADL outline accepts only annex providers implementing `BackgroundOutlineTreeProvider`, so it logged an error and skipped the annex contents. The provider also only handled a parsed `BehaviorAnnex`, while the AADL outline delegates with the containing `DefaultAnnexSubclause`.

The BA provider now follows the EMV2 pattern: it extends `BackgroundOutlineTreeProvider`, unwraps embedded subclauses, creates the named top-level behavior elements, and keeps those nodes as leaves. The BA label provider now prefixes each element name with its type.

## Regression coverage

`BehaviorAnnexEditorServicesTest` obtains the real BA UI outline binding, verifies the background-provider contract, invokes it with an embedded `DefaultAnnexSubclause`, and asserts the resulting type-qualified labels.

Before the fix, the regression failed because the provider was not a `BackgroundOutlineTreeProvider`. Before the label update, it reported only `counter`, `idle`, `running`, and `start`.

## Validation

- Focused editor-service suite: 4 tests, 0 failures, 0 errors, 0 skipped
- Complete BA Xtext suite: 12 tests, 0 failures, 0 errors, 0 skipped
- Clean root reactor with `mvn -o -T4 -s releng/osate.releng/settings.xml -Plocal -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false -DfailIfNoTests=false clean install`: 143 projects, 1,491 tests, 0 failures, 0 errors, 10 skipped

## Dependencies

Part of #2445.

Depends on #3149 and must merge after it. This PR is based on `2445_cross_references` at `1cfad480ff`.

## Residual risk

The outline intentionally remains limited to named top-level variables, states, and transitions. Nested action and expression nodes are not added.