### PR TITLE
Restore annex syntax coloring in the AADL editor 🤖

### DIFF
--- a/ba/org.osate.xtext.aadl2.ba.tests/META-INF/MANIFEST.MF
+++ b/ba/org.osate.xtext.aadl2.ba.tests/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.osate.annexsupport,
  org.osate.testsupport,
  org.osate.xtext.aadl2,
+ org.osate.xtext.aadl2.ui,
  org.osate.xtext.aadl2.ba;bundle-version="[1.0.0,2.0.0)",
  org.osate.xtext.aadl2.ba.ui;bundle-version="[1.0.0,2.0.0)",
  org.osate.ba;bundle-version="[9.0.0,10.0.0)"

--- a/ba/org.osate.xtext.aadl2.ba.tests/models/issue3162/.gitignore
+++ b/ba/org.osate.xtext.aadl2.ba.tests/models/issue3162/.gitignore
@@ -1,0 +1,2 @@
+/.aadlbin-gen/
+/instances/

--- a/ba/org.osate.xtext.aadl2.ba.tests/models/issue3162/.project
+++ b/ba/org.osate.xtext.aadl2.ba.tests/models/issue3162/.project
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>issue3162</name>
+	<comment></comment>
+	<projects></projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments></arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.osate.core.aadlnature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/ba/org.osate.xtext.aadl2.ba.tests/models/issue3162/Issue3162.aadl
+++ b/ba/org.osate.xtext.aadl2.ba.tests/models/issue3162/Issue3162.aadl
@@ -1,0 +1,24 @@
+package Issue3162
+public
+	with Base_Types;
+
+	system Example
+		features
+			input: in event data port Base_Types::Integer;
+	end Example;
+
+	system implementation Example.i
+		annex behavior_specification {**
+			-- A comment inside the annex.
+			variables
+				counter : Base_Types::Integer;
+			states
+				idle : initial state;
+				running : final state;
+			transitions
+				start: idle -[]-> running {
+					counter := input
+				};
+		**};
+	end Example.i;
+end Issue3162;

--- a/ba/org.osate.xtext.aadl2.ba.tests/src/org/osate/xtext/aadl2/ba/tests/Issue3162Test.java
+++ b/ba/org.osate.xtext.aadl2.ba.tests/src/org/osate/xtext/aadl2/ba/tests/Issue3162Test.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2004-2026 Carnegie Mellon University and others. (see Contributors file).
+ * All Rights Reserved.
+ *
+ * NO WARRANTY. ALL MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON UNIVERSITY MAKES NO WARRANTIES OF ANY
+ * KIND, EITHER EXPRESSED OR IMPLIED, AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR PURPOSE
+ * OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT
+ * MAKE ANY WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Created, in part, with funding and support from the United States Government. (see Acknowledgments file).
+ *
+ * This program includes and/or can make use of certain third party source code, object code, documentation and other
+ * files ("Third Party Software"). The Third Party Software that is used by this program is dependent upon your system
+ * configuration. By using this program, You agree to comply with any and all relevant Third Party Software terms and
+ * conditions contained in any such Third Party Software or separate license file distributed with such Third Party
+ * Software. The parties who own the Third Party Software ("Third Party Licensors") are intended third party benefici-
+ * aries to this license with respect to the terms applicable to their Third Party Software. Third Party Software li-
+ * censes only apply to the Third Party Software and not any other portion of this program or this program as a whole.
+ */
+package org.osate.xtext.aadl2.ba.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.xtext.ide.editor.syntaxcoloring.HighlightingStyles;
+import org.eclipse.xtext.ide.editor.syntaxcoloring.IHighlightedPositionAcceptor;
+import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.util.CancelIndicator;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osate.aadl2.AadlPackage;
+import org.osate.testsupport.TestHelper;
+import org.osate.xtext.aadl2.ui.internal.Aadl2Activator;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+
+/**
+ * Annex source text is colored only by {@code Aadl2SemanticHighlightingCalculator}, because the AADL lexer reduces a
+ * whole {@code {** **}} block to a single {@code ANNEXTEXT} token. That calculator has to be bound in the injector the
+ * Eclipse editor actually builds, which is {@code Aadl2RuntimeModule + SharedStateModule + Aadl2UiModule};
+ * {@code Aadl2IdeModule} is reachable only from the language server. Without the binding, Guice silently resolves
+ * {@code @ImplementedBy(DefaultSemanticHighlightingCalculator)}, which ignores annex text.
+ *
+ * <p>
+ * No annex language contributes an {@code org.osate.annexsupport.highlighter}, so the Behavior Annex is colored by the
+ * calculator's generic fallback over the annex parse tree, exactly like EMV2.
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(BehaviorAnnexEmbeddedInjectorProvider.class)
+public class Issue3162Test {
+	private static final String MODEL = "org.osate.xtext.aadl2.ba.tests/models/issue3162/Issue3162.aadl";
+
+	@Inject
+	private TestHelper<AadlPackage> testHelper;
+
+	@Test
+	public void aadlEditorInjectorBindsTheAnnexAwareCalculator() throws Exception {
+		assertEquals("org.osate.xtext.aadl2.ide.highlighting.Aadl2SemanticHighlightingCalculator",
+				aadlEditorInjector().getInstance(ISemanticHighlightingCalculator.class).getClass().getName());
+	}
+
+	@Test
+	public void behaviorAnnexTextIsColored() throws Exception {
+		var resource = (XtextResource) testHelper.testFile(MODEL).getResource();
+		var text = resource.getParseResult().getRootNode().getText();
+		int annexStart = text.indexOf("{**");
+		int annexEnd = text.indexOf("**}");
+		assertTrue("The fixture must embed a behavior_specification annex", annexStart > 0 && annexEnd > annexStart);
+
+		var colored = new ArrayList<int[]>();
+		var styles = new ArrayList<String>();
+		IHighlightedPositionAcceptor acceptor = (offset, length, ids) -> {
+			colored.add(new int[] { offset, length });
+			styles.add(String.join(",", ids));
+		};
+		aadlEditorInjector().getInstance(ISemanticHighlightingCalculator.class)
+				.provideHighlightingFor(resource, acceptor, CancelIndicator.NullImpl);
+
+		for (int[] position : colored) {
+			assertTrue("Coloring must stay inside the annex block, got offset " + position[0],
+					position[0] > annexStart && position[0] + position[1] <= annexEnd);
+		}
+
+		var keywords = new ArrayList<String>();
+		var comments = new ArrayList<String>();
+		for (int i = 0; i < colored.size(); i++) {
+			var lexeme = text.substring(colored.get(i)[0], colored.get(i)[0] + colored.get(i)[1]);
+			if (HighlightingStyles.KEYWORD_ID.equals(styles.get(i))) {
+				keywords.add(lexeme);
+			} else if (HighlightingStyles.COMMENT_ID.equals(styles.get(i))) {
+				comments.add(lexeme.strip());
+			}
+		}
+
+		assertEquals(List.of("variables", ":", "::", ";", "states", ":", "initial", "state", ";", ":", "final", "state",
+				";", "transitions", ":", "-[", "]->", "{", ":=", "}", ";"), keywords);
+		assertEquals(List.of("-- A comment inside the annex."), comments);
+		assertEquals("Every colored position must be a keyword or a comment", keywords.size() + comments.size(),
+				colored.size());
+	}
+
+	private Injector aadlEditorInjector() throws Exception {
+		Bundle bundle = FrameworkUtil.getBundle(Aadl2Activator.class);
+		if (bundle.getState() != Bundle.ACTIVE) {
+			bundle.start();
+		}
+		return Aadl2Activator.getInstance().getInjector(Aadl2Activator.ORG_OSATE_XTEXT_AADL2_AADL2);
+	}
+}

--- a/core/org.osate.xtext.aadl2.ide/META-INF/MANIFEST.MF
+++ b/core/org.osate.xtext.aadl2.ide/META-INF/MANIFEST.MF
@@ -19,5 +19,6 @@ Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.osate.xtext.aadl2.ide,
  org.osate.xtext.aadl2.ide.contentassist.antlr,
  org.osate.xtext.aadl2.ide.contentassist.antlr.internal,
- org.osate.xtext.aadl2.ide.contentassist.antlr.lexer
+ org.osate.xtext.aadl2.ide.contentassist.antlr.lexer,
+ org.osate.xtext.aadl2.ide.highlighting
 Automatic-Module-Name: org.osate.xtext.aadl2.ide

--- a/core/org.osate.xtext.aadl2.ide/src/org/osate/xtext/aadl2/ide/highlighting/Aadl2SemanticHighlightingCalculator.java
+++ b/core/org.osate.xtext.aadl2.ide/src/org/osate/xtext/aadl2/ide/highlighting/Aadl2SemanticHighlightingCalculator.java
@@ -47,6 +47,12 @@ import org.osate.annexsupport.AnnexHighlighterRegistry;
 import org.osate.annexsupport.AnnexRegistry;
 import org.osate.annexsupport.AnnexUtil;
 
+/**
+ * Colors AADL text and, because the lexer reduces each {@code {** **}} block to a single {@code ANNEXTEXT} token, the
+ * source text of every annex language as well. Bound both for the language server and for the Eclipse AADL editor.
+ *
+ * @since 2.0
+ */
 public class Aadl2SemanticHighlightingCalculator extends DefaultSemanticHighlightingCalculator { // ISemanticHighlightingCalculator {
 	private final String ANNEXTEXTKEYWORD = "annex";
 	private final String SEMICOLONKEYWORD = ";";

--- a/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/Aadl2UiModule.java
+++ b/core/org.osate.xtext.aadl2.ui/src/org/osate/xtext/aadl2/ui/Aadl2UiModule.java
@@ -29,6 +29,7 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.eclipse.ui.views.contentoutline.IContentOutlinePage;
 import org.eclipse.xtext.builder.EclipseResourceFileSystemAccess2;
 import org.eclipse.xtext.generator.AbstractFileSystemAccess2;
+import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator;
 import org.eclipse.xtext.parser.IEncodingProvider;
 import org.eclipse.xtext.resource.containers.IAllContainersState;
 import org.eclipse.xtext.ui.LanguageSpecific;
@@ -42,6 +43,7 @@ import org.eclipse.xtext.ui.editor.model.edit.ITextEditComposer;
 import org.eclipse.xtext.ui.refactoring.IDependentElementsCalculator;
 import org.eclipse.xtext.ui.resource.IStorage2UriMapper;
 import org.eclipse.xtext.ui.shared.Access;
+import org.osate.xtext.aadl2.ide.highlighting.Aadl2SemanticHighlightingCalculator;
 import org.osate.xtext.aadl2.ui.containers.Aadl2ProjectsState;
 import org.osate.xtext.aadl2.ui.containers.Aadl2ProjectsStateHelper;
 import org.osate.xtext.aadl2.ui.contentassist.AnnexAwareContentAssistProcessor;
@@ -76,6 +78,17 @@ public class Aadl2UiModule extends org.osate.xtext.aadl2.ui.AbstractAadl2UiModul
 
 	public Class<? extends org.eclipse.xtext.parser.antlr.ISyntaxErrorMessageProvider> bindISyntaxErrorMessageProvider() {
 		return org.osate.xtext.aadl2.ui.syntax.Aadl2SyntaxErrorMessageProvider.class;
+	}
+
+	/**
+	 * The Eclipse editor's injector is {@code Aadl2RuntimeModule + SharedStateModule + Aadl2UiModule}; it never mixes in
+	 * {@code Aadl2IdeModule}. Since {@code HighlightingReconciler} injects the calculator optionally, the binding has to
+	 * be repeated here or the editor silently loses all annex syntax coloring.
+	 *
+	 * @since 10.0
+	 */
+	public Class<? extends ISemanticHighlightingCalculator> bindSemanticHighlightingCalculator() {
+		return Aadl2SemanticHighlightingCalculator.class;
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #3162

## Cause

`Aadl2SemanticHighlightingCalculator` is the only thing that colors annex source text, because the AADL lexer reduces each `{** **}` block to a single `ANNEXTEXT` token. Commit d57252e67a ("Moved semantic highlighting calc") moved its `ISemanticHighlightingCalculator` binding out of `Aadl2UiModule` and into `Aadl2IdeModule`.

`Aadl2Activator.createInjector` builds the editor's injector from `Aadl2RuntimeModule + SharedStateModule + Aadl2UiModule` and never mixes in `Aadl2IdeModule`. That module belongs to `Aadl2IdeSetup` and the language server; it cannot even be instantiated in the Eclipse product platform, because `bindIRenameStrategy2` drags in lsp4j. Since `HighlightingReconciler` injects both calculator interfaces with `@Inject(optional = true)`, nothing failed or was logged — Guice quietly resolved `@ImplementedBy(DefaultSemanticHighlightingCalculator)`, which ignores annex text. Every annex language lost its coloring, and the `MetaclassReference` styling added for #2703 went with it.

## Correction

Restore `bindSemanticHighlightingCalculator()` in `Aadl2UiModule`, keeping the `Aadl2IdeModule` binding so the language server is unaffected, and export `org.osate.xtext.aadl2.ide.highlighting` so the UI bundle can name the class.

No annex language contributes an `org.osate.annexsupport.highlighter` any more — the extension point is defined but unused. Behavior Annex and EMV2 are both served by the calculator's generic fallback over the annex parse tree, so no annex-specific highlighter is needed; the Behavior Annex highlighter deleted in 8de20313cf ("Switch Behavior Annex to Xtext") does not need to come back.

`org.osate.xtext.aadl2.ui` (10.0.0) and `org.osate.xtext.aadl2.ide` (2.0.0) were both bumped in `01a7b4a298` after `9c7b0fe2e0` set the 2.18.0 API baseline, so the new API is tagged `@since 10.0` and `@since 2.0` and no further version change is required.

## Regression model and assertion

`ba/org.osate.xtext.aadl2.ba.tests/models/issue3162/Issue3162.aadl` is a standalone OSATE project whose system implementation carries a `behavior_specification` subclause containing a line comment, a variable, two states, and a transition with an assignment.

`Issue3162Test` asks `Aadl2Activator` for the AADL editor's injector — the same runtime + shared + UI mixin the editor builds — and:

1. pins the calculator it hands out to `Aadl2SemanticHighlightingCalculator`;
2. runs that calculator over the parsed resource and compares the colored lexemes against the subclause's keyword tokens (`variables, :, ::, ;, states, :, initial, state, ;, :, final, state, ;, transitions, :, -[, ]->, {, :=, }, ;`) and its single `--` comment;
3. asserts every reported position lies inside the `{** **}` block, so the offset arithmetic that maps annex-local positions back to file offsets stays honest;
4. asserts nothing else is colored.

Verified failing before the fix for the intended reason — the injector yields `DefaultSemanticHighlightingCalculator`, and the colored-lexeme list is empty — and passing after.

## Validation

Focused run:

```
mvn -T5 -s releng/osate.releng/settings.xml -Plocal -pl :org.osate.xtext.aadl2.ide,:org.osate.xtext.aadl2.ui,:org.osate.core.feature,:org.osate.xtext.aadl2.ba.tests \
  -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
  -Dtest=Issue3162Test -DfailIfNoTests=false clean install
```

`Tests run: 2, Failures: 0, Errors: 0, Skipped: 0`.

Clean root reactor, run in both directions with the same command so the failure lists could be diffed:

```
mvn -T5 -s releng/osate.releng/settings.xml -Plocal -Dtycho.localArtifacts=ignore \
  -Dpr.build=true -Dsign=false -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
  -DfailIfNoTests=false clean install
```

| | tests run | failures |
| --- | --- | --- |
| `master` baseline | 3062 | 2 |
| this branch | 3066 | 2 |

The two failures are `Issue3154Test.eachBoundSourceChecksModeConsistency` and `Issue3154Test.sharedExecuteConditionIsTypeCheckedOnce` in `org.osate.ba.tests`. They are identical on `master`, concern Behavior Annex dispatch conditions and mode consistency, and are untouched by this change. `git diff --check` is clean and the worktree is clean.

## Dependencies

None. Branched from `802f60ea29` on `master`.

## Residual risk

- The regression test pins an exact keyword-lexeme list, so a change to the Behavior Annex grammar's tokens will require updating it. That is intentional: a looser assertion would not have caught this defect, since the failure mode is "no positions at all".
- The binding is now declared in two modules. They must stay in agreement; a future move of the calculator has to touch both, which is why the reason is recorded in Javadoc at both sites.
- Exporting `org.osate.xtext.aadl2.ide.highlighting` widens the ide bundle's API surface by one class. The alternative — mixing `Aadl2IdeModule` into the editor's injector — is not viable, since that module requires lsp4j.
- Annex coloring is limited to keywords, `SL_COMMENT`, and `STRING`, which is what the generic fallback provides. Richer per-annex coloring would need an `org.osate.annexsupport.highlighter` contribution and is out of scope here.
- Only checked headlessly, by resolving the editor's injector and invoking the calculator directly. Visual confirmation in a running OSATE workbench has not been done.
