### PR TITLE
Avoid duplicate Behavior Annex subclause diagnostics 🤖

### DIFF
--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_semantic_lr_D3_L1_L2.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_semantic_lr_D3_L1_L2.txt
@@ -1,3 +1,0 @@
-error | semantic | 31 | 7 | 22 | Duplicate Element 'behavior_specification' in SubprogramImplementation 'sub.good'
-error | semantic | 41 | 7 | 22 | Duplicate Element 'behavior_specification' in SubprogramImplementation 'sub.error1'
-error | semantic | 56 | 7 | 22 | Duplicate Element 'behavior_specification' in SubprogramImplementation 'sub.error2'

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_semantic_lr_D3_L3_L4.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_semantic_lr_D3_L3_L4.txt
@@ -1,2 +1,0 @@
-error | semantic | 32 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'th.good'
-error | semantic | 44 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'th.error'

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_semantic_lr_D3_L6_L7_L8.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_semantic_lr_D3_L6_L7_L8.txt
@@ -1,3 +1,1 @@
-error | semantic | 32 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'th.good'
-error | semantic | 45 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'th.error'
 warning | semantic | 24 | 9 | 10 | Base_Types in 'with' clause of public package section is not used.

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_semantic_lr_D4_L1_L2.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_semantic_lr_D4_L1_L2.txt
@@ -1,6 +1,1 @@
-error | semantic | 118 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'th.error3'
-error | semantic | 36 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'th.good1'
-error | semantic | 52 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'th.good2'
-error | semantic | 67 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'th.error1'
-error | semantic | 98 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'th.error2'
 warning | semantic | 24 | 9 | 10 | Base_Types in 'with' clause of public package section is not used.

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_semantic_lr_D6_L2_nr_D6_N1.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_semantic_lr_D6_L2_nr_D6_N1.txt
@@ -1,2 +1,0 @@
-error | semantic | 37 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'th.good'
-error | semantic | 86 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'th.error'

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_semantic_lr_D6_L3_L4.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_semantic_lr_D6_L3_L4.txt
@@ -1,2 +1,0 @@
-error | semantic | 131 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'th.error'
-error | semantic | 50 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'th.good'

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_semantic_lr_D6_L8.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_semantic_lr_D6_L8.txt
@@ -1,2 +1,0 @@
-error | semantic | 31 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'th.good'
-error | semantic | 55 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'th.error'

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_semantic_sr_D3_18.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_semantic_sr_D3_18.txt
@@ -1,2 +1,0 @@
-error | semantic | 38 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'th.good'
-error | semantic | 54 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'th.error'

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_semantic_sr_D4_6.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_semantic_sr_D4_6.txt
@@ -1,2 +1,0 @@
-error | semantic | 31 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'th.good'
-error | semantic | 50 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'th.error'

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_syntax_aadlBaTest001.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_syntax_aadlBaTest001.txt
@@ -1,4 +1,2 @@
-error | semantic | 141 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'thread1.impl'
-error | semantic | 90 | 7 | 22 | Duplicate Element 'behavior_specification' in ProcessType 'myprocess'
 warning | semantic | 25 | 33 | 21 | AadlBaTestPropertySet in 'with' clause of public package section is not used.
 warning | semantic | 25 | 75 | 20 | AadlBaTestSubprogram in 'with' clause of public package section is not used.

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_syntax_aadlBaTest003.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_syntax_aadlBaTest003.txt
@@ -1,4 +1,2 @@
-error | semantic | 220 | 8 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'concreteThread.impl'
-error | semantic | 514 | 8 | 22 | Duplicate Element 'behavior_specification' in SubprogramType 'MySubProgConcrete'
 warning | semantic | 25 | 33 | 21 | AadlBaTestPropertySet in 'with' clause of public package section is not used.
 warning | semantic | 25 | 75 | 20 | AadlBaTestSubprogram in 'with' clause of public package section is not used.

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_syntax_aadlBaTest005.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_covering_syntax_aadlBaTest005.txt
@@ -3,9 +3,7 @@ error | semantic | 124 | 5 | 56 | The type of subcomponent 'recursiveGrp' cannot
 error | semantic | 182 | 5 | 54 | Invalid circular dependency. Subcomponent 'subprogGrp' directly or indirectly contains 'MyThreadGroup.impl'.
 error | semantic | 183 | 5 | 48 | The type of subcomponent 'recursiveGrp' cannot be the object that contains it
 error | semantic | 231 | 5 | 54 | Invalid circular dependency. Subcomponent 'subprogGrp' directly or indirectly contains 'thread2.impl'.
-error | semantic | 237 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'thread2.impl'
 error | semantic | 379 | 5 | 45 | Invalid circular dependency. Subcomponent 'threadGrp' directly or indirectly contains 'process1.impl'.
-error | semantic | 381 | 7 | 22 | Duplicate Element 'behavior_specification' in ProcessImplementation 'process1.impl'
 error | semantic | 96 | 5 | 42 | Feature group directly or indirectly contains itself
 warning | semantic | 29 | 30 | 21 | AadlBaTestPropertySet in 'with' clause of public package section is not used.
 warning | semantic | 29 | 72 | 20 | AadlBaTestSubprogram in 'with' clause of public package section is not used.

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_issue1884_issue1884.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_issue1884_issue1884.txt
@@ -1,5 +1,2 @@
 error | linking | 17 | 27 | 13 | Couldn't resolve reference to BehaviorState 'bad_reference'.
-error | semantic | 12 | 9 | 22 | Duplicate Element 'behavior_specification' in AbstractType 'resolver_error'
-error | semantic | 22 | 9 | 22 | Duplicate Element 'behavior_specification' in AbstractType 'legality_error'
-error | semantic | 4 | 9 | 22 | Duplicate Element 'behavior_specification' in AbstractType 'parser_error'
 error | syntax | 7 | 14 | 3 | mismatched input '<EOF>' expecting ';'

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_issue2056_issue2056.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_issue2056_issue2056.txt
@@ -1,2 +1,0 @@
-error | semantic | 14 | 11 | 22 | Duplicate Element 'behavior_specification' in ThreadGroupImplementation 'threadA.impl'
-error | semantic | 32 | 13 | 22 | Duplicate Element 'behavior_specification' in ThreadGroupImplementation 'threadB.impl'

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_issue2154_issue2154.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_issue2154_issue2154.txt
@@ -1,2 +1,0 @@
-error | semantic | 18 | 9 | 22 | Duplicate Element 'behavior_specification' in ProcessType 'proc'
-error | semantic | 7 | 9 | 22 | Duplicate Element 'behavior_specification' in AbstractType 'abst'

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_issue2466_issue2466.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba.tests_models_issue2466_issue2466.txt
@@ -1,2 +1,0 @@
-error | semantic | 37 | 9 | 22 | Duplicate Element 'behavior_specification' in SubprogramType 's2'
-error | semantic | 52 | 9 | 22 | Duplicate Element 'behavior_specification' in SubprogramType 's3'

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba_examples_standard_examples_ba_example_003.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba_examples_standard_examples_ba_example_003.txt
@@ -1,2 +1,0 @@
-error | semantic | 23 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'sender.v1'
-error | semantic | 44 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'sender.v2'

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba_examples_standard_examples_ba_example_005.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba_examples_standard_examples_ba_example_005.txt
@@ -1,2 +1,0 @@
-error | semantic | 39 | 9 | 22 | Duplicate Element 'behavior_specification' in SubprogramImplementation 'push.default'
-error | semantic | 49 | 9 | 22 | Duplicate Element 'behavior_specification' in SubprogramImplementation 'pop.default'

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba_examples_standard_examples_ba_example_006.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba_examples_standard_examples_ba_example_006.txt
@@ -1,2 +1,0 @@
-error | semantic | 24 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'merger.twopersistentstates'
-error | semantic | 43 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'merger.portbased'

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba_examples_standard_examples_ba_example_007.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba_examples_standard_examples_ba_example_007.txt
@@ -3,5 +3,3 @@ error | linking | 65 | 56 | 4 | Couldn't resolve reference to Property Constant,
 error | linking | 65 | 7 | 45 | Couldn't resolve reference to property definition 'Behavior_Properties::Subprogram_Call_Protocol'.
 error | linking | 67 | 56 | 4 | Couldn't resolve reference to Property Constant, Property Definition, Enumeration or Unit literal 'HSER'. For classifier references use classifier( <ref> ).
 error | linking | 67 | 7 | 45 | Couldn't resolve reference to property definition 'Behavior_Properties::Subprogram_Call_Protocol'.
-error | semantic | 45 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadType 'a_client'
-error | semantic | 82 | 9 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'a_server.i'

--- a/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba_examples_toy_examples_multiModalPingPong.txt
+++ b/ba/org.osate.ba.tests/expected/diagnostics/org.osate.ba_examples_toy_examples_multiModalPingPong.txt
@@ -1,4 +1,0 @@
-error | semantic | 112 | 7 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'Cping_t.impl'
-error | semantic | 161 | 9 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'Cpong_t.impl'
-error | semantic | 253 | 9 | 22 | Duplicate Element 'behavior_specification' in ThreadImplementation 'controller_thread.impl'
-error | semantic | 283 | 9 | 22 | Duplicate Element 'behavior_specification' in SubprogramImplementation 'controller_subprogram.impl'

--- a/ba/org.osate.ba.tests/src/org/osate/ba/tests/CoveringSemanticTest.xtend
+++ b/ba/org.osate.ba.tests/src/org/osate/ba/tests/CoveringSemanticTest.xtend
@@ -28,13 +28,13 @@ class CoveringSemanticTest {
 	@Test
 	def void test_lr_D3_L1_L2() {
 		val result = testHelper.testFile(PATH+"lr_D3_L1_L2.aadl")
-		3.assertEquals(result.issues.size)
+		0.assertEquals(result.issues.size)
 	}
 	
 	@Test
 	def void test_lr_D3_L3_L4() {
 		val result = testHelper.testFile(PATH+"lr_D3_L3_L4.aadl")
-		2.assertEquals(result.issues.size)
+		0.assertEquals(result.issues.size)
 	}
 	
 	@Test
@@ -46,42 +46,42 @@ class CoveringSemanticTest {
 	@Test
 	def void test_lr_D3_L6_L7_L8() {
 		val result = testHelper.testFile(PATH+"lr_D3_L6_L7_L8.aadl")
-		3.assertEquals(result.issues.size)
+		1.assertEquals(result.issues.size)
 	}
 	
 	@Test
 	def void test_lr_D4_L1_L2() {
 		val result = testHelper.testFile(PATH+"lr_D4_L1_L2.aadl")
-		6.assertEquals(result.issues.size)
+		1.assertEquals(result.issues.size)
 	}
 	
 	@Test
 	def void test_lr_D6_L2_nr_D6_N1() {
 		val result = testHelper.testFile(PATH+"lr_D6_L2_nr_D6_N1.aadl")
-		2.assertEquals(result.issues.size)
+		0.assertEquals(result.issues.size)
 	}
 	
 	@Test
 	def void test_lr_D6_L3_L4() {
 		val result = testHelper.testFile(PATH+"lr_D6_L3_L4.aadl")
-		2.assertEquals(result.issues.size)
+		0.assertEquals(result.issues.size)
 	}
 	
 	@Test
 	def void test_lr_D6_L8() {
 		val result = testHelper.testFile(PATH+"lr_D6_L8.aadl")
-		2.assertEquals(result.issues.size)
+		0.assertEquals(result.issues.size)
 	}
 	
 	@Test
 	def void test_sr_D3_18() {
 		val result = testHelper.testFile(PATH+"sr_D3_18.aadl")
-		2.assertEquals(result.issues.size)
+		0.assertEquals(result.issues.size)
 	}
 	
 	@Test
 	def void test_sr_D4_6() {
 		val result = testHelper.testFile(PATH+"sr_D4_6.aadl")
-		2.assertEquals(result.issues.size)
+		0.assertEquals(result.issues.size)
 	}
 }

--- a/ba/org.osate.ba.tests/src/org/osate/ba/tests/CoveringSyntaxTest.xtend
+++ b/ba/org.osate.ba.tests/src/org/osate/ba/tests/CoveringSyntaxTest.xtend
@@ -24,7 +24,7 @@ class CoveringSyntaxTest {
 	@Test
 	def void aadlBaTest001() {
 		val result = testHelper.testFile(PATH+"aadlBaTest001.aadl", PROPERTY_SET_PATH, SUBPROGRAM_PATH, TYPES_PATH)
-		4.assertEquals(result.issues.size)
+		2.assertEquals(result.issues.size)
 	}
 	
 	@Test
@@ -36,7 +36,7 @@ class CoveringSyntaxTest {
 	@Test
 	def void aadlBaTest003() {
 		val result = testHelper.testFile(PATH+"aadlBaTest003.aadl", PROPERTY_SET_PATH, SUBPROGRAM_PATH, TYPES_PATH)
-		4.assertEquals(result.issues.size)
+		2.assertEquals(result.issues.size)
 	}
 	
 	@Test
@@ -48,7 +48,7 @@ class CoveringSyntaxTest {
 	@Test
 	def void aadlBaTest005() {
 		val result = testHelper.testFile(PATH+"aadlBaTest005.aadl", PROPERTY_SET_PATH, SUBPROGRAM_PATH, TYPES_PATH)
-		11.assertEquals(result.issues.size)
+		9.assertEquals(result.issues.size)
 	}
 	
 	@Test

--- a/ba/org.osate.ba.tests/src/org/osate/ba/tests/Issue1884Test.xtend
+++ b/ba/org.osate.ba.tests/src/org/osate/ba/tests/Issue1884Test.xtend
@@ -33,6 +33,6 @@ class Issue1884Test {
 				]
 			]
 		]
-		5.assertEquals(result.issues.size)
+		2.assertEquals(result.issues.size)
 	}
 }

--- a/ba/org.osate.ba.tests/src/org/osate/ba/tests/Issue2056Test.xtend
+++ b/ba/org.osate.ba.tests/src/org/osate/ba/tests/Issue2056Test.xtend
@@ -35,6 +35,6 @@ class Issue2056Test {
 				]
 			]
 		]
-		2.assertEquals(result.issues.size)
+		0.assertEquals(result.issues.size)
 	}
 }

--- a/ba/org.osate.ba.tests/src/org/osate/ba/tests/Issue2154Test.xtend
+++ b/ba/org.osate.ba.tests/src/org/osate/ba/tests/Issue2154Test.xtend
@@ -33,14 +33,6 @@ class Issue2154Test {
 				]
 			]
 		]
-		2.assertEquals(result.issues.size)
-		result.issues.get(1) => [
-			"Duplicate Element 'behavior_specification' in ProcessType 'proc'".assertEquals(message)
-			18.assertEquals(lineNumber)
-		]
-		result.issues.get(0) => [
-			"Duplicate Element 'behavior_specification' in AbstractType 'abst'".assertEquals(message)
-			7.assertEquals(lineNumber)
-		]
+		0.assertEquals(result.issues.size)
 	}
 }

--- a/ba/org.osate.ba.tests/src/org/osate/ba/tests/Issue2466Test.xtend
+++ b/ba/org.osate.ba.tests/src/org/osate/ba/tests/Issue2466Test.xtend
@@ -39,7 +39,7 @@ class Issue2466Test {
 				]
 			]
 			
-			2.assertEquals(result.issues.size)
+			0.assertEquals(result.issues.size)
 		]
 	}
 }

--- a/ba/org.osate.xtext.aadl2.ba.tests/models/phase4/MultipleSubclauses.aadl
+++ b/ba/org.osate.xtext.aadl2.ba.tests/models/phase4/MultipleSubclauses.aadl
@@ -1,0 +1,14 @@
+package Multiple_Subclauses
+public
+
+	system S
+		annex behavior_specification {**
+		**};
+	end S;
+
+	system T
+		annex behavior_specification {**
+		**};
+	end T;
+
+end Multiple_Subclauses;

--- a/ba/org.osate.xtext.aadl2.ba.tests/src/org/osate/xtext/aadl2/ba/tests/BehaviorAnnexIntegrationTest.java
+++ b/ba/org.osate.xtext.aadl2.ba.tests/src/org/osate/xtext/aadl2/ba/tests/BehaviorAnnexIntegrationTest.java
@@ -59,9 +59,10 @@ import com.google.inject.Inject;
 
 /**
  * Exercises the Behavior Annex through the real embedded-AADL parser path. These tests ensure that the parser, linker,
- * and unparser are contributed together; semantic checkers run through the translated strict model; local BA names
- * and referenced AADL objects resolve; Xtext linking messages gate semantic validation; reviewed checker corrections
- * are explicit and fast; and no annex-library form is accidentally added.
+ * and unparser are contributed together; semantic checkers run through the translated strict model; multiple
+ * subclauses remain local instead of colliding in the global index; local BA names and referenced AADL objects resolve;
+ * Xtext linking messages gate semantic validation; reviewed checker corrections are explicit and fast; and no
+ * annex-library form is accidentally added.
  */
 @RunWith(XtextRunner.class)
 @InjectWith(BehaviorAnnexEmbeddedInjectorProvider.class)
@@ -73,6 +74,12 @@ public class BehaviorAnnexIntegrationTest {
 
 	@Inject
 	private DeclarativeToStrictTranslator translator;
+
+	@Test
+	public void multipleSubclausesDoNotHaveDuplicateNames() throws Exception {
+		var result = testHelper.testFile(MODEL_DIRECTORY + "MultipleSubclauses.aadl");
+		assertTrue(result.getSummary(), result.getIssues().isEmpty());
+	}
 
 	@Test
 	public void ordinaryBehaviorSpecificationUsesXtextPipeline() throws Exception {

--- a/ba/org.osate.xtext.aadl2.ba/src/org/osate/xtext/aadl2/ba/naming/BehaviorAnnexQualifiedNameProvider.java
+++ b/ba/org.osate.xtext.aadl2.ba/src/org/osate/xtext/aadl2/ba/naming/BehaviorAnnexQualifiedNameProvider.java
@@ -25,18 +25,19 @@ package org.osate.xtext.aadl2.ba.naming;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.naming.QualifiedName;
+import org.osate.aadl2.AnnexSubclause;
 import org.osate.xtext.aadl2.ba.behaviorAnnex.BehaviorAnnexPackage;
 import org.osate.xtext.aadl2.properties.naming.PropertiesQualifiedNameProvider;
 
 /**
- * Keeps subclause-local BA declarations out of the global AADL index. BA has no annex-library declarations, and local
- * states are scoped directly by {@code BehaviorAnnexScopeProvider}; exporting them would also make the parsed annex
- * collide with its containing {@code DefaultAnnexSubclause} in Xtext's unique-name validation.
+ * Keeps BA subclauses and their local declarations out of the global AADL index. BA has no annex-library declarations,
+ * and local states are scoped directly by {@code BehaviorAnnexScopeProvider}; exporting a host or parsed subclause
+ * would make Xtext's unique-name validation treat every BA subclause in a file as the same global element.
  */
 public final class BehaviorAnnexQualifiedNameProvider extends PropertiesQualifiedNameProvider {
 	@Override
 	public QualifiedName getFullyQualifiedName(EObject object) {
-		if (object.eClass().getEPackage() == BehaviorAnnexPackage.eINSTANCE) {
+		if (object instanceof AnnexSubclause || object.eClass().getEPackage() == BehaviorAnnexPackage.eINSTANCE) {
 			return null;
 		}
 		return super.getFullyQualifiedName(object);


### PR DESCRIPTION
Fixes #2445

## Cause

The BA qualified-name provider excluded generated BA model objects from the global index but still delegated the host `DefaultAnnexSubclause` to the Properties name provider. Each embedded BA wrapper was therefore exported as the same global `behavior_specification` element, and Xtext unique-name validation reported false duplicates when a file contained multiple BA subclauses.

## Correction

- Exclude every `AnnexSubclause` from BA global qualified-name export, matching the embedded-subclause boundary used by EMV2.
- Add an embedded AADL regression model with two systems that each contain a BA subclause and assert that validation produces no issues.
- Remove the false duplicate diagnostics from BA characterization goldens and update the corresponding legacy issue counts.

## Validation

- Focused BA Xtext integration reactor: 6 tests, 0 failures, 0 errors.
- Complete BA test bundle: 62 tests, 0 failures, 0 errors, 10 intentional skips.
- Clean root reactor with `-o -T5 -Dtycho.localArtifacts=ignore`: all 143 projects passed.
- `git diff --check` passed.

## Dependency

This PR is stacked on #3150 and should merge after it. It is the closing PR for issue #2445.

## Residual risk

The change is limited to BA subclauses and subclause-local declarations. BA has no annex-library form, and the corpus characterization confirms that unrelated diagnostics and translated models remain unchanged.