### PR TITLE
Realign Issue3154Test with the retargeted Behavior Annex diagnostics 🤖

### DIFF
--- a/ba/org.osate.ba.tests/src/org/osate/ba/tests/Issue3154Test.java
+++ b/ba/org.osate.ba.tests/src/org/osate/ba/tests/Issue3154Test.java
@@ -50,9 +50,11 @@ import org.osate.xtext.aadl2.ba.util.BehaviorAnnexUtil;
 import com.google.inject.Inject;
 
 /**
- * Exercises multi-source transitions through ordinary AADL validation: source-state rules apply to every source,
- * while shared condition and action diagnostics occur once. Also checks that strict transitions retain the shared
- * behavior so downstream consumers see the complete transition, with properly contained condition copies.
+ * Exercises multi-source transitions through ordinary AADL validation: source-state rules are checked for every
+ * source, while shared condition and action diagnostics occur once. A source-state rule that marks the shared
+ * condition therefore yields a single marker, since identical reports on one declarative element collapse. Also
+ * checks that strict transitions retain the shared behavior so downstream consumers see the complete transition,
+ * with properly contained condition copies.
  */
 @RunWith(XtextRunner.class)
 @InjectWith(BehaviorAnnexInjectorProvider.class)
@@ -85,10 +87,12 @@ public class Issue3154Test {
 	}
 
 	@Test
-	public void executionSourcesEachReportDispatchError() throws Exception {
+	public void executionSourcesReportDispatchErrorOnce() throws Exception {
+		// D.3.(L6) is checked for every source state, but it marks the shared dispatch condition, so the two reports
+		// collapse onto one marker. See Issue3155Test for the attachment this relies on.
 		var error = "ERROR: Only transition out of complete states may have dispatch condition : "
 				+ "Behavior Annex D.3.(L6) legality rule failed.";
-		assertEquals(List.of(error, error), diagnostics("ExecutionSources"));
+		assertEquals(List.of(error), diagnostics("ExecutionSources"));
 	}
 
 	@Test
@@ -126,18 +130,21 @@ public class Issue3154Test {
 		var strict = EcoreUtil.copy(BehaviorAnnexUtil.getStrictModel(annex));
 		var resource = new ResourceImpl();
 		resource.getContents().add(strict);
-		var first = strict.getTransitions().get(1).getSourceState();
-		var second = strict.getTransitions().get(2).getSourceState();
+		var first = strict.getTransitions().get(1);
+		var second = strict.getTransitions().get(2);
 		// Mode binding is not populated by the translator yet. Supply bindings through the public strict API
 		// to isolate C4's per-source checks from that independent limitation.
-		first.setBindedMode(owner.getOwnedModes().get(0));
-		second.setBindedMode(owner.getOwnedModes().get(1));
+		first.getSourceState().setBindedMode(owner.getOwnedModes().get(0));
+		second.getSourceState().setBindedMode(owner.getOwnedModes().get(1));
 		var manager = new AnalysisErrorReporterManager(QueuingAnalysisErrorReporter.factory);
 		new AadlBaRulesCheckersDriver(strict, owner, manager).process(strict);
 		var errors = ((QueuingAnalysisErrorReporter) manager.getReporter(resource)).getErrors();
 		assertEquals(errors.toString(), 2, errors.size());
 		assertTrue(errors.stream().allMatch(error -> error.message.contains("D.3.(C4)")));
-		assertEquals(List.of(first, second), errors.stream().map(error -> error.where).toList());
+		// One report per bound source, each attached to that transition's own condition copy. C4 constrains the
+		// transition, so it marks the condition rather than the source state, which is legal on its own.
+		assertEquals(List.of(first.getCondition(), second.getCondition()),
+				errors.stream().map(error -> error.where).toList());
 	}
 
 	private List<String> diagnostics(String model) throws Exception {


### PR DESCRIPTION
Repairs two stale assertions in `Issue3154Test` that leave `master` red. Follow-up to #3154 (PR #3159) and #3155 (PR #3160); no new issue was filed.

## Cause

PRs #3159 and #3160 branched from the same commit (`27b39c0d14`) and merged in sequence. The merge was textually clean, but the two changes overlap semantically: #3160 changed the diagnostics that #3159's regression test pins. Neither PR's validation could catch it, because each branch was green on its own and neither contained the other's test.

#3160 made two relevant changes:

- Transition rules now report on the element the rule constrains: D.3.(L6) marks the dispatch condition, D.3.(C4) marks the dispatch condition or its trigger expression.
- `BehaviorAnnexValidator` drops a repeat report with the same severity, message, and declarative target, so a rule that fires once per expanded source state is surfaced once.

## Correction

Test-only. No production behavior is in question and none is changed.

- `eachBoundSourceChecksModeConsistency` expected the two D.3.(C4) errors on the source states. They now attach to each transition's own condition copy, so the assertion names those copies. The error count still demonstrates the check running once per bound source, and the distinct condition copies are exactly what #3159 introduced.
- `executionSourcesEachReportDispatchError` expected two identical D.3.(L6) markers. The rule is still checked per source state, but it marks the shared dispatch condition, so the two reports collapse onto one declarative element and the user sees a single marker. Renamed to `executionSourcesReportDispatchErrorOnce` and expects one error.
- The class comment claimed a diagnostic per source; corrected to say the rules are *checked* per source.

`Issue3155Test.transitionRulesMarkTheTransitionOnce` already asserts and documents this collapse for a multi-source transition, which is why the merged production code is treated as correct here.

## Regression models and assertions

Both use the fixtures added by #3159, unchanged:

- `models/issue3154/ExecutionSources.aadl` — `first, second -[on dispatch p]-> finish;` out of two non-complete states. Asserts the full issue list is one D.3.(L6) error.
- `models/issue3154/ModeSources.aadl` — the same transition shape out of two complete states with mode bindings supplied through the strict API. Asserts two D.3.(C4) errors whose targets are `first.getCondition()` and `second.getCondition()`.

Both assertions fail before this change for the reasons above and pass after.

## Validation

Focused run:

```
mvn -o -s releng/osate.releng/settings.xml -Plocal -T5 \
  -pl :org.osate.ba,:org.osate.xtext.aadl2.ba,:org.osate.ba.tests,:org.osate.xtext.aadl2.ba.tests,:org.osate.ba.feature \
  -Dtycho.localArtifacts=default -Dpr.build=true -Dsign=false \
  -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
  -Dtest=Issue3154Test,Issue3155Test,Issue3153Test,CoveringSemanticTest,BehaviorAnnexCharacterizationTest,BehaviorAnnexConformanceTest \
  -DfailIfNoTests=false clean install
```

`Issue3154Test` 7/7; 46 tests across the selected classes with zero failures and errors.

Clean root reactor on this branch:

```
mvn -s releng/osate.releng/settings.xml -Plocal -T5 \
  -Dtycho.localArtifacts=ignore -Dpr.build=true -Dsign=false \
  -Dspotbugs=false -Dcodecoverage=false -Djavadoc=false \
  -DfailIfNoTests=false clean install
```

BUILD SUCCESS. 404 Surefire reports, 1531 tests, 0 failures, 0 errors, 10 skips.

## Dependencies and merge order

None. Branched from `master` at `802f60ea29`, which already contains both merges. Independently mergeable, and worth merging early since `master` is currently failing these two tests.

## Residual risk

Low; the change touches only test expectations. The one judgment call is accepting #3160's collapse of identical reports as correct rather than restoring a marker per source state. That trade-off was decided in #3160 and is asserted by `Issue3155Test`; the cost is that for a multi-source transition where only some sources violate D.3.(L6), the single marker on the shared condition does not indicate which source state is at fault, since the message does not name a state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)